### PR TITLE
fix: adding instruction to install app on site

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ You can install this app using the [bench](https://github.com/frappe/bench) CLI:
 ```bash
 cd $PATH_TO_YOUR_BENCH
 bench get-app $URL_OF_THIS_REPO --branch develop
-bench install-app mail
+
+# create a site 
+bench --site <your-site-name>
+bench --site <your-site-name> install-app mail
 ```
 
 ## Mail System Architecture


### PR DESCRIPTION
This PR adds a minor change into the README. The app has to be installed on site, but the current README mentions the half command which is ```bench install-app mail```.  Hence, this PR corrects that command adds a step to also create a site before it. 