### PR TITLE
feat: add Drafts page

### DIFF
--- a/frontend/src/components/HeaderActions.vue
+++ b/frontend/src/components/HeaderActions.vue
@@ -7,13 +7,15 @@
 			{{ __('Compose an email') }}
 		</Button>
 	</div>
-	<SendMail v-model="showSendModal" />
+	<SendMail v-model="showSendModal" @reloadMails="emit('reloadMails')" />
 </template>
 <script setup>
 import { Button } from 'frappe-ui'
 import { SquarePen } from 'lucide-vue-next'
 import SendMail from '@/components/Modals/SendMail.vue'
-import { ref } from 'vue'
+import { ref, defineEmits } from 'vue'
+
+const emit = defineEmits(['reloadMails'])
 
 const showSendModal = ref(false)
 

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -100,7 +100,7 @@
 		v-model="showSendModal"
 		:mailID="draftMailID"
 		:replyDetails="replyDetails"
-		@resetCurrentMail="emit('resetCurrentMail')"
+		@reloadMails="reloadMails"
 	/>
 </template>
 <script setup>
@@ -125,7 +125,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['resetCurrentMail'])
+const emit = defineEmits(['reloadMails'])
 
 const replyDetails = reactive({
 	to: '',
@@ -146,6 +146,11 @@ const mailThread = createResource({
 	},
 	auto: !!props.mailID,
 })
+
+const reloadMails = () => {
+	emit('reloadMails')
+	mailThread.reload()
+}
 
 const mailBody = (bodyHTML) => {
 	bodyHTML = bodyHTML.replace(/<br\s*\/?>/, '')

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -96,7 +96,12 @@
 			{{ __('No emails to show') }}
 		</div>
 	</div>
-	<SendMail v-model="showSendModal" :mailID="draftMailID" :replyDetails="replyDetails" />
+	<SendMail
+		v-model="showSendModal"
+		:mailID="draftMailID"
+		:replyDetails="replyDetails"
+		@reloadMailThread="mailThread.reload()"
+	/>
 </template>
 <script setup>
 import { createResource, Avatar, Button, Tooltip } from 'frappe-ui'
@@ -194,11 +199,6 @@ watch(
 		mailThread.reload({ mailID: newName })
 	}
 )
-
-watch(showSendModal, (value) => {
-	// TODO: fix this
-	if (!value) mailThread.reload()
-})
 </script>
 <style>
 .prose

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -100,7 +100,7 @@
 		v-model="showSendModal"
 		:mailID="draftMailID"
 		:replyDetails="replyDetails"
-		@reloadMailThread="mailThread.reload()"
+		@resetCurrentMail="emit('resetCurrentMail')"
 	/>
 </template>
 <script setup>
@@ -124,6 +124,8 @@ const props = defineProps({
 		required: true,
 	},
 })
+
+const emit = defineEmits(['resetCurrentMail'])
 
 const replyDetails = reactive({
 	to: '',

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -100,7 +100,7 @@
 		v-model="showSendModal"
 		:mailID="draftMailID"
 		:replyDetails="replyDetails"
-		@reloadMails="reloadMails"
+		@reloadMails="emit('reloadMails')"
 	/>
 </template>
 <script setup>
@@ -147,10 +147,10 @@ const mailThread = createResource({
 	auto: !!props.mailID,
 })
 
-const reloadMails = () => {
-	emit('reloadMails')
-	mailThread.reload()
+const reloadThread = () => {
+	if (props.mailID) mailThread.reload()
 }
+defineExpose({ reloadThread })
 
 const mailBody = (bodyHTML) => {
 	bodyHTML = bodyHTML.replace(/<br\s*\/?>/, '')
@@ -200,12 +200,7 @@ const getReplyHtml = (html, creation) => {
 	return `<br><blockquote>${replyHeader} <br> ${html}</blockquote>`
 }
 
-watch(
-	() => props.mailID,
-	(newName) => {
-		if (newName) mailThread.reload()
-	}
-)
+watch(() => props.mailID, reloadThread)
 </script>
 <style>
 .prose

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -196,6 +196,7 @@ watch(
 )
 
 watch(showSendModal, (value) => {
+	// TODO: fix this
 	if (!value) mailThread.reload()
 })
 </script>

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -41,7 +41,8 @@
 							</span>
 						</div>
 					</div>
-					<div class="flex items-center self-start space-x-2">
+					<div v-if="mail.folder === 'Drafts'"></div>
+					<div v-else class="flex items-center self-start space-x-2">
 						<MailDate :datetime="mail.creation" />
 						<Tooltip :text="__('Reply')">
 							<Button variant="ghost" @click="openModal('reply', mail)">

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="mailThread.data?.length" class="p-3">
+	<div v-if="props.mailID" class="p-3">
 		<div
 			class="p-3 mb-4"
 			v-for="mail in mailThread.data"
@@ -136,13 +136,13 @@ const replyDetails = reactive({
 
 const mailThread = createResource({
 	url: 'mail_client.api.mail.get_mail_thread',
-	makeParams(values) {
+	makeParams() {
 		return {
-			name: values?.mailID || props.mailID,
+			name: props.mailID,
 			mail_type: props.type,
 		}
 	},
-	auto: props.mailID ? true : false,
+	auto: !!props.mailID,
 })
 
 const mailBody = (bodyHTML) => {
@@ -196,7 +196,7 @@ const getReplyHtml = (html, creation) => {
 watch(
 	() => props.mailID,
 	(newName) => {
-		mailThread.reload({ mailID: newName })
+		if (newName) mailThread.reload()
 	}
 )
 </script>

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -41,7 +41,20 @@
 							</span>
 						</div>
 					</div>
-					<div v-if="mail.folder === 'Drafts'"></div>
+					<div
+						v-if="mail.folder === 'Drafts'"
+						class="flex items-center self-start space-x-2"
+					>
+						<MailDate :datetime="mail.modified" />
+						<Tooltip :text="__('Edit')">
+							<Button
+								icon="edit"
+								variant="ghost"
+								@click="openModal('editDraft', mail.name)"
+							>
+							</Button>
+						</Tooltip>
+					</div>
 					<div v-else class="flex items-center self-start space-x-2">
 						<MailDate :datetime="mail.creation" />
 						<Tooltip :text="__('Reply')">
@@ -83,7 +96,7 @@
 			{{ __('No emails to show') }}
 		</div>
 	</div>
-	<SendMail v-model="showSendModal" :replyDetails="replyDetails" />
+	<SendMail v-model="showSendModal" :mailID="draftMailID" :replyDetails="replyDetails" />
 </template>
 <script setup>
 import { createResource, Avatar, Button, Tooltip } from 'frappe-ui'
@@ -93,6 +106,7 @@ import SendMail from '@/components/Modals/SendMail.vue'
 import MailDate from '@/components/MailDate.vue'
 
 const showSendModal = ref(false)
+const draftMailID = ref(null)
 const dayjs = inject('$dayjs')
 
 const props = defineProps({
@@ -137,6 +151,11 @@ const mailBody = (bodyHTML) => {
 }
 
 const openModal = (type, mail) => {
+	if (type === 'editDraft') {
+		draftMailID.value = mail
+		showSendModal.value = true
+		return
+	}
 	if (props.type == 'Incoming Mail') {
 		replyDetails.to = mail.sender
 	} else {
@@ -175,6 +194,10 @@ watch(
 		mailThread.reload({ mailID: newName })
 	}
 )
+
+watch(showSendModal, (value) => {
+	if (!value) mailThread.reload()
+})
 </script>
 <style>
 .prose

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -246,11 +246,12 @@ const defaultOutgoing = createResource({
 })
 
 const createDraftMail = createResource({
-	url: 'mail_client.api.outbound.create_draft_mail',
+	url: 'mail_client.api.outbound.send',
 	method: 'POST',
 	makeParams(values) {
 		return {
 			from_: `${user.data?.full_name} <${mail.from}>`,
+			do_not_submit: true,
 			...mail,
 		}
 	},

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -217,6 +217,7 @@ const emit = defineEmits(['reloadMails'])
 
 const discardMail = async () => {
 	if (mailID.value) await deleteDraftMail.submit()
+	else if (!isMailEmpty.value) Object.assign(mail, emptyMail)
 	show.value = false
 }
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -242,7 +242,7 @@ const defaultOutgoing = createResource({
 	url: 'mail_client.api.mail.get_default_outgoing',
 	auto: true,
 	onSuccess(data) {
-		mail.from = data
+		if (data) mail.from = data
 	},
 })
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -137,7 +137,7 @@
 								</FileUploader>
 							</div>
 							<div class="mt-2 flex items-center justify-end space-x-2 sm:mt-0">
-								<Button :label="__('Discard')" @click="() => (show = false)" />
+								<Button :label="__('Discard')" @click="discardMail" />
 								<Button @click="send()" variant="solid" :label="__('Send')" />
 							</div>
 						</div>
@@ -211,6 +211,11 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['reloadMailThread'])
+
+const discardMail = async () => {
+	if (mailID.value) await deleteDraftMail.submit()
+	show.value = false
+}
 
 const emptyMail = {
 	to: '',
@@ -321,6 +326,7 @@ const deleteDraftMail = createResource({
 	},
 	onSuccess() {
 		mailID.value = null
+		Object.assign(mail, emptyMail)
 		setCurrentMail('draft', null)
 	},
 })

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -222,10 +222,8 @@ const discardMail = async () => {
 
 const syncMail = useDebounceFn(() => {
 	if (!isMailWatcherActive.value) return
-	if (mailID.value) {
-		if (isMailEmpty.value) deleteDraftMail.submit()
-		else updateDraftMail.submit()
-	} else if (!isMailEmpty.value) createDraftMail.submit()
+	if (mailID.value) updateDraftMail.submit()
+	else if (!isMailEmpty.value) createDraftMail.submit()
 }, SYNC_DEBOUNCE_TIME)
 
 const emptyMail = {

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -166,6 +166,7 @@ import EmojiPicker from '@/components/EmojiPicker.vue'
 import MultiselectInput from '@/components/Controls/MultiselectInput.vue'
 import { EditorContent } from '@tiptap/vue-3'
 import { validateEmail } from '@/utils'
+import { userStore } from '@/stores/user'
 
 const user = inject('$user')
 const attachments = defineModel('attachments')
@@ -178,6 +179,7 @@ const cc = ref(false)
 const bcc = ref(false)
 const emoji = ref()
 const isSendMail = ref(false)
+const { setCurrentMail } = userStore()
 
 const editor = computed(() => {
 	return textEditor.value.editor
@@ -318,6 +320,7 @@ const deleteDraftMail = createResource({
 	},
 	onSuccess() {
 		mailID.value = null
+		setCurrentMail('draft', null)
 	},
 })
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -220,8 +220,12 @@ const mail = reactive({ ...emptyMail })
 
 watch(show, () => {
 	if (!show.value) {
-		mailID.value = null
-		Object.assign(mail, emptyMail)
+		if (mailID.value) {
+			if (isMailEmpty.value) deleteDraftMail.submit()
+			else updateDraftMail.submit()
+			mailID.value = null
+			Object.assign(mail, emptyMail)
+		}
 		return
 	}
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -265,7 +265,7 @@ watchDebounced(
 			else updateDraftMail.submit()
 		} else if (!isMailEmpty.value) createDraftMail.submit()
 	},
-	{ debounce: 1000 }
+	{ debounce: 1500 }
 )
 
 const defaultOutgoing = createResource({
@@ -289,6 +289,7 @@ const createDraftMail = createResource({
 	},
 	onSuccess(data) {
 		mailID.value = data
+		setCurrentMail('draft', data)
 	},
 })
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -213,7 +213,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['resetCurrentMail'])
+const emit = defineEmits(['reloadMails'])
 
 const discardMail = async () => {
 	if (mailID.value) await deleteDraftMail.submit()
@@ -290,6 +290,7 @@ const createDraftMail = createResource({
 	onSuccess(data) {
 		mailID.value = data
 		setCurrentMail('draft', data)
+		emit('reloadMails')
 	},
 })
 
@@ -304,10 +305,13 @@ const updateDraftMail = createResource({
 		}
 	},
 	onSuccess(data) {
-		if (data.docstatus) emit('resetCurrentMail')
-		if (!isSendMail.value) return
-		isSendMail.value = false
-		show.value = false
+		if (data.docstatus) setCurrentMail('draft', null)
+		emit('reloadMails')
+
+		if (isSendMail.value) {
+			isSendMail.value = false
+			show.value = false
+		}
 	},
 })
 
@@ -321,9 +325,8 @@ const deleteDraftMail = createResource({
 		}
 	},
 	onSuccess() {
-		mailID.value = null
-		Object.assign(mail, emptyMail)
 		setCurrentMail('draft', null)
+		emit('reloadMails')
 	},
 })
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -203,14 +203,15 @@ const props = defineProps({
 	},
 })
 
-const mail = reactive({
-	from: '',
+const emptyMail = {
 	to: '',
 	cc: '',
 	bcc: '',
 	subject: '',
 	html: '',
-})
+}
+
+const mail = reactive({ ...emptyMail })
 
 watch(show, () => {
 	if (show.value && props.replyDetails) {
@@ -274,6 +275,8 @@ const updateDraftMail = createResource({
 		if (!isSendMail.value) return
 		isSendMail.value = false
 		show.value = false
+		mailID.value = null
+		Object.assign(mail, emptyMail)
 	},
 })
 

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -213,7 +213,7 @@ const props = defineProps({
 	},
 })
 
-const emit = defineEmits(['reloadMailThread'])
+const emit = defineEmits(['resetCurrentMail'])
 
 const discardMail = async () => {
 	if (mailID.value) await deleteDraftMail.submit()
@@ -303,8 +303,8 @@ const updateDraftMail = createResource({
 			...mail,
 		}
 	},
-	onSuccess() {
-		if (!show.value) emit('reloadMailThread')
+	onSuccess(data) {
+		if (data.docstatus) emit('resetCurrentMail')
 		if (!isSendMail.value) return
 		isSendMail.value = false
 		show.value = false

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -176,6 +176,7 @@ const bccInput = ref(null)
 const cc = ref(false)
 const bcc = ref(false)
 const emoji = ref()
+const isSendMail = ref(false)
 
 const editor = computed(() => {
 	return textEditor.value.editor
@@ -264,8 +265,14 @@ const updateDraftMail = createResource({
 		return {
 			mail_id: mailID.value,
 			from_: `${user.data?.full_name} <${mail.from}>`,
+			do_submit: isSendMail.value,
 			...mail,
 		}
+	},
+	onSuccess() {
+		if (!isSendMail.value) return
+		isSendMail.value = false
+		show.value = false
 	},
 })
 
@@ -277,27 +284,14 @@ const deleteDraftMail = createResource({
 			mail_id: mailID.value,
 		}
 	},
-})
-
-const sendMail = createResource({
-	url: 'mail_client.api.outbound.send',
-	method: 'POST',
-	makeParams(values) {
-		return {
-			mail_id: mailID.value,
-		}
+	onSuccess() {
+		mailID.value = null
 	},
 })
 
 const send = () => {
-	sendMail.submit(
-		{},
-		{
-			onSuccess() {
-				show.value = false
-			},
-		}
-	)
+	isSendMail.value = true
+	updateDraftMail.submit()
 }
 
 const toggleCC = () => {

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -208,6 +208,8 @@ const props = defineProps({
 	},
 })
 
+const emit = defineEmits(['reloadMailThread'])
+
 const emptyMail = {
 	to: '',
 	cc: '',
@@ -218,11 +220,13 @@ const emptyMail = {
 
 const mail = reactive({ ...emptyMail })
 
-watch(show, () => {
+watch(show, async () => {
 	if (!show.value) {
 		if (mailID.value) {
-			if (isMailEmpty.value) deleteDraftMail.submit()
-			else updateDraftMail.submit()
+			if (isMailEmpty.value) await deleteDraftMail.submit()
+			else await updateDraftMail.submit()
+			emit('reloadMailThread')
+
 			mailID.value = null
 			Object.assign(mail, emptyMail)
 		}
@@ -303,6 +307,7 @@ const updateDraftMail = createResource({
 	},
 })
 
+// TODO: delete using documentresource directly
 const deleteDraftMail = createResource({
 	url: 'mail_client.api.mail.delete_mail',
 	makeParams(values) {

--- a/frontend/src/components/Modals/SendMail.vue
+++ b/frontend/src/components/Modals/SendMail.vue
@@ -138,7 +138,7 @@
 							</div>
 							<div class="mt-2 flex items-center justify-end space-x-2 sm:mt-0">
 								<Button :label="__('Discard')" @click="discardMail" />
-								<Button @click="send()" variant="solid" :label="__('Send')" />
+								<Button @click="send" variant="solid" :label="__('Send')" />
 							</div>
 						</div>
 					</div>
@@ -286,7 +286,7 @@ const createDraftMail = createResource({
 	method: 'POST',
 	makeParams(values) {
 		return {
-			// TODO: use display_name
+			// TODO: use mailbox display_name
 			from_: `${user.data?.full_name} <${mail.from}>`,
 			do_not_submit: true,
 			...mail,
@@ -317,11 +317,11 @@ const updateDraftMail = createResource({
 
 // TODO: delete using documentresource directly
 const deleteDraftMail = createResource({
-	url: 'mail_client.api.mail.delete_mail',
+	url: 'frappe.client.delete',
 	makeParams(values) {
 		return {
-			mail_type: 'Outgoing Mail',
-			mail_id: mailID.value,
+			doctype: 'Outgoing Mail',
+			name: mailID.value,
 		}
 	},
 	onSuccess() {

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -15,7 +15,7 @@
 					</div>
 				</template>
 			</Breadcrumbs>
-			<HeaderActions />
+			<HeaderActions @reloadMails="reloadDrafts" />
 		</header>
 		<div v-if="draftMails.data" class="flex h-[calc(100vh-3.2rem)]">
 			<div
@@ -48,7 +48,7 @@
 				<MailDetails
 					:mailID="currentMail.draft"
 					type="Outgoing Mail"
-					@resetCurrentMail="setCurrentMail('draft', null)"
+					@reloadMails="reloadDrafts"
 				/>
 			</div>
 		</div>
@@ -72,8 +72,6 @@ const reloadDrafts = () => {
 	draftMails.reload()
 	draftMailsCount.reload()
 }
-
-watch(() => currentMail.draft, reloadDrafts)
 
 const draftMails = createListResource({
 	url: 'mail_client.api.mail.get_draft_mails',

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -1,0 +1,127 @@
+<template>
+	<div class="h-full">
+		<header
+			class="sticky top-0 z-10 flex items-center justify-between border-b bg-white px-3 py-2.5 sm:px-5"
+		>
+			<Breadcrumbs :items="breadcrumbs">
+				<template #suffix>
+					<div v-if="outgoingMailCount.data" class="self-end text-xs text-gray-600 ml-2">
+						{{
+							__('{0} {1}').format(
+								formatNumber(outgoingMailCount.data),
+								outgoingMailCount.data == 1 ? singularize('messages') : 'messages'
+							)
+						}}
+					</div>
+				</template>
+			</Breadcrumbs>
+			<HeaderActions />
+		</header>
+		<div v-if="outgoingMails.data" class="flex h-[calc(100vh-3.2rem)]">
+			<div
+				@scroll="loadMoreEmails"
+				ref="mailSidebar"
+				class="mailSidebar border-r w-1/3 p-2 sticky top-16 overflow-y-scroll overscroll-contain"
+			>
+				<div
+					v-for="(mail, idx) in outgoingMails.data"
+					@click="openMail(mail)"
+					class="flex flex-col space-y-1 cursor-pointer"
+					:class="{ 'bg-gray-200 rounded': mail.name == currentMail }"
+				>
+					<SidebarDetail :mail="mail" />
+					<div
+						:class="{
+							'mx-4 h-[0.25px] border-b border-gray-100':
+								idx < outgoingMails.data.length - 1,
+						}"
+					></div>
+				</div>
+			</div>
+			<div class="flex w-px cursor-col-resize justify-center" @mousedown="startResizing">
+				<div
+					ref="resizer"
+					class="h-full w-[2px] rounded-full transition-all duration-300 ease-in-out group-hover:bg-gray-400"
+				/>
+			</div>
+			<div class="flex-1 overflow-auto w-2/3">
+				<MailDetails :mailID="currentMail" type="Outgoing Mail" />
+			</div>
+		</div>
+	</div>
+</template>
+<script setup>
+import { Breadcrumbs, createResource, createListResource } from 'frappe-ui'
+import { computed, inject, ref, onMounted } from 'vue'
+import HeaderActions from '@/components/HeaderActions.vue'
+import { formatNumber, startResizing, singularize } from '@/utils'
+import MailDetails from '@/components/MailDetails.vue'
+import { useDebounceFn } from '@vueuse/core'
+import SidebarDetail from '@/components/SidebarDetail.vue'
+
+const socket = inject('$socket')
+const user = inject('$user')
+const mailStart = ref(0)
+const mailList = ref([])
+const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')))
+
+onMounted(() => {
+	socket.on('outgoing_mail_sent', (data) => {
+		outgoingMails.reload()
+		outgoingMailCount.reload()
+	})
+})
+
+const outgoingMails = createListResource({
+	url: 'mail_client.api.mail.get_outgoing_mails',
+	doctype: 'Outgoing Mail',
+	auto: true,
+	start: mailStart.value,
+	pageLength: 50,
+	cache: ['outgoing', user.data?.name],
+	onSuccess(data) {
+		mailList.value = mailList.value.concat(data)
+		mailStart.value = mailStart.value + data.length
+		if (!currentMail.value && mailList.value.length) {
+			setCurrentMail(mailList.value[0].name)
+		}
+	},
+})
+
+const outgoingMailCount = createResource({
+	url: 'frappe.client.get_count',
+	makeParams(values) {
+		return {
+			doctype: 'Outgoing Mail',
+			filters: {
+				sender: user.data?.name,
+				folder: 'Sent',
+			},
+		}
+	},
+	cache: ['outgoingMailCount', user.data?.name],
+	auto: true,
+})
+
+const loadMoreEmails = useDebounceFn(() => {
+	if (outgoingMails.hasNextPage) outgoingMails.next()
+}, 500)
+
+const setCurrentMail = (mail) => {
+	sessionStorage.setItem('currentOutgoingMail', JSON.stringify(mail))
+}
+
+const openMail = (mail) => {
+	currentMail.value = mail.name
+	setCurrentMail(mail.name)
+}
+
+const breadcrumbs = computed(() => {
+	return [
+		{
+			label: `Drafts`,
+			route: { name: 'Drafts' },
+		},
+	]
+})
+</script>

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -100,7 +100,7 @@ const draftMailsCount = createResource({
 			doctype: 'Outgoing Mail',
 			filters: {
 				sender: user.data?.name,
-				folder: 'Drafts',
+				status: 'Draft',
 			},
 		}
 	},

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -46,6 +46,7 @@
 			</div>
 			<div class="flex-1 overflow-auto w-2/3">
 				<MailDetails
+					ref="mailDetails"
 					:mailID="currentMail.draft"
 					type="Outgoing Mail"
 					@reloadMails="reloadDrafts"
@@ -56,7 +57,7 @@
 </template>
 <script setup>
 import { Breadcrumbs, createResource, createListResource } from 'frappe-ui'
-import { computed, inject, watch } from 'vue'
+import { ref, computed, inject, watch } from 'vue'
 import HeaderActions from '@/components/HeaderActions.vue'
 import { formatNumber, startResizing, singularize } from '@/utils'
 import MailDetails from '@/components/MailDetails.vue'
@@ -64,6 +65,7 @@ import { useDebounceFn } from '@vueuse/core'
 import SidebarDetail from '@/components/SidebarDetail.vue'
 import { userStore } from '@/stores/user'
 
+const mailDetails = ref(null)
 const socket = inject('$socket')
 const user = inject('$user')
 const { currentMail, setCurrentMail } = userStore()
@@ -80,7 +82,9 @@ const draftMails = createListResource({
 	pageLength: 50,
 	cache: ['draftMails', user.data?.name],
 	onSuccess(data) {
-		if (!currentMail.draft && data.length) setCurrentMail('draft', data[0].name)
+		if (!data.length) return
+		if (!currentMail.draft) setCurrentMail('draft', data[0].name)
+		mailDetails.value?.reloadThread()
 	},
 })
 

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -5,11 +5,11 @@
 		>
 			<Breadcrumbs :items="breadcrumbs">
 				<template #suffix>
-					<div v-if="outgoingMailCount.data" class="self-end text-xs text-gray-600 ml-2">
+					<div v-if="draftMailsCount.data" class="self-end text-xs text-gray-600 ml-2">
 						{{
 							__('{0} {1}').format(
-								formatNumber(outgoingMailCount.data),
-								outgoingMailCount.data == 1 ? singularize('messages') : 'messages'
+								formatNumber(draftMailsCount.data),
+								draftMailsCount.data == 1 ? singularize('messages') : 'messages'
 							)
 						}}
 					</div>
@@ -68,7 +68,7 @@ const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')
 onMounted(() => {
 	socket.on('outgoing_mail_sent', (data) => {
 		draftMails.reload()
-		outgoingMailCount.reload()
+		draftMailsCount.reload()
 	})
 })
 
@@ -78,7 +78,7 @@ const draftMails = createListResource({
 	auto: true,
 	start: mailStart.value,
 	pageLength: 50,
-	cache: ['outgoing', user.data?.name],
+	cache: ['draftMails', user.data?.name],
 	onSuccess(data) {
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
@@ -88,18 +88,18 @@ const draftMails = createListResource({
 	},
 })
 
-const outgoingMailCount = createResource({
+const draftMailsCount = createResource({
 	url: 'frappe.client.get_count',
 	makeParams(values) {
 		return {
 			doctype: 'Outgoing Mail',
 			filters: {
 				sender: user.data?.name,
-				folder: 'Sent',
+				folder: 'Drafts',
 			},
 		}
 	},
-	cache: ['outgoingMailCount', user.data?.name],
+	cache: ['draftMailsCount', user.data?.name],
 	auto: true,
 })
 

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -45,14 +45,18 @@
 				/>
 			</div>
 			<div class="flex-1 overflow-auto w-2/3">
-				<MailDetails :mailID="currentMail.draft" type="Outgoing Mail" />
+				<MailDetails
+					:mailID="currentMail.draft"
+					type="Outgoing Mail"
+					@resetCurrentMail="setCurrentMail('draft', null)"
+				/>
 			</div>
 		</div>
 	</div>
 </template>
 <script setup>
 import { Breadcrumbs, createResource, createListResource } from 'frappe-ui'
-import { computed, inject, ref, watch, onMounted } from 'vue'
+import { computed, inject, watch } from 'vue'
 import HeaderActions from '@/components/HeaderActions.vue'
 import { formatNumber, startResizing, singularize } from '@/utils'
 import MailDetails from '@/components/MailDetails.vue'
@@ -69,18 +73,7 @@ const reloadDrafts = () => {
 	draftMailsCount.reload()
 }
 
-onMounted(() => {
-	socket.on('outgoing_mail_sent', (data) => {
-		reloadDrafts()
-	})
-})
-
-watch(
-	() => currentMail.draft,
-	(val) => {
-		reloadDrafts()
-	}
-)
+watch(() => currentMail.draft, reloadDrafts)
 
 const draftMails = createListResource({
 	url: 'mail_client.api.mail.get_draft_mails',

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -62,7 +62,6 @@ import { userStore } from '@/stores/user'
 
 const socket = inject('$socket')
 const user = inject('$user')
-const mailStart = ref(0)
 const { currentMail, setCurrentMail } = userStore()
 
 const reloadDrafts = () => {
@@ -87,10 +86,9 @@ const draftMails = createListResource({
 	url: 'mail_client.api.mail.get_draft_mails',
 	doctype: 'Outgoing Mail',
 	auto: true,
-	start: mailStart.value,
+	pageLength: 50,
 	cache: ['draftMails', user.data?.name],
 	onSuccess(data) {
-		mailStart.value = data.length
 		if (!currentMail.draft && data.length) setCurrentMail('draft', data[0].name)
 	},
 })

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -80,7 +80,7 @@ onMounted(() => {
 watch(
 	() => currentMail.draft,
 	(val) => {
-		if (!val) reloadDrafts()
+		reloadDrafts()
 	}
 )
 
@@ -89,14 +89,12 @@ const draftMails = createListResource({
 	doctype: 'Outgoing Mail',
 	auto: true,
 	start: mailStart.value,
-	pageLength: 50,
 	cache: ['draftMails', user.data?.name],
 	onSuccess(data) {
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
-		if (!currentMail.draft && mailList.value.length) {
+		if (!currentMail.draft && mailList.value.length)
 			setCurrentMail('draft', mailList.value[0].name)
-		}
 	},
 })
 
@@ -116,7 +114,7 @@ const draftMailsCount = createResource({
 })
 
 const loadMoreEmails = useDebounceFn(() => {
-	if (draftMails.hasNextPage) outgoingMails.next()
+	if (draftMails.hasNextPage) draftMails.next()
 }, 500)
 
 const breadcrumbs = computed(() => {

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -17,14 +17,14 @@
 			</Breadcrumbs>
 			<HeaderActions />
 		</header>
-		<div v-if="outgoingMails.data" class="flex h-[calc(100vh-3.2rem)]">
+		<div v-if="draftMails.data" class="flex h-[calc(100vh-3.2rem)]">
 			<div
 				@scroll="loadMoreEmails"
 				ref="mailSidebar"
 				class="mailSidebar border-r w-1/3 p-2 sticky top-16 overflow-y-scroll overscroll-contain"
 			>
 				<div
-					v-for="(mail, idx) in outgoingMails.data"
+					v-for="(mail, idx) in draftMails.data"
 					@click="openMail(mail)"
 					class="flex flex-col space-y-1 cursor-pointer"
 					:class="{ 'bg-gray-200 rounded': mail.name == currentMail }"
@@ -33,7 +33,7 @@
 					<div
 						:class="{
 							'mx-4 h-[0.25px] border-b border-gray-100':
-								idx < outgoingMails.data.length - 1,
+								idx < draftMails.data.length - 1,
 						}"
 					></div>
 				</div>
@@ -67,13 +67,13 @@ const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')
 
 onMounted(() => {
 	socket.on('outgoing_mail_sent', (data) => {
-		outgoingMails.reload()
+		draftMails.reload()
 		outgoingMailCount.reload()
 	})
 })
 
-const outgoingMails = createListResource({
-	url: 'mail_client.api.mail.get_outgoing_mails',
+const draftMails = createListResource({
+	url: 'mail_client.api.mail.get_draft_mails',
 	doctype: 'Outgoing Mail',
 	auto: true,
 	start: mailStart.value,
@@ -104,7 +104,7 @@ const outgoingMailCount = createResource({
 })
 
 const loadMoreEmails = useDebounceFn(() => {
-	if (outgoingMails.hasNextPage) outgoingMails.next()
+	if (draftMails.hasNextPage) outgoingMails.next()
 }, 500)
 
 const setCurrentMail = (mail) => {

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -63,7 +63,7 @@ const socket = inject('$socket')
 const user = inject('$user')
 const mailStart = ref(0)
 const mailList = ref([])
-const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')))
+const currentMail = ref(JSON.parse(sessionStorage.getItem('currentDraftMail')))
 
 onMounted(() => {
 	socket.on('outgoing_mail_sent', (data) => {
@@ -83,7 +83,7 @@ const draftMails = createListResource({
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
 		if (!currentMail.value && mailList.value.length) {
-			setCurrentMail(mailList.value[0].name)
+			openMail(mailList.value[0])
 		}
 	},
 })
@@ -108,7 +108,7 @@ const loadMoreEmails = useDebounceFn(() => {
 }, 500)
 
 const setCurrentMail = (mail) => {
-	sessionStorage.setItem('currentOutgoingMail', JSON.stringify(mail))
+	sessionStorage.setItem('currentDraftMail', JSON.stringify(mail))
 }
 
 const openMail = (mail) => {

--- a/frontend/src/pages/Drafts.vue
+++ b/frontend/src/pages/Drafts.vue
@@ -63,7 +63,6 @@ import { userStore } from '@/stores/user'
 const socket = inject('$socket')
 const user = inject('$user')
 const mailStart = ref(0)
-const mailList = ref([])
 const { currentMail, setCurrentMail } = userStore()
 
 const reloadDrafts = () => {
@@ -91,10 +90,8 @@ const draftMails = createListResource({
 	start: mailStart.value,
 	cache: ['draftMails', user.data?.name],
 	onSuccess(data) {
-		mailList.value = mailList.value.concat(data)
-		mailStart.value = mailStart.value + data.length
-		if (!currentMail.draft && mailList.value.length)
-			setCurrentMail('draft', mailList.value[0].name)
+		mailStart.value = data.length
+		if (!currentMail.draft && data.length) setCurrentMail('draft', data[0].name)
 	},
 })
 

--- a/frontend/src/pages/Inbox.vue
+++ b/frontend/src/pages/Inbox.vue
@@ -62,7 +62,6 @@ import { userStore } from '@/stores/user'
 
 const socket = inject('$socket')
 const user = inject('$user')
-const mailStart = ref(0)
 const { currentMail, setCurrentMail } = userStore()
 
 onMounted(() => {
@@ -76,10 +75,9 @@ const incomingMails = createListResource({
 	url: 'mail_client.api.mail.get_incoming_mails',
 	doctype: 'Incoming Mail',
 	auto: true,
-	start: mailStart.value,
+	pageLength: 50,
 	cache: ['incoming', user.data?.name],
 	onSuccess(data) {
-		mailStart.value = data.length
 		if (!currentMail.incoming && data.length) setCurrentMail('incoming', data[0].name)
 	},
 })

--- a/frontend/src/pages/Inbox.vue
+++ b/frontend/src/pages/Inbox.vue
@@ -63,7 +63,6 @@ import { userStore } from '@/stores/user'
 const socket = inject('$socket')
 const user = inject('$user')
 const mailStart = ref(0)
-const mailList = ref([])
 const { currentMail, setCurrentMail } = userStore()
 
 onMounted(() => {
@@ -80,10 +79,8 @@ const incomingMails = createListResource({
 	start: mailStart.value,
 	cache: ['incoming', user.data?.name],
 	onSuccess(data) {
-		mailList.value = mailList.value.concat(data)
-		mailStart.value = mailStart.value + data.length
-		if (!currentMail.incoming && mailList.value.length)
-			setCurrentMail('incoming', mailList.value[0].name)
+		mailStart.value = data.length
+		if (!currentMail.incoming && data.length) setCurrentMail('incoming', data[0].name)
 	},
 })
 

--- a/frontend/src/pages/Inbox.vue
+++ b/frontend/src/pages/Inbox.vue
@@ -78,14 +78,12 @@ const incomingMails = createListResource({
 	doctype: 'Incoming Mail',
 	auto: true,
 	start: mailStart.value,
-	pageLength: 50,
 	cache: ['incoming', user.data?.name],
 	onSuccess(data) {
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
-		if (!currentMail.incoming && mailList.value.length) {
+		if (!currentMail.incoming && mailList.value.length)
 			setCurrentMail('incoming', mailList.value[0].name)
-		}
 	},
 })
 

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -73,7 +73,7 @@ onMounted(() => {
 })
 
 const outgoingMails = createListResource({
-	url: 'mail_client.api.mail.get_outgoing_mails',
+	url: 'mail_client.api.mail.get_sent_mails',
 	doctype: 'Outgoing Mail',
 	auto: true,
 	start: mailStart.value,

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -78,14 +78,12 @@ const sentMails = createListResource({
 	doctype: 'Outgoing Mail',
 	auto: true,
 	start: mailStart.value,
-	pageLength: 50,
 	cache: ['sentMails', user.data?.name],
 	onSuccess(data) {
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
-		if (!currentMail.sent && mailList.value.length) {
+		if (!currentMail.sent && mailList.value.length)
 			setCurrentMail('sent', mailList.value[0].name)
-		}
 	},
 })
 
@@ -105,7 +103,7 @@ const sentMailsCount = createResource({
 })
 
 const loadMoreEmails = useDebounceFn(() => {
-	if (sentMails.hasNextPage) outgoingMails.next()
+	if (sentMails.hasNextPage) sentMails.next()
 }, 500)
 
 const breadcrumbs = computed(() => {

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -5,11 +5,11 @@
 		>
 			<Breadcrumbs :items="breadcrumbs">
 				<template #suffix>
-					<div v-if="outgoingMailCount.data" class="self-end text-xs text-gray-600 ml-2">
+					<div v-if="sentMailsCount.data" class="self-end text-xs text-gray-600 ml-2">
 						{{
 							__('{0} {1}').format(
-								formatNumber(outgoingMailCount.data),
-								outgoingMailCount.data == 1 ? singularize('messages') : 'messages'
+								formatNumber(sentMailsCount.data),
+								sentMailsCount.data == 1 ? singularize('messages') : 'messages'
 							)
 						}}
 					</div>
@@ -17,14 +17,14 @@
 			</Breadcrumbs>
 			<HeaderActions />
 		</header>
-		<div v-if="outgoingMails.data" class="flex h-[calc(100vh-3.2rem)]">
+		<div v-if="sentMails.data" class="flex h-[calc(100vh-3.2rem)]">
 			<div
 				@scroll="loadMoreEmails"
 				ref="mailSidebar"
 				class="mailSidebar border-r w-1/3 p-2 sticky top-16 overflow-y-scroll overscroll-contain"
 			>
 				<div
-					v-for="(mail, idx) in outgoingMails.data"
+					v-for="(mail, idx) in sentMails.data"
 					@click="openMail(mail)"
 					class="flex flex-col space-y-1 cursor-pointer"
 					:class="{ 'bg-gray-200 rounded': mail.name == currentMail }"
@@ -33,7 +33,7 @@
 					<div
 						:class="{
 							'mx-4 h-[0.25px] border-b border-gray-100':
-								idx < outgoingMails.data.length - 1,
+								idx < sentMails.data.length - 1,
 						}"
 					></div>
 				</div>
@@ -67,18 +67,18 @@ const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')
 
 onMounted(() => {
 	socket.on('outgoing_mail_sent', (data) => {
-		outgoingMails.reload()
-		outgoingMailCount.reload()
+		sentMails.reload()
+		sentMailsCount.reload()
 	})
 })
 
-const outgoingMails = createListResource({
+const sentMails = createListResource({
 	url: 'mail_client.api.mail.get_sent_mails',
 	doctype: 'Outgoing Mail',
 	auto: true,
 	start: mailStart.value,
 	pageLength: 50,
-	cache: ['outgoing', user.data?.name],
+	cache: ['sentMails', user.data?.name],
 	onSuccess(data) {
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
@@ -88,7 +88,7 @@ const outgoingMails = createListResource({
 	},
 })
 
-const outgoingMailCount = createResource({
+const sentMailsCount = createResource({
 	url: 'frappe.client.get_count',
 	makeParams(values) {
 		return {
@@ -99,12 +99,12 @@ const outgoingMailCount = createResource({
 			},
 		}
 	},
-	cache: ['outgoingMailCount', user.data?.name],
+	cache: ['sentMailsCount', user.data?.name],
 	auto: true,
 })
 
 const loadMoreEmails = useDebounceFn(() => {
-	if (outgoingMails.hasNextPage) outgoingMails.next()
+	if (sentMails.hasNextPage) outgoingMails.next()
 }, 500)
 
 const setCurrentMail = (mail) => {

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -63,7 +63,6 @@ import { userStore } from '@/stores/user'
 const socket = inject('$socket')
 const user = inject('$user')
 const mailStart = ref(0)
-const mailList = ref([])
 const { currentMail, setCurrentMail } = userStore()
 
 onMounted(() => {
@@ -80,10 +79,8 @@ const sentMails = createListResource({
 	start: mailStart.value,
 	cache: ['sentMails', user.data?.name],
 	onSuccess(data) {
-		mailList.value = mailList.value.concat(data)
-		mailStart.value = mailStart.value + data.length
-		if (!currentMail.sent && mailList.value.length)
-			setCurrentMail('sent', mailList.value[0].name)
+		mailStart.value = data.length
+		if (!currentMail.sent && data.length) setCurrentMail('sent', data[0].name)
 	},
 })
 
@@ -94,7 +91,7 @@ const sentMailsCount = createResource({
 			doctype: 'Outgoing Mail',
 			filters: {
 				sender: user.data?.name,
-				status: 'Sent',
+				folder: 'Sent',
 			},
 		}
 	},

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -63,7 +63,7 @@ const socket = inject('$socket')
 const user = inject('$user')
 const mailStart = ref(0)
 const mailList = ref([])
-const currentMail = ref(JSON.parse(sessionStorage.getItem('currentOutgoingMail')))
+const currentMail = ref(JSON.parse(sessionStorage.getItem('currentSentMail')))
 
 onMounted(() => {
 	socket.on('outgoing_mail_sent', (data) => {
@@ -83,7 +83,7 @@ const sentMails = createListResource({
 		mailList.value = mailList.value.concat(data)
 		mailStart.value = mailStart.value + data.length
 		if (!currentMail.value && mailList.value.length) {
-			setCurrentMail(mailList.value[0].name)
+			openMail(mailList.value[0])
 		}
 	},
 })
@@ -108,7 +108,7 @@ const loadMoreEmails = useDebounceFn(() => {
 }, 500)
 
 const setCurrentMail = (mail) => {
-	sessionStorage.setItem('currentOutgoingMail', JSON.stringify(mail))
+	sessionStorage.setItem('currentSentMail', JSON.stringify(mail))
 }
 
 const openMail = (mail) => {

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -62,7 +62,6 @@ import { userStore } from '@/stores/user'
 
 const socket = inject('$socket')
 const user = inject('$user')
-const mailStart = ref(0)
 const { currentMail, setCurrentMail } = userStore()
 
 onMounted(() => {
@@ -76,10 +75,9 @@ const sentMails = createListResource({
 	url: 'mail_client.api.mail.get_sent_mails',
 	doctype: 'Outgoing Mail',
 	auto: true,
-	start: mailStart.value,
+	pageLength: 50,
 	cache: ['sentMails', user.data?.name],
 	onSuccess(data) {
-		mailStart.value = data.length
 		if (!currentMail.sent && data.length) setCurrentMail('sent', data[0].name)
 	},
 })

--- a/frontend/src/pages/Sent.vue
+++ b/frontend/src/pages/Sent.vue
@@ -89,7 +89,7 @@ const sentMailsCount = createResource({
 			doctype: 'Outgoing Mail',
 			filters: {
 				sender: user.data?.name,
-				folder: 'Sent',
+				status: 'Sent',
 			},
 		}
 	},

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -19,6 +19,11 @@ const routes = [
 		name: 'Sent',
 		component: () => import('@/pages/Sent.vue'),
 	},
+	{
+		path: '/drafts',
+		name: 'Drafts',
+		component: () => import('@/pages/Drafts.vue'),
+	},
 ]
 
 let router = createRouter({

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -36,7 +36,8 @@ export const sessionStore = defineStore('mail-session', () => {
 		url: 'logout',
 		onSuccess() {
 			sessionStorage.removeItem('currentIncomingMail')
-			sessionStorage.removeItem('currentOutgoingMail')
+			sessionStorage.removeItem('currentSentMail')
+			sessionStorage.removeItem('currentDraftMail')
 			userResource.reset()
 			user.value = null
 			window.location.reload()

--- a/frontend/src/stores/user.js
+++ b/frontend/src/stores/user.js
@@ -1,6 +1,7 @@
 import router from '@/router'
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
+import { reactive } from 'vue'
 
 export const userStore = defineStore('mail-users', () => {
 	let userResource = createResource({
@@ -13,7 +14,22 @@ export const userStore = defineStore('mail-users', () => {
 		auto: true,
 	})
 
-	return {
-		userResource,
+	const currentMail = reactive({
+		incoming: JSON.parse(sessionStorage.getItem('currentIncomingMail')) || null,
+		sent: JSON.parse(sessionStorage.getItem('currentSentMail')) || null,
+		draft: JSON.parse(sessionStorage.getItem('currentDraftMail')) || null,
+	})
+
+	const setCurrentMail = (folder, mail) => {
+		const itemName = `current${folder.charAt(0).toUpperCase() + folder.slice(1)}Mail`
+		if (!mail) {
+			currentMail[folder] = null
+			sessionStorage.removeItem(itemName)
+			return
+		}
+		currentMail[folder] = mail
+		sessionStorage.setItem(itemName, JSON.stringify(mail))
 	}
+
+	return { userResource, currentMail, setCurrentMail }
 })

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -28,6 +28,12 @@ export function getSidebarLinks() {
 			to: 'Sent',
 			activeFor: ['Sent'],
 		},
+		{
+			label: 'Drafts',
+			icon: 'Edit3',
+			to: 'Drafts',
+			activeFor: ['Drafts'],
+		},
 	]
 }
 

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -88,14 +88,28 @@ def get_incoming_mails(start: int = 0) -> list:
 
 
 @frappe.whitelist()
-def get_outgoing_mails(start: int = 0) -> list:
+def get_sent_mails(start: int = 0) -> list:
+	"""Returns mails from Sent frolder for the current user."""
+
+	return get_outgoing_mails("Sent", start)
+
+
+@frappe.whitelist()
+def get_draft_mails(start: int = 0) -> list:
+	"""Returns mails from Drafts folder for the current user."""
+
+	return get_outgoing_mails("Drafts", start)
+
+
+def get_outgoing_mails(folder: str, start: int = 0) -> list:
 	"""Returns outgoing mails for the current user."""
 
 	mailboxes = get_user_mailboxes(frappe.session.user, "Outgoing")
+	docstatus = 0 if folder == "Drafts" else 1
 
 	mails = frappe.get_all(
 		"Outgoing Mail",
-		{"sender": ["in", mailboxes], "docstatus": 1, "folder": "Sent"},
+		{"sender": ["in", mailboxes], "docstatus": docstatus, "folder": folder},
 		[
 			"name",
 			"subject",
@@ -291,6 +305,7 @@ def get_mail_details(name: str, type: str, include_all_details: bool = False) ->
 		"message_id",
 		"in_reply_to_mail_name",
 		"in_reply_to_mail_type",
+		"folder",
 	]
 
 	mail = frappe.db.get_value(type, name, fields, as_dict=1)

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -106,7 +106,13 @@ def get_outgoing_mails(folder: str, start: int = 0) -> list:
 	"""Returns outgoing mails for the current user."""
 
 	mailboxes = get_user_mailboxes(frappe.session.user, "Outgoing")
-	docstatus = 0 if folder == "Drafts" else 1
+
+	if folder == "Drafts":
+		docstatus = 0
+		order_by = "modified desc"
+	else:
+		docstatus = 1
+		order_by = "created_at desc"
 
 	mails = frappe.get_all(
 		"Outgoing Mail",
@@ -125,7 +131,7 @@ def get_outgoing_mails(folder: str, start: int = 0) -> list:
 		],
 		limit=50,
 		start=start,
-		order_by="created_at desc",
+		order_by=order_by,
 	)
 
 	return get_mail_list(mails, "Outgoing Mail")

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -420,5 +420,3 @@ def update_draft_mail(
 
 	if do_submit:
 		doc.submit()
-
-	return doc

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -112,6 +112,7 @@ def get_outgoing_mails(status: str, start: int = 0) -> list:
 		order_by = "modified desc"
 	else:
 		docstatus = 1
+		# TODO: fix sorting
 		order_by = "created_at desc"
 
 	mails = frappe.get_all(

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -384,6 +384,7 @@ def update_draft_mail(
 	bcc: str | list[str] | None = None,
 	html: str | None = None,
 	attachments: list[dict] | None = None,
+	do_submit: bool = False,
 ):
 	"""Update draft mail."""
 
@@ -400,6 +401,9 @@ def update_draft_mail(
 	doc.body_html = html
 	doc.save()
 	doc._add_attachment(attachments)
+
+	if do_submit:
+		doc.submit()
 
 
 @frappe.whitelist()

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -90,24 +90,24 @@ def get_incoming_mails(start: int = 0) -> list:
 
 @frappe.whitelist()
 def get_sent_mails(start: int = 0) -> list:
-	"""Returns mails from Sent frolder for the current user."""
+	"""Returns sent mails for the current user."""
 
 	return get_outgoing_mails("Sent", start)
 
 
 @frappe.whitelist()
 def get_draft_mails(start: int = 0) -> list:
-	"""Returns mails from Drafts folder for the current user."""
+	"""Returns draft mails for the current user."""
 
-	return get_outgoing_mails("Drafts", start)
+	return get_outgoing_mails("Draft", start)
 
 
-def get_outgoing_mails(folder: str, start: int = 0) -> list:
+def get_outgoing_mails(status: str, start: int = 0) -> list:
 	"""Returns outgoing mails for the current user."""
 
 	mailboxes = get_user_mailboxes(frappe.session.user, "Outgoing")
 
-	if folder == "Drafts":
+	if status == "Draft":
 		docstatus = 0
 		order_by = "modified desc"
 	else:
@@ -116,7 +116,7 @@ def get_outgoing_mails(folder: str, start: int = 0) -> list:
 
 	mails = frappe.get_all(
 		"Outgoing Mail",
-		{"sender": ["in", mailboxes], "docstatus": docstatus, "folder": folder},
+		{"sender": ["in", mailboxes], "docstatus": docstatus, "status": status},
 		[
 			"name",
 			"subject",
@@ -419,10 +419,3 @@ def update_draft_mail(
 
 	if do_submit:
 		doc.submit()
-
-
-@frappe.whitelist()
-def delete_mail(mail_type: str, mail_id: str):
-	"""Delete mail."""
-
-	frappe.delete_doc(mail_type, mail_id)

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -406,14 +406,12 @@ def update_draft_mail(
 
 	display_name, sender = parseaddr(from_)
 
-	# TODO: don't rewrite full doc
 	doc = frappe.get_doc("Outgoing Mail", mail_id)
 	doc.sender = sender
 	doc.display_name = display_name
-	doc.recipients = []
-	doc._add_recipient("To", to)
-	doc._add_recipient("Cc", cc)
-	doc._add_recipient("Bcc", bcc)
+	doc._update_recipients("To", to)
+	doc._update_recipients("Cc", cc)
+	doc._update_recipients("Bcc", bcc)
 	doc.subject = subject
 	doc.body_html = html
 	doc.save()

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 from frappe.translate import get_all_translations
 from frappe.utils import is_html
 
+from mail_client.utils.cache import get_user_default_mailbox
 from mail_client.utils.user import get_user_mailboxes, has_role, is_system_manager
 
 
@@ -302,6 +303,7 @@ def get_mail_details(name: str, type: str, include_all_details: bool = False) ->
 		"sender",
 		"display_name",
 		"creation",
+		"modified",
 		"message_id",
 		"in_reply_to_mail_name",
 		"in_reply_to_mail_type",
@@ -379,7 +381,7 @@ def get_mail_contacts(txt=None) -> list:
 def get_default_outgoing() -> str | None:
 	"""Returns default outgoing mailbox."""
 
-	return frappe.db.exists({"doctype": "Mailbox", "user": frappe.session.user, "is_default": 1})
+	return get_user_default_mailbox(frappe.session.user)
 
 
 @frappe.whitelist()

--- a/mail_client/api/mail.py
+++ b/mail_client/api/mail.py
@@ -419,3 +419,5 @@ def update_draft_mail(
 
 	if do_submit:
 		doc.submit()
+
+	return doc

--- a/mail_client/api/outbound.py
+++ b/mail_client/api/outbound.py
@@ -8,6 +8,45 @@ from mail_client.mail_client.doctype.outgoing_mail.outgoing_mail import create_o
 
 
 @frappe.whitelist(methods=["POST"])
+def create_draft_mail(
+	from_: str,
+	to: str | list[str],
+	subject: str,
+	cc: str | list[str] | None = None,
+	bcc: str | list[str] | None = None,
+	html: str | None = None,
+	reply_to: str | list[str] | None = None,
+	in_reply_to_mail_type: str | None = None,
+	in_reply_to_mail_name: str | None = None,
+	custom_headers: dict | None = None,
+	attachments: list[dict] | None = None,
+	is_newsletter: bool = False,
+) -> str:
+	"""Create draft mail."""
+
+	display_name, sender = parseaddr(from_)
+	doc = create_outgoing_mail(
+		sender=sender,
+		to=to,
+		display_name=display_name,
+		cc=cc,
+		bcc=bcc,
+		subject=subject,
+		body_html=html,
+		reply_to=reply_to,
+		in_reply_to_mail_type=in_reply_to_mail_type,
+		in_reply_to_mail_name=in_reply_to_mail_name,
+		custom_headers=custom_headers,
+		attachments=attachments,
+		via_api=1,
+		is_newsletter=cint(is_newsletter),
+		do_not_submit=True,
+	)
+
+	return doc.name
+
+
+@frappe.whitelist(methods=["POST"])
 def send(
 	from_: str,
 	to: str | list[str],

--- a/mail_client/api/outbound.py
+++ b/mail_client/api/outbound.py
@@ -8,45 +8,6 @@ from mail_client.mail_client.doctype.outgoing_mail.outgoing_mail import create_o
 
 
 @frappe.whitelist(methods=["POST"])
-def create_draft_mail(
-	from_: str,
-	to: str | list[str],
-	subject: str,
-	cc: str | list[str] | None = None,
-	bcc: str | list[str] | None = None,
-	html: str | None = None,
-	reply_to: str | list[str] | None = None,
-	in_reply_to_mail_type: str | None = None,
-	in_reply_to_mail_name: str | None = None,
-	custom_headers: dict | None = None,
-	attachments: list[dict] | None = None,
-	is_newsletter: bool = False,
-) -> str:
-	"""Create draft mail."""
-
-	display_name, sender = parseaddr(from_)
-	doc = create_outgoing_mail(
-		sender=sender,
-		to=to,
-		display_name=display_name,
-		cc=cc,
-		bcc=bcc,
-		subject=subject,
-		body_html=html,
-		reply_to=reply_to,
-		in_reply_to_mail_type=in_reply_to_mail_type,
-		in_reply_to_mail_name=in_reply_to_mail_name,
-		custom_headers=custom_headers,
-		attachments=attachments,
-		via_api=1,
-		is_newsletter=cint(is_newsletter),
-		do_not_submit=True,
-	)
-
-	return doc.name
-
-
-@frappe.whitelist(methods=["POST"])
 def send(
 	from_: str,
 	to: str | list[str],
@@ -60,6 +21,7 @@ def send(
 	custom_headers: dict | None = None,
 	attachments: list[dict] | None = None,
 	is_newsletter: bool = False,
+	do_not_submit: bool = False,
 ) -> str:
 	"""Send Mail."""
 
@@ -79,6 +41,7 @@ def send(
 		attachments=attachments,
 		via_api=1,
 		is_newsletter=cint(is_newsletter),
+		do_not_submit=do_not_submit,
 	)
 
 	return doc.name

--- a/mail_client/api/outbound.py
+++ b/mail_client/api/outbound.py
@@ -10,8 +10,8 @@ from mail_client.mail_client.doctype.outgoing_mail.outgoing_mail import create_o
 @frappe.whitelist(methods=["POST"])
 def send(
 	from_: str,
-	to: str | list[str],
 	subject: str,
+	to: str | list[str] | None = None,
 	cc: str | list[str] | None = None,
 	bcc: str | list[str] | None = None,
 	html: str | None = None,
@@ -28,8 +28,8 @@ def send(
 	display_name, sender = parseaddr(from_)
 	doc = create_outgoing_mail(
 		sender=sender,
-		to=to,
 		display_name=display_name,
+		to=to,
 		cc=cc,
 		bcc=bcc,
 		subject=subject,

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.json
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.json
@@ -74,7 +74,6 @@
    "fieldtype": "Table",
    "label": "Recipients",
    "options": "Mail Recipient",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -473,7 +472,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-20 10:47:08.592108",
+ "modified": "2024-11-22 14:34:10.362892",
  "modified_by": "Administrator",
  "module": "Mail Client",
  "name": "Outgoing Mail",

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
@@ -524,7 +524,7 @@ class OutgoingMail(Document):
 			if d not in prev_recipients:
 				self._add_recipient(type, d)
 
-		for d in self.recipients:
+		for d in self.recipients[:]:
 			if d.type == type and d.email not in recipients:
 				self.recipients.remove(d)
 

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
@@ -76,11 +76,6 @@ class OutgoingMail(Document):
 			self.validate_max_message_size()
 
 	def on_submit(self) -> None:
-		if not self.recipients:
-			frappe.throw(
-				_("Please add at least one recipient before sending the mail."), frappe.MandatoryError
-			)
-
 		self.create_mail_contacts()
 
 		status = "Pending"
@@ -175,6 +170,14 @@ class OutgoingMail(Document):
 
 	def validate_recipients(self) -> None:
 		"""Validates the recipients."""
+
+		if not self.recipients:
+			if self.get("_action") == "submit":
+				frappe.throw(
+					_("Please add at least one recipient before sending the mail."), frappe.MandatoryError
+				)
+
+			return
 
 		max_recipients = self.runtime.client_settings.max_recipients
 		if len(self.recipients) > max_recipients:
@@ -478,7 +481,7 @@ class OutgoingMail(Document):
 
 		return self.runtime.mail_domain.get_password("dkim_private_key")
 
-	def _add_recipient(self, type: str, recipient: str | list[str]) -> None:
+	def _add_recipient(self, type: str, recipient: str | list[str] | None = None) -> None:
 		"""Adds the recipients."""
 
 		if not recipient:

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
@@ -508,6 +508,18 @@ class OutgoingMail(Document):
 
 		return recipients if as_list else ", ".join(recipients)
 
+	def _update_recipients(self, type: str, recipients: list[str] | None = None) -> None:
+		"""Updates the recipients by comparing new and old list."""
+
+		prev_recipients = self._get_recipients(type, as_list=True)
+		for d in recipients:
+			if d not in prev_recipients:
+				self._add_recipient(type, d)
+
+		for d in self.recipients:
+			if d.type == type and d.email not in recipients:
+				self.recipients.remove(d)
+
 	def _add_attachment(self, attachment: dict | list[dict]) -> None:
 		"""Adds the attachments."""
 

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
@@ -476,15 +476,17 @@ class OutgoingMail(Document):
 	def _add_recipient(self, type: str, recipient: str | list[str]) -> None:
 		"""Adds the recipients."""
 
-		if recipient:
-			recipients = [recipient] if isinstance(recipient, str) else recipient
-			for rcpt in recipients:
-				display_name, email = parseaddr(rcpt)
+		if not recipient:
+			return
 
-				if not email:
-					frappe.throw(_("Invalid format for recipient {0}.").format(frappe.bold(rcpt)))
+		recipients = [recipient] if isinstance(recipient, str) else recipient
+		for rcpt in recipients:
+			display_name, email = parseaddr(rcpt)
 
-				self.append("recipients", {"type": type, "email": email, "display_name": display_name})
+			if not email:
+				frappe.throw(_("Invalid format for recipient {0}.").format(frappe.bold(rcpt)))
+
+			self.append("recipients", {"type": type, "email": email, "display_name": display_name})
 
 	def _get_recipients(self, type: str | None = None, as_list: bool = False) -> str | list[str]:
 		"""Returns the recipients."""

--- a/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail_client/mail_client/doctype/outgoing_mail/outgoing_mail.py
@@ -76,6 +76,11 @@ class OutgoingMail(Document):
 			self.validate_max_message_size()
 
 	def on_submit(self) -> None:
+		if not self.recipients:
+			frappe.throw(
+				_("Please add at least one recipient before sending the mail."), frappe.MandatoryError
+			)
+
 		self.create_mail_contacts()
 
 		status = "Pending"


### PR DESCRIPTION
This PR introduces Drafts for the frontend app:-
- Mails will typically get saved as 'Draft' if you type something up in the SendMail dialog and exit it without hitting 'Send'.
- All Draft mails created can be accessed from the 'Drafts' section of the sidebar.
- You can resume editing Draft mails by clicking on the edit icon. Changes are synced with the backend by debouncing the input by 1.5 seconds.


https://github.com/user-attachments/assets/dd8266e9-3659-4e80-90e8-397c398df852


