### PR TITLE
refactor: drop pytz

### DIFF
--- a/mail_client/api/inbound.py
+++ b/mail_client/api/inbound.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from email.utils import formataddr
 from typing import TYPE_CHECKING
 
 import frappe
-import pytz
 from frappe import _
 from frappe.utils import cint, convert_utc_to_system_timezone, now
 
@@ -78,7 +77,7 @@ def convert_to_system_timezone(last_synced_at: str) -> datetime | None:
 
 	if last_synced_at:
 		dt = datetime.fromisoformat(last_synced_at)
-		dt_utc = dt.astimezone(pytz.utc)
+		dt_utc = dt.astimezone(timezone.utc)
 		return convert_utc_to_system_timezone(dt_utc)
 
 

--- a/mail_client/utils/__init__.py
+++ b/mail_client/utils/__init__.py
@@ -1,11 +1,11 @@
 import re
 import socket
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime as parsedate
+from zoneinfo import ZoneInfo
 
 import frappe
-import pytz
 from bs4 import BeautifulSoup
 from frappe import _
 from frappe.utils import convert_utc_to_system_timezone, get_datetime, get_datetime_str, get_system_timezone
@@ -68,10 +68,10 @@ def convert_to_utc(date_time: datetime | str, from_timezone: str | None = None) 
 
 	dt = get_datetime(date_time)
 	if dt.tzinfo is None:
-		tz = pytz.timezone(from_timezone or get_system_timezone())
-		dt = tz.localize(dt)
+		tz = ZoneInfo(from_timezone or get_system_timezone())
+		dt = dt.replace(tzinfo=tz)
 
-	return dt.astimezone(pytz.utc)
+	return dt.astimezone(timezone.utc)
 
 
 def parsedate_to_datetime(date_header: str) -> "datetime":
@@ -92,7 +92,7 @@ def parse_iso_datetime(
 	if not to_timezone:
 		to_timezone = get_system_timezone()
 
-	dt = datetime.fromisoformat(datetime_str.replace("Z", "+00:00")).astimezone(pytz.timezone(to_timezone))
+	dt = datetime.fromisoformat(datetime_str.replace("Z", "+00:00")).astimezone(ZoneInfo(to_timezone))
 
 	return get_datetime_str(dt) if as_str else dt
 
@@ -101,7 +101,7 @@ def add_or_update_tzinfo(date_time: datetime | str, timezone: str | None = None)
 	"""Adds or updates timezone to the datetime."""
 
 	date_time = get_datetime(date_time)
-	target_tz = pytz.timezone(timezone or get_system_timezone())
+	target_tz = ZoneInfo(timezone or get_system_timezone())
 
 	if date_time.tzinfo is None:
 		date_time = target_tz.localize(date_time)


### PR DESCRIPTION
Follow up to https://github.com/frappe/frappe/pull/28093 so I can drop the pytz dependency
