### PR TITLE
feat: add permission for Mail Tenant and Mail Tenant Member

### DIFF
--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -150,6 +150,7 @@ email_css = ["/assets/mail/css/email.css"]
 # Permissions evaluated in scripted ways
 
 permission_query_conditions = {
+	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.get_permission_query_condition",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.get_permission_query_condition",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.get_permission_query_condition",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.get_permission_query_condition",
@@ -157,6 +158,7 @@ permission_query_conditions = {
 }
 
 has_permission = {
+	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.has_permission",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.has_permission",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.has_permission",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.has_permission",

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -151,6 +151,7 @@ email_css = ["/assets/mail/css/email.css"]
 
 permission_query_conditions = {
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.get_permission_query_condition",
+	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.get_permission_query_condition",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.get_permission_query_condition",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.get_permission_query_condition",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.get_permission_query_condition",
@@ -159,6 +160,7 @@ permission_query_conditions = {
 
 has_permission = {
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.has_permission",
+	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.has_permission",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.has_permission",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.has_permission",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.has_permission",

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -5,7 +5,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from mail.utils.user import has_role
+from mail.utils.cache import get_user_mail_tenant
+from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
 
 
 class MailTenantMember(Document):
@@ -26,3 +27,30 @@ class MailTenantMember(Document):
 
 	def clear_cache(self):
 		frappe.cache.delete_value(f"user|{self.user}")
+
+
+def has_permission(doc: "Document", ptype: str, user: str) -> bool:
+	if doc.doctype != "Mail Tenant Member":
+		return False
+
+	if is_system_manager(user):
+		return True
+
+	if is_mail_tenant_admin(doc.tenant, user):
+		return True
+
+	return False
+
+
+def get_permission_query_condition(user: str | None = None) -> str:
+	if not user:
+		user = frappe.session.user
+
+	if is_system_manager(user):
+		return ""
+
+	if has_role(user, "Mail Admin"):
+		if tenant := get_user_mail_tenant(user):
+			return f'(`tabMail Tenant Member`.`tenant` = "{tenant}")'
+
+	return "1=0"

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -12,8 +12,17 @@ class MailTenantMember(Document):
 	def validate(self):
 		self.validate_user()
 
+	def on_update(self):
+		self.clear_cache()
+
+	def on_trash(self):
+		self.clear_cache()
+
 	def validate_user(self):
 		if not has_role(self.user, ["Mail Admin", "Mail User"]):
 			frappe.throw(
 				_("User {0} does not have Mail Admin or Mail User role.").format(frappe.bold(self.user))
 			)
+
+	def clear_cache(self):
+		frappe.cache.delete_value(f"user|{self.user}")

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -43,6 +43,15 @@ def get_imap_limits() -> dict:
 	return frappe.cache.get_value("imap_limits", generator)
 
 
+def get_user_mail_tenant(user: str) -> str | None:
+	"""Returns the mail tenant of the user."""
+
+	def generator() -> str | None:
+		return frappe.db.get_value("Mail Tenant Member", {"user": user}, "tenant")
+
+	return frappe.cache.hget(f"user|{user}", "mail_tenant", generator)
+
+
 def get_user_mail_account(user: str) -> str | None:
 	"""Returns the mail account of the user."""
 

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -24,6 +24,15 @@ def get_user_email_addresses(user: str) -> list:
 
 
 @request_cache
+def is_mail_tenant_admin(tenant: str, user: str) -> bool:
+	"""Returns True if the user is an admin of the mail tenant else False."""
+
+	return has_role(user, "Mail Admin") and frappe.db.exists(
+		"Mail Tenant Member", {"tenant": tenant, "user": user}
+	)
+
+
+@request_cache
 def is_mail_account_owner(account: str, user: str) -> bool:
 	"""Returns True if the mail account is associated with the user else False."""
 


### PR DESCRIPTION
- Mail Tenant:
   - System Manager can CRUD Mail Tenant.
   - Mail Admin role + Tenant Member can read and update Mail Tenant.
   - Mail User does not have permission to Mail Tenant.

   ![image](https://github.com/user-attachments/assets/7c1fdadc-ce8f-47ae-b638-fc6dd62d5ad0)

- Mail Tenant Member:
   - System Manager can CRUD a Mail Tenant Member.
   - Mail Admin role + Tenant Member can CRUD members within his Mail Tenant.
   - Mail User does not have permission to Mail Tenant Member.

   ![image](https://github.com/user-attachments/assets/54031e8f-ccbb-4efd-8e89-140dcc0117f3)

