### PR TITLE
feat: add permission for Mail Domain Request

### DIFF
--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -109,4 +109,4 @@ def verify_domain_key(domain_request: str) -> bool:
 	"""Verify the domain request key"""
 
 	doc = frappe.get_doc("Mail Domain Request", domain_request)
-	return doc.verify_key()
+	return doc.verify_and_create_domain(save=True)

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -152,6 +152,7 @@ email_css = ["/assets/mail/css/email.css"]
 permission_query_conditions = {
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.get_permission_query_condition",
 	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.get_permission_query_condition",
+	"Mail Domain Request": "mail.mail.doctype.mail_domain_request.mail_domain_request.get_permission_query_condition",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.get_permission_query_condition",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.get_permission_query_condition",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.get_permission_query_condition",
@@ -161,6 +162,7 @@ permission_query_conditions = {
 has_permission = {
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.has_permission",
 	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.has_permission",
+	"Mail Domain Request": "mail.mail.doctype.mail_domain_request.mail_domain_request.has_permission",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.has_permission",
 	"Mail Contact": "mail.mail.doctype.mail_contact.mail_contact.has_permission",
 	"Outgoing Mail": "mail.mail.doctype.outgoing_mail.outgoing_mail.has_permission",

--- a/mail/mail/doctype/mail_account_request/mail_account_request.json
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.json
@@ -74,7 +74,7 @@
    "fieldtype": "Link",
    "label": "Invited By",
    "link_filters": "[[\"User\",\"role\",\"=\",\"Mail Admin\"]]",
-   "mandatory_depends_on": "eval:doc.tenant",
+   "mandatory_depends_on": "eval: doc.role == \"Mail User\"",
    "options": "User",
    "search_index": 1
   },
@@ -110,7 +110,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 21:19:02.587409",
+ "modified": "2025-01-28 13:44:42.740701",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account Request",

--- a/mail/mail/doctype/mail_account_request/mail_account_request.py
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.py
@@ -10,6 +10,10 @@ from frappe.utils import add_days, get_url, nowdate, random_string
 
 
 class MailAccountRequest(Document):
+	def validate(self) -> None:
+		self.validate_role()
+		self.validate_tenant()
+
 	def before_insert(self) -> None:
 		self.set_request_key()
 
@@ -19,6 +23,20 @@ class MailAccountRequest(Document):
 	def after_insert(self) -> None:
 		if self.send_email:
 			self.send_verification_email()
+
+	def validate_role(self) -> None:
+		if not self.role:
+			frappe.throw(_("Role is mandatory."))
+
+		if self.role not in ["Mail User", "Mail Admin"]:
+			frappe.throw(_("Invalid role. Please select a valid role."))
+
+	def validate_tenant(self) -> None:
+		if self.role == "Mail Admin":
+			self.tenant = None
+		elif self.role == "Mail User":
+			if not self.tenant:
+				frappe.throw(_("Tenant is mandatory for Mail User role."))
 
 	def set_request_key(self) -> None:
 		"""Sets a random key for the request."""

--- a/mail/mail/doctype/mail_agent_request_log/mail_agent_request_log.py
+++ b/mail/mail/doctype/mail_agent_request_log/mail_agent_request_log.py
@@ -146,6 +146,6 @@ def create_mail_agent_request_log(
 	request_log.request_json = request_json
 	request_log.execute_on_start = execute_on_start
 	request_log.execute_on_end = execute_on_end
-	request_log.insert()
+	request_log.insert(ignore_permissions=True)
 
 	return request_log

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -5,7 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_ceuu",
-  "mail_tenant",
+  "tenant",
   "domain_name",
   "enabled",
   "is_verified",
@@ -156,7 +156,7 @@
    "search_index": 1
   },
   {
-   "fieldname": "mail_tenant",
+   "fieldname": "tenant",
    "fieldtype": "Link",
    "in_list_view": 1,
    "in_standard_filter": 1,
@@ -205,7 +205,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-01-27 20:03:04.601562",
+ "modified": "2025-01-28 11:55:45.686944",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",
@@ -226,6 +226,16 @@
    "delete": 1,
    "email": 1,
    "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin",
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
    "permlevel": 1,
    "print": 1,
    "read": 1,
@@ -233,6 +243,16 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin",
+   "share": 1
   }
  ],
  "sort_field": "creation",

--- a/mail/mail/doctype/mail_domain_request/mail_domain_request.js
+++ b/mail/mail/doctype/mail_domain_request/mail_domain_request.js
@@ -4,13 +4,47 @@
 frappe.ui.form.on("Mail Domain Request", {
 	refresh(frm) {
 		frm.trigger("add_actions");
+		frm.trigger("set_user");
+		frm.trigger("set_tenant");
 	},
 
 	add_actions(frm) {
 		if (frm.doc.__islocal) return;
 
-		frm.add_custom_button(__("Verify DNS Record"), () => {
-			frm.call("verify_key");
+		frm.add_custom_button(__("Verify and Create Domain"), () => {
+			frm.call({
+				doc: frm.doc,
+				method: "verify_and_create_domain",
+				args: {
+					save: true,
+				},
+				freeze: true,
+				freeze_message: __("Verifying and creating Domain..."),
+				callback: (r) => {
+					if (!r.exc) {
+						frm.refresh();
+					}
+				},
+			});
 		});
+	},
+
+	set_user(frm) {
+		if (frm.doc.__islocal && !frm.doc.user) {
+			frm.set_value("user", frappe.session.user);
+		}
+	},
+
+	set_tenant(frm) {
+		if (frm.doc.__islocal && !frm.doc.tenant) {
+			frappe.call({
+				method: "mail.utils.user.get_user_tenant",
+				callback: (r) => {
+					if (r.message) {
+						frm.set_value("tenant", r.message);
+					}
+				},
+			});
+		}
 	},
 });

--- a/mail/mail/doctype/mail_domain_request/mail_domain_request.json
+++ b/mail/mail/doctype/mail_domain_request/mail_domain_request.json
@@ -5,9 +5,10 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "domain_name",
-  "tenant",
+  "section_break_c44a",
   "user",
+  "tenant",
+  "domain_name",
   "column_break_batf",
   "verification_key",
   "is_verified"
@@ -26,10 +27,14 @@
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "User",
    "link_filters": "[[\"User\",\"role\",\"=\",\"Mail Admin\"]]",
+   "no_copy": 1,
    "options": "User",
+   "permlevel": 1,
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -46,6 +51,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: !doc.__islocal",
    "fieldname": "is_verified",
    "fieldtype": "Check",
    "label": "Is Verified",
@@ -57,15 +63,23 @@
    "fieldname": "tenant",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Tenant",
+   "no_copy": 1,
    "options": "Mail Tenant",
+   "permlevel": 1,
    "reqd": 1,
+   "search_index": 1,
    "set_only_once": 1
+  },
+  {
+   "fieldname": "section_break_c44a",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 21:43:17.779219",
+ "modified": "2025-01-28 15:33:09.730936",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain Request",
@@ -75,7 +89,6 @@
   {
    "create": 1,
    "delete": 1,
-   "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
@@ -86,10 +99,31 @@
   },
   {
    "create": 1,
-   "if_owner": 1,
+   "export": 1,
+   "print": 1,
    "read": 1,
+   "report": 1,
    "role": "Mail Admin",
    "write": 1
+  },
+  {
+   "delete": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin"
   }
  ],
  "show_title_field_in_link": 1,

--- a/mail/mail/doctype/mail_domain_request/mail_domain_request.py
+++ b/mail/mail/doctype/mail_domain_request/mail_domain_request.py
@@ -8,15 +8,38 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import random_string
 
+from mail.utils.cache import get_user_mail_tenant
 from mail.utils.dns import verify_dns_record
+from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
 
 
 class MailDomainRequest(Document):
+	def before_validate(self) -> None:
+		if self.is_new():
+			self.set_user_and_tenant()
+
 	def validate(self) -> None:
-		self.validate_domain_name()
+		if self.is_new():
+			self.validate_domain_name()
+
+		self.validate_user_and_tenant()
 
 	def before_insert(self) -> None:
 		self.set_verification_key()
+
+	def set_user_and_tenant(self) -> None:
+		"""Set the user and tenant"""
+
+		user = frappe.session.user
+
+		if is_system_manager(user):
+			if not self.user:
+				frappe.throw(_("User is required"))
+			elif not self.tenant:
+				frappe.throw(_("Tenant is required"))
+		else:
+			self.user = user
+			self.tenant = get_user_mail_tenant(user)
 
 	def validate_domain_name(self) -> None:
 		"""Validates the domain name"""
@@ -25,20 +48,34 @@ class MailDomainRequest(Document):
 		if re.fullmatch(domain_regex, self.domain_name) is None:
 			frappe.throw(_("Invalid domain name"))
 
+		if frappe.db.exists("Mail Domain", {"domain_name": self.domain_name}):
+			frappe.throw(_("Domain {0} already registered").format(self.domain_name))
+
+	def validate_user_and_tenant(self) -> None:
+		"""Validates the user and tenant"""
+
+		if not is_mail_tenant_admin(self.tenant, self.user):
+			frappe.throw(_("User must be an admin of the tenant"))
+
 	def set_verification_key(self) -> None:
 		"""Set the verification key"""
 
 		self.verification_key = "frappe-mail-verification=" + random_string(48)
 
 	@frappe.whitelist()
-	def verify_key(self) -> bool:
-		"""Verify the DNS record"""
+	def verify_and_create_domain(self, save: bool = False) -> bool:
+		"""Verifies the domain and creates the mail domain"""
 
-		self.is_verified = verify_dns_record(self.domain_name, "TXT", self.verification_key)
-		if self.is_verified:
+		self.is_verified = 0
+		if verify_dns_record(self.domain_name, "TXT", self.verification_key):
+			self.is_verified = 1
+			frappe.msgprint(_("Domain Verification Successful"), indicator="green", alert=True)
 			self.create_domain()
+		else:
+			frappe.msgprint(_("Domain Verification Failed"), indicator="red", alert=True)
 
-		self.save()
+		if save:
+			self.save()
 
 		return self.is_verified
 
@@ -46,9 +83,36 @@ class MailDomainRequest(Document):
 		"""Create the mail domain"""
 
 		domain = frappe.new_doc("Mail Domain")
+		domain.tenant = self.tenant
 		domain.domain_name = self.domain_name
-		domain.tenant = self.mail_tenant
-		domain.verified = self.is_verified
-		domain.insert()
+		domain.insert(ignore_permissions=True)
 
 		return domain.name
+
+
+def has_permission(doc: "Document", ptype: str, user: str) -> bool:
+	if doc.doctype != "Mail Domain Request":
+		return False
+
+	if is_system_manager(user):
+		return True
+
+	if is_mail_tenant_admin(doc.tenant, user):
+		if ptype in ("create", "read", "write"):
+			return True
+
+	return False
+
+
+def get_permission_query_condition(user: str | None = None) -> str:
+	if not user:
+		user = frappe.session.user
+
+	if is_system_manager(user):
+		return ""
+
+	if has_role(user, "Mail Admin"):
+		if tenant := get_user_mail_tenant(user):
+			return f'(`tabMail Domain Request`.`tenant` = "{tenant}")'
+
+	return "1=0"

--- a/mail/mail/doctype/mail_tenant/mail_tenant.json
+++ b/mail/mail/doctype/mail_tenant/mail_tenant.json
@@ -75,11 +75,26 @@
  "links": [
   {
    "group": "Reference",
+   "link_doctype": "Mail Account Request",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Reference",
+   "link_doctype": "Mail Domain Request",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Reference",
    "link_doctype": "Mail Tenant Member",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Reference",
+   "link_doctype": "Mail Domain",
    "link_fieldname": "tenant"
   }
  ],
- "modified": "2025-01-28 10:10:25.105911",
+ "modified": "2025-01-28 12:02:08.663645",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Tenant",

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.utils.caching import request_cache
 
-from mail.utils.cache import get_user_mail_account, get_user_mail_aliases
+from mail.utils.cache import get_user_mail_account, get_user_mail_aliases, get_user_mail_tenant
 
 
 @request_cache
@@ -21,6 +21,20 @@ def get_user_email_addresses(user: str) -> list:
 		email_addresses.extend(aliases)
 
 	return email_addresses
+
+
+@frappe.whitelist()
+def get_user_tenant() -> str | None:
+	"""Returns the mail tenant of the user."""
+
+	return get_user_mail_tenant(frappe.session.user)
+
+
+@request_cache
+def is_mail_tenant_owner(tenant: str, user: str) -> bool:
+	"""Returns True if the user is the owner of the mail tenant else False."""
+
+	return frappe.db.get_value("Mail Tenant", tenant, "user") == user
 
 
 @request_cache


### PR DESCRIPTION
- Mail Domain Request
   - System Manager can CRUD Mail Domain Requests.
   - Mail Admin role + Tenant Member can read and create Mail Domain Request.
   - Mail User does not have permission to Mail Domain Request.

   ![image](https://github.com/user-attachments/assets/552f9b12-2ce2-4caa-b22a-b67dfa229185)
   ![image](https://github.com/user-attachments/assets/aa22fdb9-963e-42b5-b925-403f9d8fbd7e)
