### PR TITLE
build: move build-email-css to frontend package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "dev": "vite",
     "serve": "vite preview",
-    "build": "vite build --base=/assets/mail/frontend/ && yarn copy-html-entry",
-    "copy-html-entry": "cp ../mail/public/frontend/index.html ../mail/www/mail.html"
+    "build": "yarn build-app && yarn build-email-css",
+    "build-app": "vite build --base=/assets/mail/frontend/ && yarn copy-html-entry",
+    "copy-html-entry": "cp ../mail/public/frontend/index.html ../mail/www/mail.html",
+		"build-email-css": "npx tailwindcss -i ../mail/public/email/style.css -o ../mail/public/css/email.css --config ../mail/public/email/tailwind.config.js"
   },
   "dependencies": {
     "@vueuse/core": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "test-local": "cypress open --e2e --browser chrome",
     "postinstall": "cd frontend && yarn install --check-files",
     "dev": "cd frontend && yarn dev",
-    "build": "yarn build-app && yarn build-email-css",
-    "build-app": "cd frontend && yarn build",
-		"build-email-css": "npx tailwindcss -i ./mail/public/email/style.css -o ./mail/public/css/email.css --config ./mail/public/email/tailwind.config.js"
+    "build": "cd frontend && yarn build"
   },
   "repository": "https://github.com/frappe/mail",
   "author": "Frappe",


### PR DESCRIPTION
Fixes error caused due to missing tailwindcss lib