### PR TITLE
feat: add permission for Mail Account Request

### DIFF
--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -150,6 +150,7 @@ email_css = ["/assets/mail/css/email.css"]
 # Permissions evaluated in scripted ways
 
 permission_query_conditions = {
+	"Mail Account Request": "mail.mail.doctype.mail_account_request.mail_account_request.get_permission_query_condition",
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.get_permission_query_condition",
 	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.get_permission_query_condition",
 	"Mail Domain Request": "mail.mail.doctype.mail_domain_request.mail_domain_request.get_permission_query_condition",
@@ -161,6 +162,7 @@ permission_query_conditions = {
 }
 
 has_permission = {
+	"Mail Account Request": "mail.mail.doctype.mail_account_request.mail_account_request.has_permission",
 	"Mail Tenant": "mail.mail.doctype.mail_tenant.mail_tenant.has_permission",
 	"Mail Tenant Member": "mail.mail.doctype.mail_tenant_member.mail_tenant_member.has_permission",
 	"Mail Domain Request": "mail.mail.doctype.mail_domain_request.mail_domain_request.has_permission",

--- a/mail/mail/doctype/mail_account/mail_account.json
+++ b/mail/mail/doctype/mail_account/mail_account.json
@@ -177,7 +177,7 @@
    "link_fieldname": "sender"
   }
  ],
- "modified": "2025-01-24 11:47:24.297689",
+ "modified": "2025-01-29 12:44:05.165383",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account",
@@ -197,6 +197,17 @@
    "write": 1
   },
   {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin",
+   "share": 1,
+   "write": 1
+  },
+  {
    "read": 1,
    "role": "Mail User",
    "write": 1
@@ -210,6 +221,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin",
    "share": 1,
    "write": 1
   },

--- a/mail/mail/doctype/mail_account_request/mail_account_request.js
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.js
@@ -4,13 +4,117 @@
 frappe.ui.form.on("Mail Account Request", {
 	refresh(frm) {
 		frm.trigger("add_actions");
+		frm.trigger("set_is_invite");
+		frm.trigger("set_invited_by");
+		frm.trigger("set_tenant");
+		frm.trigger("make_fields_read_only");
 	},
 
 	add_actions(frm) {
-		if (frm.doc.__islocal) return;
+		if (frm.doc.__islocal || frm.doc.is_verified) return;
 
-		frm.add_custom_button(__("Send Verification Email"), () => {
-			frm.call("send_verification_email");
+		frm.add_custom_button(
+			__("Send Verification Email"),
+			() => {
+				frm.trigger("send_verification_email");
+			},
+			__("Actions")
+		);
+
+		if (!frm.doc.is_invite) return;
+
+		frm.add_custom_button(
+			__("Force Verify and Create Account"),
+			() => {
+				frm.trigger("force_verify_and_create_account");
+			},
+			__("Actions")
+		);
+	},
+
+	set_is_invite(frm) {
+		if (frm.doc.__islocal && !frm.doc.is_invite) {
+			frm.set_value("is_invite", 1);
+		}
+	},
+
+	set_invited_by(frm) {
+		if (frm.doc.__islocal && !frm.doc.invited_by) {
+			frm.set_value("invited_by", frappe.session.user);
+		}
+	},
+
+	set_tenant(frm) {
+		if (frm.doc.__islocal && !frm.doc.tenant) {
+			frappe.call({
+				method: "mail.utils.user.get_user_tenant",
+				callback: (r) => {
+					if (r.message) {
+						frm.set_value("tenant", r.message);
+					}
+				},
+			});
+		}
+	},
+
+	make_fields_read_only(frm) {
+		if (frappe.user_roles.includes("System Manager")) return;
+
+		frm.set_df_property("is_invite", "read_only", 1);
+		frm.set_df_property("invited_by", "read_only", 1);
+		frm.set_df_property("tenant", "read_only", 1);
+	},
+
+	send_verification_email(frm) {
+		frm.call("send_verification_email");
+	},
+
+	force_verify_and_create_account(frm) {
+		let dialog = new frappe.ui.Dialog({
+			title: "User Details",
+			fields: [
+				{
+					label: __("First Name"),
+					fieldname: "first_name",
+					fieldtype: "Data",
+					reqd: 1,
+				},
+				{
+					label: __("Last Name"),
+					fieldname: "last_name",
+					fieldtype: "Data",
+					reqd: 1,
+				},
+				{
+					label: __("Password"),
+					fieldname: "password",
+					fieldtype: "Password",
+					reqd: 1,
+				},
+			],
+			size: "small",
+			primary_action_label: "Create Account",
+			primary_action(values) {
+				frm.call({
+					doc: frm.doc,
+					method: "force_verify_and_create_account",
+					args: {
+						first_name: values.first_name,
+						last_name: values.last_name,
+						password: values.password,
+					},
+					freeze: true,
+					freeze_message: __("Creating Account..."),
+					callback: (r) => {
+						if (!r.exc) {
+							frm.refresh();
+						}
+					},
+				});
+				dialog.hide();
+			},
 		});
+
+		dialog.show();
 	},
 });

--- a/mail/mail/doctype/mail_account_request/mail_account_request.json
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.json
@@ -5,11 +5,16 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "section_break_ikiq",
+  "is_invite",
+  "section_break_lwpm",
   "email",
-  "tenant",
-  "column_break_hswp",
   "role",
+  "column_break_hswp",
   "invited_by",
+  "tenant",
+  "domain_name",
+  "account",
   "email_verification_section",
   "is_verified",
   "is_expired",
@@ -26,6 +31,7 @@
   {
    "fieldname": "request_key",
    "fieldtype": "Data",
+   "in_standard_filter": 1,
    "label": "Request Key",
    "no_copy": 1,
    "read_only": 1,
@@ -39,22 +45,30 @@
    "label": "Email",
    "options": "Email",
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "tenant",
    "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Tenant",
-   "mandatory_depends_on": "eval: doc.role == \"Mail User\"",
+   "mandatory_depends_on": "eval: doc.is_invite",
+   "no_copy": 1,
    "options": "Mail Tenant",
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "role",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Role",
    "options": "\nMail User\nMail Admin",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "default": "1",
@@ -72,11 +86,15 @@
   {
    "fieldname": "invited_by",
    "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Invited By",
    "link_filters": "[[\"User\",\"role\",\"=\",\"Mail Admin\"]]",
-   "mandatory_depends_on": "eval: doc.role == \"Mail User\"",
+   "mandatory_depends_on": "eval: doc.is_invite",
+   "no_copy": 1,
    "options": "User",
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "email_verification_section",
@@ -106,11 +124,48 @@
    "no_copy": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_invite",
+   "fieldtype": "Check",
+   "label": "Is Invite",
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "section_break_ikiq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_lwpm",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account",
+   "mandatory_depends_on": "eval: doc.is_invite",
+   "options": "Email",
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "domain_name",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Domain",
+   "mandatory_depends_on": "eval: doc.is_invite",
+   "options": "Mail Domain",
+   "search_index": 1,
+   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-28 13:44:42.740701",
+ "modified": "2025-01-29 16:22:46.334378",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account Request",
@@ -127,6 +182,16 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Mail Admin",
    "write": 1
   }
  ],

--- a/mail/mail/doctype/mail_account_request/mail_account_request.py
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.py
@@ -2,44 +2,97 @@
 # For license information, please see license.txt
 
 import random
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, get_url, nowdate, random_string
 
+from mail.mail.doctype.mail_account.mail_account import create_mail_account
 from mail.utils.cache import get_tenant_for_user
 from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
+from mail.utils.validation import (
+	is_valid_email_for_domain,
+	validate_domain_is_enabled_and_verified,
+	validate_domain_owned_by_tenant,
+)
 
 
 class MailAccountRequest(Document):
 	def validate(self) -> None:
 		self.validate_role()
-		self.validate_tenant()
+
+		if self.is_new():
+			self.validate_is_invite()
+
+			if self.is_invite:
+				self.validate_invited_by_and_tenant()
+				self.validate_domain()
+				self.validate_account()
 
 	def before_insert(self) -> None:
 		self.set_request_key()
-
-		if not self.invited_by:
-			self.set_otp()
+		self.set_otp()
 
 	def after_insert(self) -> None:
 		if self.send_email:
 			self.send_verification_email()
 
 	def validate_role(self) -> None:
+		"""Validates the role."""
+
 		if not self.role:
 			frappe.throw(_("Role is mandatory."))
 
 		if self.role not in ["Mail User", "Mail Admin"]:
 			frappe.throw(_("Invalid role. Please select a valid role."))
 
-	def validate_tenant(self) -> None:
-		if self.role == "Mail Admin":
+	def validate_is_invite(self) -> None:
+		"""Validates the is_invite field."""
+
+		if not self.is_invite:
+			self.role = "Mail Admin"
+			self.invited_by = None
 			self.tenant = None
-		elif self.role == "Mail User":
-			if not self.tenant:
-				frappe.throw(_("Tenant is mandatory for Mail User role."))
+			self.domain_name = None
+			self.account = None
+
+	def validate_invited_by_and_tenant(self) -> None:
+		"""Validates the invited_by and tenant fields."""
+
+		user = frappe.session.user
+		if is_system_manager(user):
+			if not self.invited_by:
+				frappe.throw(_("Invited By is required"))
+			elif not self.tenant:
+				frappe.throw(_("Tenant is required"))
+		else:
+			self.invited_by = user
+			self.tenant = get_tenant_for_user(user)
+
+		if not is_mail_tenant_admin(self.tenant, self.invited_by):
+			frappe.throw(
+				_("User {0} is not authorized to invite users to the selected tenant.").format(
+					frappe.bold(self.invited_by)
+				)
+			)
+
+	def validate_domain(self) -> None:
+		"""Validates the domain."""
+
+		validate_domain_owned_by_tenant(self.domain_name, self.tenant)
+		validate_domain_is_enabled_and_verified(self.domain_name)
+
+	def validate_account(self) -> None:
+		"""Validates the account."""
+
+		if not is_valid_email_for_domain(self.account, self.domain_name):
+			frappe.throw(
+				_("Account domain {0} does not match with domain {1}.").format(
+					frappe.bold(self.account.split("@")[1]), frappe.bold(self.domain_name)
+				)
+			)
 
 	def set_request_key(self) -> None:
 		"""Sets a random key for the request."""
@@ -62,7 +115,7 @@ class MailAccountRequest(Document):
 			"image_path": "https://frappe.io/files/Frappe-black.png",
 		}
 
-		if self.invited_by:
+		if self.is_invite and self.invited_by:
 			subject = _("You have been invited by {0} to join Frappe Mail").format(self.invited_by)
 			template = "invite_signup"
 			tenant_name = frappe.db.get_value("Mail Tenant", self.tenant, "tenant_name")
@@ -79,6 +132,35 @@ class MailAccountRequest(Document):
 			now=True,
 		)
 		frappe.msgprint(_("Verification email sent successfully."), indicator="green", alert=True)
+
+	@frappe.whitelist()
+	def force_verify_and_create_account(self, first_name: str, last_name: str, password: str) -> None:
+		"""Force verify and create account for invited user."""
+
+		if not self.is_invite:
+			frappe.throw(_("This method can only be called for invited users."))
+
+		if self.is_verified:
+			frappe.throw(_("Account is already verified and created."))
+
+		user = frappe.session.user
+		if not is_system_manager(user) and not is_mail_tenant_admin(self.tenant, user):
+			frappe.throw(_("You are not authorized to perform this action."))
+
+		self.db_set("is_verified", 1)
+		self.create_account(first_name, last_name, password)
+
+	def create_account(self, first_name: str, last_name: str, password: str) -> None:
+		"""Create mail account for the user."""
+
+		if not self.is_verified:
+			frappe.throw(_("Please verify the email address first."))
+
+		account = create_mail_account(
+			email=self.account, first_name=first_name, last_name=last_name, password=password, role=self.role
+		)
+		tenant = frappe.get_doc("Mail Tenant", self.tenant)
+		tenant.add_member(account.user)
 
 
 def expire_mail_account_requests() -> None:

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -5,13 +5,13 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_ceuu",
-  "tenant",
-  "domain_name",
   "enabled",
   "is_verified",
   "is_subdomain",
   "is_root_domain",
   "column_break_lr3y",
+  "tenant",
+  "domain_name",
   "dkim_rsa_key_size",
   "newsletter_retention",
   "dns_records_section",
@@ -172,6 +172,11 @@
  "links": [
   {
    "group": "Reference",
+   "link_doctype": "Mail Account Request",
+   "link_fieldname": "domain_name"
+  },
+  {
+   "group": "Reference",
    "link_doctype": "Mail Domain Request",
    "link_fieldname": "domain_name"
   },
@@ -211,7 +216,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-01-29 11:32:31.994852",
+ "modified": "2025-01-29 19:26:13.013330",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",

--- a/mail/mail/doctype/mail_domain_request/mail_domain_request.js
+++ b/mail/mail/doctype/mail_domain_request/mail_domain_request.js
@@ -12,20 +12,7 @@ frappe.ui.form.on("Mail Domain Request", {
 		if (frm.doc.__islocal) return;
 
 		frm.add_custom_button(__("Verify and Create Domain"), () => {
-			frm.call({
-				doc: frm.doc,
-				method: "verify_and_create_domain",
-				args: {
-					save: true,
-				},
-				freeze: true,
-				freeze_message: __("Verifying and creating Domain..."),
-				callback: (r) => {
-					if (!r.exc) {
-						frm.refresh();
-					}
-				},
-			});
+			frm.trigger("verify_and_create_domain");
 		});
 	},
 
@@ -46,5 +33,22 @@ frappe.ui.form.on("Mail Domain Request", {
 				},
 			});
 		}
+	},
+
+	verify_and_create_domain(frm) {
+		frm.call({
+			doc: frm.doc,
+			method: "verify_and_create_domain",
+			args: {
+				save: true,
+			},
+			freeze: true,
+			freeze_message: __("Creating Domain..."),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh();
+				}
+			},
+		});
 	},
 });

--- a/mail/utils/validation.py
+++ b/mail/utils/validation.py
@@ -68,7 +68,7 @@ def is_valid_email_for_domain(email: str, domain_name: str, raise_exception: boo
 
 	email_domain = email.split("@")[1]
 
-	if not email_domain == domain_name:
+	if email_domain != domain_name:
 		if raise_exception:
 			frappe.throw(
 				_("Email domain {0} does not match with domain {1}.").format(
@@ -101,6 +101,14 @@ def validate_domain_is_enabled_and_verified(domain_name: str) -> None:
 		frappe.throw(_("Domain {0} is disabled.").format(frappe.bold(domain_name)))
 	if not is_verified:
 		frappe.throw(_("Domain {0} is not verified.").format(frappe.bold(domain_name)))
+
+
+@request_cache
+def validate_domain_owned_by_tenant(domain_name: str, tenant: str) -> None:
+	"""Validates if the domain is owned by the tenant."""
+
+	if tenant != frappe.db.get_value("Mail Domain", domain_name, "tenant"):
+		frappe.throw(_("Domain {0} is not owned by the selected tenant.").format(frappe.bold(domain_name)))
 
 
 def validate_user_has_mail_admin_role(user: str) -> None:


### PR DESCRIPTION
- Mail Account Request:
   - System Manager can CRUD Mail Account Request.
   - Mail Admin role + Tenant Member can create, and read Mail Account Request (is_invite = 1) for Enabled and Verified domains owned by tenant. Additionally, can force verify and create an account.
   - Mail User does not have permission to Mail Account Request.

   ![image](https://github.com/user-attachments/assets/f9d7784d-5a6c-4dde-babd-9604e49b5311)

