### PR TITLE
feat: add/remove Mail Admin role from Tenant Member

### DIFF
--- a/mail/api/auth.py
+++ b/mail/api/auth.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 
-from mail.utils.user import has_role, is_mail_account_owner
+from mail.utils.user import has_role, is_account_owner
 
 
 @frappe.whitelist(methods=["POST"])
@@ -27,7 +27,7 @@ def validate_account(account: str) -> None:
 
 	user = frappe.session.user
 
-	if not is_mail_account_owner(account, user):
+	if not is_account_owner(account, user):
 		frappe.throw(
 			_("Mail Account {0} is not associated with user {1}").format(
 				frappe.bold(account), frappe.bold(user)

--- a/mail/mail/doctype/incoming_mail/incoming_mail.py
+++ b/mail/mail/doctype/incoming_mail/incoming_mail.py
@@ -24,7 +24,7 @@ from mail.mail.doctype.mime_message.mime_message import (
 from mail.utils import get_dmarc_address, get_in_reply_to_mail, load_compressed_file
 from mail.utils.cache import get_account_for_user
 from mail.utils.email_parser import EmailParser, extract_ip_and_host, extract_spam_status
-from mail.utils.user import is_mail_account_owner, is_system_manager
+from mail.utils.user import is_account_owner, is_system_manager
 
 if TYPE_CHECKING:
 	from mail.mail.doctype.outgoing_mail.outgoing_mail import OutgoingMail
@@ -273,7 +273,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 		return False
 
 	user_is_system_manager = is_system_manager(user)
-	user_is_account_owner = is_mail_account_owner(doc.receiver, user)
+	user_is_account_owner = is_account_owner(doc.receiver, user)
 
 	if ptype in ["create", "submit"]:
 		return user_is_system_manager

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -154,10 +154,9 @@ def create_mail_account(
 			account_user.email = email
 			account_user.owner = email
 			account_user.send_welcome_email = 0
+			account_user.append_roles(roles)
 			if password:
 				account_user.new_password = password
-			for role in roles:
-				account_user.append_roles(role)
 			account_user.insert(ignore_permissions=True)
 		else:
 			frappe.throw(_("User with email {0} already exists.").format(frappe.bold(email)))

--- a/mail/mail/doctype/mail_account_request/mail_account_request.py
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.py
@@ -11,7 +11,7 @@ from frappe.utils import add_days, get_url, nowdate, random_string
 
 from mail.mail.doctype.mail_account.mail_account import create_mail_account
 from mail.utils.cache import get_tenant_for_user
-from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
+from mail.utils.user import has_role, is_system_manager, is_tenant_admin
 from mail.utils.validation import (
 	is_valid_email_for_domain,
 	validate_domain_is_enabled_and_verified,
@@ -71,7 +71,7 @@ class MailAccountRequest(Document):
 			self.invited_by = user
 			self.tenant = get_tenant_for_user(user)
 
-		if not is_mail_tenant_admin(self.tenant, self.invited_by):
+		if not is_tenant_admin(self.tenant, self.invited_by):
 			frappe.throw(
 				_("User {0} is not authorized to invite users to the selected tenant.").format(
 					frappe.bold(self.invited_by)
@@ -144,7 +144,7 @@ class MailAccountRequest(Document):
 			frappe.throw(_("Account is already verified and created."))
 
 		user = frappe.session.user
-		if not is_system_manager(user) and not is_mail_tenant_admin(self.tenant, user):
+		if not is_system_manager(user) and not is_tenant_admin(self.tenant, user):
 			frappe.throw(_("You are not authorized to perform this action."))
 
 		self.db_set("is_verified", 1)
@@ -181,7 +181,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 	if is_system_manager(user):
 		return True
 
-	if is_mail_tenant_admin(doc.tenant, user):
+	if is_tenant_admin(doc.tenant, user):
 		if ptype in ("create", "read", "write"):
 			return True
 

--- a/mail/mail/doctype/mail_domain/mail_domain.py
+++ b/mail/mail/doctype/mail_domain/mail_domain.py
@@ -13,7 +13,7 @@ from mail.mail.doctype.mail_account.mail_account import create_dmarc_account
 from mail.utils import get_dkim_host, get_dkim_selector, get_dmarc_address
 from mail.utils.cache import get_root_domain_name, get_tenant_for_user
 from mail.utils.dns import verify_dns_record
-from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
+from mail.utils.user import has_role, is_system_manager, is_tenant_admin
 
 
 class MailDomain(Document):
@@ -244,7 +244,7 @@ def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool
 	if is_system_manager(user):
 		return True
 
-	if is_mail_tenant_admin(doc.tenant, user):
+	if is_tenant_admin(doc.tenant, user):
 		if ptype in ("read", "write"):
 			return True
 

--- a/mail/mail/doctype/mail_domain_request/mail_domain_request.py
+++ b/mail/mail/doctype/mail_domain_request/mail_domain_request.py
@@ -10,7 +10,7 @@ from frappe.utils import random_string
 
 from mail.utils.cache import get_tenant_for_user
 from mail.utils.dns import verify_dns_record
-from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
+from mail.utils.user import has_role, is_system_manager, is_tenant_admin
 
 
 class MailDomainRequest(Document):
@@ -54,7 +54,7 @@ class MailDomainRequest(Document):
 	def validate_user_and_tenant(self) -> None:
 		"""Validates the user and tenant"""
 
-		if not is_mail_tenant_admin(self.tenant, self.user):
+		if not is_tenant_admin(self.tenant, self.user):
 			frappe.throw(_("User must be an admin of the tenant"))
 
 	def set_verification_key(self) -> None:
@@ -97,7 +97,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 	if is_system_manager(user):
 		return True
 
-	if is_mail_tenant_admin(doc.tenant, user):
+	if is_tenant_admin(doc.tenant, user):
 		if ptype in ("create", "read", "write"):
 			return True
 

--- a/mail/mail/doctype/mail_tenant/mail_tenant.py
+++ b/mail/mail/doctype/mail_tenant/mail_tenant.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 
 from mail.utils.cache import get_tenant_for_user
-from mail.utils.user import has_role, is_mail_tenant_admin, is_system_manager
+from mail.utils.user import has_role, is_system_manager, is_tenant_admin
 
 
 class MailTenant(Document):
@@ -53,7 +53,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 	if is_system_manager(user):
 		return True
 
-	if is_mail_tenant_admin(doc.name, user):
+	if is_tenant_admin(doc.name, user):
 		if ptype in ("read", "write"):
 			return True
 

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.json
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.json
@@ -6,7 +6,9 @@
  "engine": "InnoDB",
  "field_order": [
   "tenant",
-  "user"
+  "user",
+  "column_break_prdy",
+  "is_admin"
  ],
  "fields": [
   {
@@ -33,11 +35,24 @@
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_admin",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Admin",
+   "no_copy": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_prdy",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-27 22:09:54.305800",
+ "modified": "2025-01-30 11:32:32.856103",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Tenant Member",
@@ -71,5 +86,6 @@
  ],
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -11,7 +11,11 @@ from mail.utils.user import has_role, is_mail_tenant_admin, is_mail_tenant_owner
 
 class MailTenantMember(Document):
 	def validate(self) -> None:
-		self.validate_user()
+		if self.is_new():
+			self.validate_user()
+
+		self.validate_user_roles()
+		self.validate_is_admin()
 
 	def on_update(self) -> None:
 		self.clear_cache()
@@ -35,10 +39,48 @@ class MailTenantMember(Document):
 					)
 				)
 
-		if not has_role(self.user, ["Mail Admin", "Mail User"]):
+	def validate_user_roles(self) -> None:
+		"""Validates if the user has the required roles to be a member of the Mail Tenant."""
+
+		# Tenant Owner must have Mail Admin role.
+		# Tenant Member must have Mail User role and can have Mail Admin role.
+		required_role = "Mail Admin" if is_mail_tenant_owner(self.tenant, self.user) else "Mail User"
+		if not has_role(self.user, required_role):
 			frappe.throw(
-				_("User {0} does not have Mail Admin or Mail User role.").format(frappe.bold(self.user))
+				_("User {0} does not have {1} role.").format(
+					frappe.bold(self.user), frappe.bold(required_role)
+				)
 			)
+
+	def validate_is_admin(self) -> None:
+		"""Validates if the user is an admin of the Mail Tenant."""
+
+		if is_mail_tenant_owner(self.tenant, self.user):
+			self.is_admin = 1
+			return
+
+		has_admin_role = has_role(self.user, "Mail Admin")
+
+		if self.is_admin and not has_admin_role:
+			user = frappe.get_doc("User", self.user)
+			user.append("roles", {"role": "Mail Admin"})
+			user.save(ignore_permissions=True)
+			frappe.msgprint(
+				_("Mail Admin role has been assigned to the user {0}.").format(frappe.bold(self.user))
+			)
+
+		elif not self.is_admin and has_admin_role:
+			user = frappe.get_doc("User", self.user)
+			for role in user.get("roles")[:]:
+				if role.role == "Mail Admin":
+					user.get("roles").remove(role)
+					user.save(ignore_permissions=True)
+					frappe.msgprint(
+						_("Mail Admin role has been removed from the user {0}.").format(
+							frappe.bold(self.user)
+						)
+					)
+					break
 
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 
 from mail.utils.cache import get_tenant_for_user
-from mail.utils.user import has_role, is_mail_tenant_admin, is_mail_tenant_owner, is_system_manager
+from mail.utils.user import has_role, is_system_manager, is_tenant_admin, is_tenant_owner
 
 
 class MailTenantMember(Document):
@@ -21,7 +21,7 @@ class MailTenantMember(Document):
 		self.clear_cache()
 
 	def on_trash(self) -> None:
-		if is_mail_tenant_owner(self.tenant, self.user):
+		if is_tenant_owner(self.tenant, self.user):
 			frappe.throw(_("Cannot remove the owner of the Mail Tenant."))
 
 		self.clear_cache()
@@ -44,7 +44,7 @@ class MailTenantMember(Document):
 
 		# Tenant Owner must have Mail Admin role.
 		# Tenant Member must have Mail User role and can have Mail Admin role.
-		required_role = "Mail Admin" if is_mail_tenant_owner(self.tenant, self.user) else "Mail User"
+		required_role = "Mail Admin" if is_tenant_owner(self.tenant, self.user) else "Mail User"
 		if not has_role(self.user, required_role):
 			frappe.throw(
 				_("User {0} does not have {1} role.").format(
@@ -55,7 +55,7 @@ class MailTenantMember(Document):
 	def validate_is_admin(self) -> None:
 		"""Validates if the user is an admin of the Mail Tenant."""
 
-		if is_mail_tenant_owner(self.tenant, self.user):
+		if is_tenant_owner(self.tenant, self.user):
 			self.is_admin = 1
 			return
 
@@ -95,7 +95,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 	if is_system_manager(user):
 		return True
 
-	if is_mail_tenant_admin(doc.tenant, user):
+	if is_tenant_admin(doc.tenant, user):
 		return True
 
 	return False

--- a/mail/mail/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail/mail/doctype/outgoing_mail/outgoing_mail.py
@@ -51,7 +51,7 @@ from mail.utils.cache import get_account_for_email, get_account_for_user, get_de
 from mail.utils.dns import get_host_by_ip
 from mail.utils.dt import parsedate_to_datetime
 from mail.utils.email_parser import EmailParser
-from mail.utils.user import get_user_email_addresses, is_mail_account_owner, is_system_manager
+from mail.utils.user import get_user_email_addresses, is_account_owner, is_system_manager
 
 MAX_FAILED_COUNT = 5
 
@@ -1219,7 +1219,7 @@ def has_permission(doc: "Document", ptype: str, user: str) -> bool:
 		return False
 
 	user_is_system_manager = is_system_manager(user)
-	user_is_account_owner = is_mail_account_owner(doc.sender, user)
+	user_is_account_owner = is_account_owner(doc.sender, user)
 
 	if ptype == "create":
 		return True

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -44,25 +44,25 @@ def get_imap_limits() -> dict:
 
 
 def get_tenant_for_user(user: str) -> str | None:
-	"""Returns the mail tenant of the user."""
+	"""Returns the tenant of the user."""
 
 	def generator() -> str | None:
 		return frappe.db.get_value("Mail Tenant Member", {"user": user}, "tenant")
 
-	return frappe.cache.hget(f"user|{user}", "mail_tenant", generator)
+	return frappe.cache.hget(f"user|{user}", "tenant", generator)
 
 
 def get_account_for_user(user: str) -> str | None:
-	"""Returns the mail account of the user."""
+	"""Returns the account of the user."""
 
 	def generator() -> str | None:
 		return frappe.db.get_value("Mail Account", {"user": user, "enabled": 1}, "name")
 
-	return frappe.cache.hget(f"user|{user}", "mail_account", generator)
+	return frappe.cache.hget(f"user|{user}", "account", generator)
 
 
 def get_account_for_email(email: str) -> str | None:
-	"""Returns the mail account for the email."""
+	"""Returns the account for the email."""
 
 	def generator() -> str | None:
 		if account := frappe.db.exists("Mail Account", {"email": email}):
@@ -70,11 +70,11 @@ def get_account_for_email(email: str) -> str | None:
 		elif alias := frappe.db.exists("Mail Alias", {"email": email, "alias_for_type": "Mail Account"}):
 			return frappe.db.get_value("Mail Alias", alias, "alias_for_name")
 
-	return frappe.cache.hget(f"email|{email}", "mail_account", generator)
+	return frappe.cache.hget(f"email|{email}", "account", generator)
 
 
 def get_aliases_for_user(user: str) -> list:
-	"""Returns the mail aliases of the user."""
+	"""Returns the aliases of the user."""
 
 	def generator() -> list:
 		account = get_account_for_user(user)
@@ -93,7 +93,7 @@ def get_aliases_for_user(user: str) -> list:
 			)
 		).run(pluck="name")
 
-	return frappe.cache.hget(f"user|{user}", "mail_aliases", generator)
+	return frappe.cache.hget(f"user|{user}", "aliases", generator)
 
 
 def get_default_outgoing_email_for_user(user: str) -> str | None:

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -38,11 +38,18 @@ def is_mail_tenant_owner(tenant: str, user: str) -> bool:
 
 
 @request_cache
+def is_mail_tenant_member(tenant: str, user: str) -> bool:
+	"""Returns True if the user is a member of the mail tenant else False."""
+
+	return frappe.db.exists("Mail Tenant Member", {"tenant": tenant, "user": user})
+
+
+@request_cache
 def is_mail_tenant_admin(tenant: str, user: str) -> bool:
 	"""Returns True if the user is an admin of the mail tenant else False."""
 
 	return has_role(user, "Mail Admin") and frappe.db.exists(
-		"Mail Tenant Member", {"tenant": tenant, "user": user}
+		"Mail Tenant Member", {"tenant": tenant, "user": user, "is_admin": 1}
 	)
 
 

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -25,28 +25,21 @@ def get_user_email_addresses(user: str) -> list:
 
 @frappe.whitelist()
 def get_user_tenant() -> str | None:
-	"""Returns the mail tenant of the user."""
+	"""Returns the tenant of the user."""
 
 	return get_tenant_for_user(frappe.session.user)
 
 
 @request_cache
-def is_mail_tenant_owner(tenant: str, user: str) -> bool:
-	"""Returns True if the user is the owner of the mail tenant else False."""
+def is_tenant_owner(tenant: str, user: str) -> bool:
+	"""Returns True if the user is the owner of the tenant else False."""
 
 	return frappe.db.get_value("Mail Tenant", tenant, "user") == user
 
 
 @request_cache
-def is_mail_tenant_member(tenant: str, user: str) -> bool:
-	"""Returns True if the user is a member of the mail tenant else False."""
-
-	return frappe.db.exists("Mail Tenant Member", {"tenant": tenant, "user": user})
-
-
-@request_cache
-def is_mail_tenant_admin(tenant: str, user: str) -> bool:
-	"""Returns True if the user is an admin of the mail tenant else False."""
+def is_tenant_admin(tenant: str, user: str) -> bool:
+	"""Returns True if the user is an admin of the tenant else False."""
 
 	return has_role(user, "Mail Admin") and frappe.db.exists(
 		"Mail Tenant Member", {"tenant": tenant, "user": user, "is_admin": 1}
@@ -54,8 +47,15 @@ def is_mail_tenant_admin(tenant: str, user: str) -> bool:
 
 
 @request_cache
-def is_mail_account_owner(account: str, user: str) -> bool:
-	"""Returns True if the mail account is associated with the user else False."""
+def is_tenant_member(tenant: str, user: str) -> bool:
+	"""Returns True if the user is a member of the tenant else False."""
+
+	return frappe.db.exists("Mail Tenant Member", {"tenant": tenant, "user": user})
+
+
+@request_cache
+def is_account_owner(account: str, user: str) -> bool:
+	"""Returns True if the account is associated with the user else False."""
 
 	return frappe.db.get_value("Mail Account", account, "user") == user
 


### PR DESCRIPTION
- Mail Admin can add/remove Mail Admin role from its tenant members (except Tenant Owner) using the Is Admin checkbox in the Mail Tenant Member document.

   ![image](https://github.com/user-attachments/assets/c95699d7-a4fb-47c6-8f03-8e8fa86c2786)
