### PR TITLE
feat: add permission for Mail Account

### DIFF
--- a/mail/mail/doctype/mail_account/mail_account.json
+++ b/mail/mail/doctype/mail_account/mail_account.json
@@ -150,10 +150,10 @@
    "unique": 1
   },
   {
+   "depends_on": "eval: !doc.__islocal",
    "fetch_from": "domain_name.tenant",
    "fieldname": "tenant",
    "fieldtype": "Link",
-   "hidden": 1,
    "in_standard_filter": 1,
    "label": "Tenant",
    "no_copy": 1,
@@ -196,7 +196,7 @@
    "link_fieldname": "sender"
   }
  ],
- "modified": "2025-01-31 11:48:58.302903",
+ "modified": "2025-01-31 12:14:53.434068",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account",

--- a/mail/mail/doctype/mail_account/mail_account.json
+++ b/mail/mail/doctype/mail_account/mail_account.json
@@ -10,6 +10,7 @@
   "create_mail_contact",
   "column_break_47zs",
   "domain_name",
+  "tenant",
   "user",
   "email",
   "password",
@@ -147,10 +148,28 @@
    "no_copy": 1,
    "options": "Email",
    "unique": 1
+  },
+  {
+   "fetch_from": "domain_name.tenant",
+   "fieldname": "tenant",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "in_standard_filter": 1,
+   "label": "Tenant",
+   "no_copy": 1,
+   "options": "Mail Tenant",
+   "read_only": 1,
+   "search_index": 1,
+   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [
+  {
+   "group": "Reference",
+   "link_doctype": "Mail Account Request",
+   "link_fieldname": "account"
+  },
   {
    "group": "Reference",
    "link_doctype": "Mail Alias",
@@ -177,7 +196,7 @@
    "link_fieldname": "sender"
   }
  ],
- "modified": "2025-01-29 12:44:05.165383",
+ "modified": "2025-01-31 11:48:58.302903",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account",

--- a/mail/mail/doctype/mail_account/mail_account.json
+++ b/mail/mail/doctype/mail_account/mail_account.json
@@ -172,18 +172,18 @@
   },
   {
    "group": "Reference",
+   "link_doctype": "Mail Sync History",
+   "link_fieldname": "account"
+  },
+  {
+   "group": "Alias & Group",
    "link_doctype": "Mail Alias",
    "link_fieldname": "alias_for_name"
   },
   {
-   "group": "Reference",
+   "group": "Alias & Group",
    "link_doctype": "Mail Group Member",
    "link_fieldname": "member_name"
-  },
-  {
-   "group": "Reference",
-   "link_doctype": "Mail Sync History",
-   "link_fieldname": "account"
   },
   {
    "group": "Mail",
@@ -196,7 +196,7 @@
    "link_fieldname": "sender"
   }
  ],
- "modified": "2025-01-31 12:14:53.434068",
+ "modified": "2025-01-31 15:13:48.054282",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account",

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -91,12 +91,13 @@ class MailAccount(Document):
 	def validate_user_tenant(self) -> None:
 		"""Validates the user tenant."""
 
-		if self.tenant != get_tenant_for_user(self.user):
-			frappe.throw(
-				_("Domain {0} and User {1} do not belong to the same tenant.").format(
-					frappe.bold(self.domain_name), frappe.bold(self.user)
+		if self.is_new() or self.enabled:
+			if self.tenant != get_tenant_for_user(self.user):
+				frappe.throw(
+					_("Domain {0} and User {1} do not belong to the same tenant.").format(
+						frappe.bold(self.domain_name), frappe.bold(self.user)
+					)
 				)
-			)
 
 	def validate_email(self) -> None:
 		"""Validates the email address."""

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -33,6 +33,7 @@ class MailAccount(Document):
 		self.validate_domain()
 		self.validate_user()
 		self.validate_user_tenant()
+		self.validate_tenant_max_accounts()
 		self.validate_email()
 		self.validate_password()
 		self.validate_default_outgoing_email()
@@ -98,6 +99,21 @@ class MailAccount(Document):
 						frappe.bold(self.domain_name), frappe.bold(self.user)
 					)
 				)
+
+	def validate_tenant_max_accounts(self) -> None:
+		"""Validates the Tenant Max Accounts."""
+
+		if is_system_manager(frappe.session.user):
+			return
+
+		total_accounts = frappe.db.count("Mail Account", filters={"tenant": self.tenant, "enabled": 1})
+		max_accounts = frappe.db.get_value("Mail Tenant", self.tenant, "max_accounts")
+		if total_accounts >= max_accounts:
+			frappe.throw(
+				_("You have reached the maximum limit of {0} accounts for the tenant.").format(
+					frappe.bold(max_accounts)
+				)
+			)
 
 	def validate_email(self) -> None:
 		"""Validates the email address."""

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -173,12 +173,12 @@
  "links": [
   {
    "group": "Reference",
-   "link_doctype": "Mail Account Request",
+   "link_doctype": "Mail Domain Request",
    "link_fieldname": "domain_name"
   },
   {
    "group": "Reference",
-   "link_doctype": "Mail Domain Request",
+   "link_doctype": "Mail Account Request",
    "link_fieldname": "domain_name"
   },
   {
@@ -217,7 +217,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-01-31 11:42:45.906460",
+ "modified": "2025-01-31 12:36:31.647997",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -178,27 +178,27 @@
   },
   {
    "group": "Reference",
+   "link_doctype": "DKIM Key",
+   "link_fieldname": "domain_name"
+  },
+  {
+   "group": "Account",
    "link_doctype": "Mail Account Request",
    "link_fieldname": "domain_name"
   },
   {
-   "group": "Reference",
+   "group": "Account",
    "link_doctype": "Mail Account",
    "link_fieldname": "domain_name"
   },
   {
-   "group": "Reference",
-   "link_doctype": "Mail Group",
-   "link_fieldname": "domain_name"
-  },
-  {
-   "group": "Reference",
+   "group": "Alias & Group",
    "link_doctype": "Mail Alias",
    "link_fieldname": "domain_name"
   },
   {
-   "group": "Reference",
-   "link_doctype": "DKIM Key",
+   "group": "Alias & Group",
+   "link_doctype": "Mail Group",
    "link_fieldname": "domain_name"
   },
   {
@@ -217,7 +217,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-01-31 12:36:31.647997",
+ "modified": "2025-01-31 14:58:43.018293",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -165,7 +165,8 @@
    "options": "Mail Tenant",
    "permlevel": 1,
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -216,7 +217,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-01-29 19:26:13.013330",
+ "modified": "2025-01-31 11:42:45.906460",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",

--- a/mail/mail/doctype/mail_tenant/mail_tenant.json
+++ b/mail/mail/doctype/mail_tenant/mail_tenant.json
@@ -74,27 +74,32 @@
  "index_web_pages_for_search": 1,
  "links": [
   {
-   "group": "Reference",
-   "link_doctype": "Mail Account Request",
-   "link_fieldname": "tenant"
-  },
-  {
-   "group": "Reference",
-   "link_doctype": "Mail Domain Request",
-   "link_fieldname": "tenant"
-  },
-  {
-   "group": "Reference",
+   "group": "Member",
    "link_doctype": "Mail Tenant Member",
    "link_fieldname": "tenant"
   },
   {
-   "group": "Reference",
+   "group": "Domain",
+   "link_doctype": "Mail Domain Request",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Domain",
    "link_doctype": "Mail Domain",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Account",
+   "link_doctype": "Mail Account Request",
+   "link_fieldname": "tenant"
+  },
+  {
+   "group": "Account",
+   "link_doctype": "Mail Account",
    "link_fieldname": "tenant"
   }
  ],
- "modified": "2025-01-28 12:02:08.663645",
+ "modified": "2025-01-31 12:17:35.027162",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Tenant",

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -24,6 +24,7 @@ class MailTenantMember(Document):
 		if is_tenant_owner(self.tenant, self.user):
 			frappe.throw(_("Cannot remove the owner of the Mail Tenant."))
 
+		self.validate_active_account()
 		self.clear_cache()
 
 	def validate_user(self) -> None:
@@ -81,6 +82,16 @@ class MailTenantMember(Document):
 						)
 					)
 					break
+
+	def validate_active_account(self) -> None:
+		"""Validates if the user has an active Mail Account."""
+
+		if active_account := frappe.db.exists("Mail Account", {"user": self.user, "enabled": 1}):
+			frappe.throw(
+				_("User {0} has an active Mail Account {1}. Please disable it first.").format(
+					frappe.bold(self.user), frappe.bold(active_account)
+				)
+			)
 
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -43,6 +43,15 @@ def get_imap_limits() -> dict:
 	return frappe.cache.get_value("imap_limits", generator)
 
 
+def get_domains_owned_by_tenant(tenant: str) -> list:
+	"""Returns the domains owned by the tenant."""
+
+	def generator() -> list:
+		return frappe.get_all("Mail Domain", filters={"tenant": tenant}, pluck="name")
+
+	return frappe.cache.hget(f"tenant|{tenant}", "domains", generator)
+
+
 def get_tenant_for_user(user: str) -> str | None:
 	"""Returns the tenant of the user."""
 

--- a/mail/utils/validation.py
+++ b/mail/utils/validation.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.utils.caching import request_cache
 from validate_email_address import validate_email
 
+from mail.utils.cache import get_tenant_for_user
 from mail.utils.user import has_role
 
 
@@ -109,6 +110,20 @@ def validate_domain_owned_by_tenant(domain_name: str, tenant: str) -> None:
 
 	if tenant != frappe.db.get_value("Mail Domain", domain_name, "tenant"):
 		frappe.throw(_("Domain {0} is not owned by the selected tenant.").format(frappe.bold(domain_name)))
+
+
+def validate_domain_and_user_tenant(domain_name: str, user: str) -> None:
+	"""Validates if the domain and user belong to the same tenant."""
+
+	domain_tenant = frappe.db.get_value("Mail Domain", domain_name, "tenant")
+	user_tenant = get_tenant_for_user(user)
+
+	if domain_tenant != user_tenant:
+		frappe.throw(
+			_("Domain {0} and User {1} do not belong to the same tenant.").format(
+				frappe.bold(domain_name), frappe.bold(user)
+			)
+		)
 
 
 def validate_user_has_mail_admin_role(user: str) -> None:


### PR DESCRIPTION
- Mail Account:
   - System Manager can CRUD Mail Account.
   - Mail Admin role + Tenant Member can read and write Mail Account.
   - Mail User role + Account owner can read and write Mail Account (perm_level=0).

![image](https://github.com/user-attachments/assets/8b20a843-2eb2-4261-a216-e1e528e5a240)