### PR TITLE
feat: add permission for outbound reports

### DIFF
--- a/mail/mail/doctype/mail_domain/mail_domain.js
+++ b/mail/mail/doctype/mail_domain/mail_domain.js
@@ -30,6 +30,19 @@ frappe.ui.form.on("Mail Domain", {
 				__("Reports")
 			);
 
+			if (frappe.user_roles.includes("System Manager")) {
+				frm.add_custom_button(
+					__("DMARC Report Viewer"),
+					() => {
+						frappe.route_options = {
+							domain_name: frm.doc.name,
+						};
+						frappe.set_route("query-report", "DMARC Report Viewer");
+					},
+					__("Reports")
+				);
+			}
+
 			frm.add_custom_button(
 				__("Outgoing Mail Summary"),
 				() => {

--- a/mail/mail/doctype/mail_domain/mail_domain.json
+++ b/mail/mail/doctype/mail_domain/mail_domain.json
@@ -217,7 +217,7 @@
    "link_fieldname": "domain_name"
   }
  ],
- "modified": "2025-02-02 22:12:32.794504",
+ "modified": "2025-02-04 18:26:03.115949",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Domain",
@@ -242,6 +242,10 @@
    "report": 1,
    "role": "Mail Admin",
    "write": 1
+  },
+  {
+   "role": "Mail User",
+   "select": 1
   },
   {
    "delete": 1,

--- a/mail/mail/doctype/mail_domain/mail_domain.py
+++ b/mail/mail/doctype/mail_domain/mail_domain.py
@@ -13,7 +13,7 @@ from mail.mail.doctype.mail_account.mail_account import create_dmarc_account
 from mail.utils import get_dkim_host, get_dkim_selector, get_dmarc_address
 from mail.utils.cache import get_root_domain_name, get_tenant_for_user
 from mail.utils.dns import verify_dns_record
-from mail.utils.user import has_role, is_system_manager, is_tenant_admin
+from mail.utils.user import get_user_linked_domains, has_role, is_system_manager, is_tenant_admin
 
 
 class MailDomain(Document):
@@ -274,5 +274,9 @@ def get_permission_query_condition(user: str | None = None) -> str:
 	if has_role(user, "Mail Admin"):
 		if tenant := get_tenant_for_user(user):
 			return f"(`tabMail Domain`.`tenant` = {frappe.db.escape(tenant)})"
+
+	if has_role(user, "Mail User"):
+		if linked_domains := get_user_linked_domains(user):
+			return f'(`tabMail Domain`.`domain_name` IN ({", ".join([frappe.db.escape(domain) for domain in linked_domains])}))'
 
 	return "1=0"

--- a/mail/mail/doctype/outgoing_mail/outgoing_mail.json
+++ b/mail/mail/doctype/outgoing_mail/outgoing_mail.json
@@ -631,7 +631,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-04 10:47:22.754393",
+ "modified": "2025-02-04 19:46:51.775392",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Outgoing Mail",
@@ -648,6 +648,11 @@
    "role": "System Manager",
    "submit": 1,
    "write": 1
+  },
+  {
+   "report": 1,
+   "role": "Mail Admin",
+   "select": 1
   },
   {
    "cancel": 1,

--- a/mail/mail/report/mail_tracker/mail_tracker.json
+++ b/mail/mail/report/mail_tracker/mail_tracker.json
@@ -9,7 +9,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-01-14 09:35:48.299286",
+ "modified": "2025-02-04 19:48:07.545384",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Tracker",
@@ -21,6 +21,9 @@
  "roles": [
   {
    "role": "System Manager"
+  },
+  {
+   "role": "Mail Admin"
   },
   {
    "role": "Mail User"

--- a/mail/mail/report/mail_tracker/mail_tracker.py
+++ b/mail/mail/report/mail_tracker/mail_tracker.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.query_builder import Criterion, Order
 from frappe.query_builder.functions import Date
 
-from mail.utils.cache import get_account_for_user
+from mail.utils.cache import get_account_for_user, get_domains_owned_by_tenant, get_tenant_for_user
 from mail.utils.user import has_role, is_system_manager
 
 
@@ -148,10 +148,14 @@ def get_data(filters: dict | None = None) -> list[dict]:
 	user = frappe.session.user
 	if not is_system_manager(user):
 		conditions = []
-		account = get_account_for_user(user)
 
-		if has_role(user, "Mail User") and account:
-			conditions.append(OM.sender == account)
+		if has_role(user, "Mail Admin"):
+			if tenant := get_tenant_for_user(user):
+				if domains := get_domains_owned_by_tenant(tenant):
+					conditions.append(OM.domain_name.isin(domains))
+		elif has_role(user, "Mail User"):
+			if account := get_account_for_user(user):
+				conditions.append(OM.sender == account)
 
 		if not conditions:
 			return []

--- a/mail/mail/report/outbound_delay/outbound_delay.json
+++ b/mail/mail/report/outbound_delay/outbound_delay.json
@@ -9,7 +9,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-01-14 09:36:05.547152",
+ "modified": "2025-02-04 21:01:00.357625",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Outbound Delay",
@@ -21,6 +21,9 @@
  "roles": [
   {
    "role": "System Manager"
+  },
+  {
+   "role": "Mail Admin"
   },
   {
    "role": "Mail User"

--- a/mail/mail/report/outbound_delay/outbound_delay.py
+++ b/mail/mail/report/outbound_delay/outbound_delay.py
@@ -8,7 +8,7 @@ from frappe.query_builder import Criterion, Order
 from frappe.query_builder.functions import Date, IfNull
 from frappe.utils import flt
 
-from mail.utils.cache import get_account_for_user
+from mail.utils.cache import get_account_for_user, get_domains_owned_by_tenant, get_tenant_for_user
 from mail.utils.user import has_role, is_system_manager
 
 
@@ -211,10 +211,14 @@ def get_data(filters: dict | None = None) -> list[dict]:
 	user = frappe.session.user
 	if not is_system_manager(user):
 		conditions = []
-		account = get_account_for_user(user)
 
-		if has_role(user, "Mail User") and account:
-			conditions.append(OM.sender == account)
+		if has_role(user, "Mail Admin"):
+			if tenant := get_tenant_for_user(user):
+				if domains := get_domains_owned_by_tenant(tenant):
+					conditions.append(OM.domain_name.isin(domains))
+		elif has_role(user, "Mail User"):
+			if account := get_account_for_user(user):
+				conditions.append(OM.sender == account)
 
 		if not conditions:
 			return []

--- a/mail/mail/report/outgoing_mail_summary/outgoing_mail_summary.json
+++ b/mail/mail/report/outgoing_mail_summary/outgoing_mail_summary.json
@@ -9,7 +9,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-01-14 09:35:26.586768",
+ "modified": "2025-02-04 21:05:41.074549",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Outgoing Mail Summary",
@@ -21,6 +21,9 @@
  "roles": [
   {
    "role": "System Manager"
+  },
+  {
+   "role": "Mail Admin"
   },
   {
    "role": "Mail User"

--- a/mail/utils/query.py
+++ b/mail/utils/query.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.query_builder import Criterion, Order
 
-from mail.utils.cache import get_account_for_user
+from mail.utils.cache import get_account_for_user, get_domains_owned_by_tenant, get_tenant_for_user
 from mail.utils.user import has_role, is_system_manager
 
 
@@ -31,10 +31,14 @@ def get_outgoing_mails(
 
 	if not is_system_manager(user):
 		conditions = []
-		account = get_account_for_user(user)
 
-		if has_role(user, "Mail User") and account:
-			conditions.append(OM.sender == account)
+		if has_role(user, "Mail Admin"):
+			if tenant := get_tenant_for_user(user):
+				if domains := get_domains_owned_by_tenant(tenant):
+					conditions.append(OM.domain_name.isin(domains))
+		elif has_role(user, "Mail User"):
+			if account := get_account_for_user(user):
+				conditions.append(OM.sender == account)
 
 		if not conditions:
 			return []

--- a/mail/utils/query.py
+++ b/mail/utils/query.py
@@ -22,7 +22,7 @@ def get_outgoing_mails(
 	OM = frappe.qb.DocType("Outgoing Mail")
 	query = (
 		frappe.qb.from_(OM)
-		.select(OM.name)
+		.select(OM.name, OM.subject)
 		.where((OM.docstatus == 1) & (OM[searchfield].like(f"%{txt}%")))
 		.orderby(OM.creation, OM.created_at, order=Order.desc)
 		.offset(start)

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -23,6 +23,17 @@ def get_user_email_addresses(user: str) -> list:
 	return email_addresses
 
 
+def get_user_linked_domains(user: str) -> list:
+	"""Returns the list of linked domains associated with the user."""
+
+	linked_domains = set()
+	if email_addresses := get_user_email_addresses(user):
+		for email_address in email_addresses:
+			linked_domains.add(email_address.split("@")[1])
+
+	return list(linked_domains)
+
+
 @frappe.whitelist()
 def get_user_tenant() -> str | None:
 	"""Returns the tenant of the user."""


### PR DESCRIPTION
- Mail Tracker, Outbound Delay and Outgoing Mail Summary:
   - System Manager can view report for all the outbound mails.
   - Mail Admin can view reports for outbound mails linked to tenant owned domains.
   - Mail User can view reports for outbound mails linked to his account. 

   ![image](https://github.com/user-attachments/assets/d765f8ad-ee9d-42d4-9411-a5417e157092)
