### PR TITLE
feat: dynamic rate limiter

### DIFF
--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -1,12 +1,12 @@
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 
 from mail.mail.doctype.mail_account.mail_account import create_user
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60 * 60)
+@dynamic_rate_limit()
 def self_signup(email: str) -> str:
 	"""Create a new Mail Account Request for self signup"""
 
@@ -20,7 +20,7 @@ def self_signup(email: str) -> str:
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60 * 60)
+@dynamic_rate_limit()
 def resend_otp(account_request: str) -> None:
 	"""Resend OTP to the user"""
 
@@ -31,7 +31,7 @@ def resend_otp(account_request: str) -> None:
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60 * 60)
+@dynamic_rate_limit()
 def verify_otp(account_request: str, otp: str) -> str:
 	"""Verify the OTP and return the request key"""
 
@@ -44,7 +44,7 @@ def verify_otp(account_request: str, otp: str) -> str:
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60 * 60)
+@dynamic_rate_limit()
 def get_account_request(request_key: str) -> dict:
 	"""Return the account request details"""
 
@@ -57,7 +57,7 @@ def get_account_request(request_key: str) -> dict:
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=10, seconds=60 * 60)
+@dynamic_rate_limit()
 def create_account(request_key: str, first_name: str, last_name: str, password: str) -> None:
 	"""Create a new user account"""
 

--- a/mail/api/admin.py
+++ b/mail/api/admin.py
@@ -2,9 +2,9 @@ from typing import TYPE_CHECKING, Literal
 
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 from frappe.utils import cint
 
+from mail.utils.rate_limiter import dynamic_rate_limit
 from mail.utils.user import is_tenant_admin
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ def get_domain_request(domain_name: str, mail_tenant: str) -> "MailDomainRequest
 
 
 @frappe.whitelist()
-@rate_limit(limit=10, seconds=60 * 60)
+@dynamic_rate_limit()
 def verify_dns_record(domain_request: str) -> bool:
 	"""Verify the domain request key"""
 
@@ -71,7 +71,7 @@ def get_tenant_members(tenant: str) -> list:
 
 
 @frappe.whitelist()
-@rate_limit(limit=10, seconds=60 * 60)
+@dynamic_rate_limit()
 def add_member(
 	tenant: str,
 	username: str,

--- a/mail/api/blacklist.py
+++ b/mail/api/blacklist.py
@@ -1,12 +1,12 @@
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 
 from mail.mail.doctype.ip_blacklist.ip_blacklist import get_blacklist_for_ip_address
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(methods=["GET"], allow_guest=True)
-@rate_limit(limit=180, seconds=60 * 60)
+@dynamic_rate_limit()
 def get(ip_address: str) -> dict:
 	"""Returns the blacklist for the given IP address."""
 

--- a/mail/api/inbound.py
+++ b/mail/api/inbound.py
@@ -4,19 +4,19 @@ from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 from frappe.utils import convert_utc_to_system_timezone, now
 
 from mail.api.auth import validate_account, validate_user
 from mail.mail.doctype.mail_sync_history.mail_sync_history import get_mail_sync_history
 from mail.utils.dt import convert_to_utc
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 if TYPE_CHECKING:
 	from mail.mail.doctype.mail_sync_history.mail_sync_history import MailSyncHistory
 
 
 @frappe.whitelist(methods=["GET"])
-@rate_limit(limit=10, seconds=60)
+@dynamic_rate_limit()
 def pull(
 	account: str,
 	limit: int = 50,
@@ -40,7 +40,7 @@ def pull(
 
 
 @frappe.whitelist(methods=["GET"])
-@rate_limit(limit=10, seconds=60)
+@dynamic_rate_limit()
 def pull_raw(
 	account: str,
 	limit: int = 50,

--- a/mail/api/outbound.py
+++ b/mail/api/outbound.py
@@ -2,14 +2,14 @@ from email.utils import parseaddr
 
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 from frappe.utils import cint
 
 from mail.mail.doctype.outgoing_mail.outgoing_mail import create_outgoing_mail
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(methods=["POST"])
-@rate_limit(limit=300, seconds=60)
+@dynamic_rate_limit()
 def send(
 	from_: str,
 	subject: str,
@@ -50,7 +50,7 @@ def send(
 
 
 @frappe.whitelist(methods=["POST"])
-@rate_limit(limit=300, seconds=60)
+@dynamic_rate_limit()
 def send_raw(
 	from_: str,
 	to: str | list[str],

--- a/mail/api/spamd.py
+++ b/mail/api/spamd.py
@@ -2,13 +2,13 @@ from html import unescape
 
 import frappe
 from frappe import _
-from frappe.rate_limiter import rate_limit
 
 from mail.mail.doctype.spam_check_log.spam_check_log import create_spam_check_log
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(methods=["POST"])
-@rate_limit(limit=60, seconds=60)
+@dynamic_rate_limit()
 def scan(message: str | None = None) -> dict:
 	"""Returns the spam score, spamd response and scanning mode of the message"""
 
@@ -26,7 +26,7 @@ def scan(message: str | None = None) -> dict:
 
 
 @frappe.whitelist(methods=["POST"])
-@rate_limit(limit=60, seconds=60)
+@dynamic_rate_limit()
 def get_spam_score(message: str | None = None) -> float:
 	"""Returns the spam score of the message"""
 

--- a/mail/api/track.py
+++ b/mail/api/track.py
@@ -1,11 +1,12 @@
 import frappe
 from frappe import _
 from frappe.query_builder import Case
-from frappe.rate_limiter import rate_limit
+
+from mail.utils.rate_limiter import dynamic_rate_limit
 
 
 @frappe.whitelist(methods=["GET"], allow_guest=True)
-@rate_limit(limit=10, seconds=60)
+@dynamic_rate_limit()
 def open() -> None:
 	"""Updates Outgoing Mail opened status."""
 

--- a/mail/install.py
+++ b/mail/install.py
@@ -1,8 +1,43 @@
 import frappe
 
+from mail.mail.doctype.rate_limit.rate_limit import create_rate_limit
+
 
 def after_install() -> None:
+	add_rate_limits()
 	create_default_tenant()
+
+
+def add_rate_limits() -> None:
+	"""Add rate limits."""
+
+	rate_limits = [
+		# mail.api.account
+		{"method_path": "mail.api.account.self_signup", "limit": 5, "seconds": 60 * 60},
+		{"method_path": "mail.api.account.resend_otp", "limit": 5, "seconds": 60 * 60},
+		{"method_path": "mail.api.account.verify_otp", "limit": 5, "seconds": 60 * 60},
+		{"method_path": "mail.api.account.get_account_request", "limit": 5, "seconds": 60 * 60},
+		{"method_path": "mail.api.account.create_account", "limit": 10, "seconds": 60 * 60},
+		# mail.api.admin
+		{"method_path": "mail.api.admin.verify_dns_record", "limit": 10, "seconds": 60 * 60},
+		{"method_path": "mail.api.admin.add_member", "limit": 10, "seconds": 60 * 60},
+		# mail.api.blacklist
+		{"method_path": "mail.api.blacklist.get", "limit": 180, "seconds": 60 * 60},
+		# mail.api.inbound
+		{"method_path": "mail.api.inbound.pull", "limit": 10, "seconds": 60},
+		{"method_path": "mail.api.inbound.pull_raw", "limit": 10, "seconds": 60},
+		# mail.api.outbound
+		{"method_path": "mail.api.outbound.send", "limit": 300, "seconds": 60},
+		{"method_path": "mail.api.outbound.send_raw", "limit": 300, "seconds": 60},
+		# mail.api.spamd
+		{"method_path": "mail.api.spamd.scan", "limit": 60, "seconds": 60},
+		{"method_path": "mail.api.spamd.get_spam_score", "limit": 60, "seconds": 60},
+		# mail.api.track
+		{"method_path": "mail.api.track.open", "limit": 10, "seconds": 60},
+	]
+
+	for rl in rate_limits:
+		create_rate_limit(**rl)
 
 
 def create_default_tenant() -> None:

--- a/mail/mail/doctype/rate_limit/rate_limit.js
+++ b/mail/mail/doctype/rate_limit/rate_limit.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Rate Limit", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/mail/mail/doctype/rate_limit/rate_limit.json
+++ b/mail/mail/doctype/rate_limit/rate_limit.json
@@ -81,7 +81,8 @@
    "label": "Method Path",
    "placeholder": "mail.api.track.open",
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "default": "1",
@@ -92,7 +93,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-10 12:51:27.757006",
+ "modified": "2025-02-10 15:52:41.222086",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Rate Limit",

--- a/mail/mail/doctype/rate_limit/rate_limit.json
+++ b/mail/mail/doctype/rate_limit/rate_limit.json
@@ -12,7 +12,7 @@
   "method_path",
   "methods",
   "column_break_kcmd",
-  "key",
+  "key_",
   "limit",
   "seconds",
   "ip_based"
@@ -21,11 +21,6 @@
   {
    "fieldname": "section_break_v9lm",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "key",
-   "fieldtype": "Data",
-   "label": "Key"
   },
   {
    "default": "5",
@@ -89,11 +84,16 @@
    "fieldname": "ignore_in_developer_mode",
    "fieldtype": "Check",
    "label": "Ignore in Developer Mode"
+  },
+  {
+   "fieldname": "key_",
+   "fieldtype": "Data",
+   "label": "Key"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-10 15:52:41.222086",
+ "modified": "2025-02-11 13:51:39.268019",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Rate Limit",

--- a/mail/mail/doctype/rate_limit/rate_limit.json
+++ b/mail/mail/doctype/rate_limit/rate_limit.json
@@ -1,0 +1,118 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2025-02-10 12:14:22.025044",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_v9lm",
+  "enabled",
+  "ignore_in_developer_mode",
+  "section_break_vvaw",
+  "method_path",
+  "methods",
+  "column_break_kcmd",
+  "key",
+  "limit",
+  "seconds",
+  "ip_based"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_v9lm",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "key",
+   "fieldtype": "Data",
+   "label": "Key"
+  },
+  {
+   "default": "5",
+   "fieldname": "limit",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Limit",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "86400",
+   "fieldname": "seconds",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Seconds",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "ALL",
+   "fieldname": "methods",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Methods",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "ip_based",
+   "fieldtype": "Check",
+   "label": "IP Based"
+  },
+  {
+   "default": "1",
+   "depends_on": "eval: !doc.__islocal",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled",
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_vvaw",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_kcmd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "method_path",
+   "fieldtype": "Data",
+   "label": "Method Path",
+   "placeholder": "mail.api.track.open",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "ignore_in_developer_mode",
+   "fieldtype": "Check",
+   "label": "Ignore in Developer Mode"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-02-10 12:51:27.757006",
+ "modified_by": "Administrator",
+ "module": "Mail",
+ "name": "Rate Limit",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/mail/doctype/rate_limit/rate_limit.json
+++ b/mail/mail/doctype/rate_limit/rate_limit.json
@@ -27,6 +27,7 @@
    "fieldname": "limit",
    "fieldtype": "Int",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Limit",
    "non_negative": 1,
    "reqd": 1
@@ -36,6 +37,7 @@
    "fieldname": "seconds",
    "fieldtype": "Int",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Seconds",
    "non_negative": 1,
    "reqd": 1
@@ -45,6 +47,7 @@
    "fieldname": "methods",
    "fieldtype": "Small Text",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Methods",
    "reqd": 1
   },
@@ -52,6 +55,7 @@
    "default": "1",
    "fieldname": "ip_based",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "IP Based"
   },
   {
@@ -73,6 +77,8 @@
   {
    "fieldname": "method_path",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Method Path",
    "placeholder": "mail.api.track.open",
    "reqd": 1,
@@ -88,12 +94,14 @@
   {
    "fieldname": "key_",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Key"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-11 13:51:39.268019",
+ "modified": "2025-02-11 15:02:50.785940",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Rate Limit",

--- a/mail/mail/doctype/rate_limit/rate_limit.py
+++ b/mail/mail/doctype/rate_limit/rate_limit.py
@@ -1,9 +1,18 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class RateLimit(Document):
-	pass
+	def on_update(self) -> None:
+		self.clear_cache()
+
+	def on_trash(self) -> None:
+		self.clear_cache()
+
+	def clear_cache(self) -> None:
+		"""Clear cache for the rate limit"""
+
+		frappe.cache.hdel("rate_limits", self.method_path)

--- a/mail/mail/doctype/rate_limit/rate_limit.py
+++ b/mail/mail/doctype/rate_limit/rate_limit.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class RateLimit(Document):
+	pass

--- a/mail/mail/doctype/rate_limit/rate_limit.py
+++ b/mail/mail/doctype/rate_limit/rate_limit.py
@@ -16,3 +16,9 @@ class RateLimit(Document):
 		"""Clear cache for the rate limit"""
 
 		frappe.cache.hdel("rate_limits", self.method_path)
+
+
+def on_doctype_update() -> None:
+	frappe.db.add_unique(
+		"Rate Limit", ["method_path", "key_", "ip_based", "seconds"], constraint_name="unique_rate_limit"
+	)

--- a/mail/mail/doctype/rate_limit/rate_limit.py
+++ b/mail/mail/doctype/rate_limit/rate_limit.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import cint
 
 
 class RateLimit(Document):
@@ -16,6 +17,29 @@ class RateLimit(Document):
 		"""Clear cache for the rate limit"""
 
 		frappe.cache.hdel("rate_limits", self.method_path)
+
+
+def create_rate_limit(
+	method_path: str,
+	limit: int = 5,
+	seconds: int = 86_400,
+	key: str | None = None,
+	ip_based: bool = True,
+	methods: str = "ALL",
+	ignore_in_developer_mode: bool = True,
+) -> "RateLimit":
+	"""Create a Rate Limit document"""
+
+	doc = frappe.new_doc("Rate Limit")
+	doc.enabled = 1
+	doc.ignore_in_developer_mode = cint(ignore_in_developer_mode)
+	doc.method_path = method_path
+	doc.methods = methods
+	doc.key = key
+	doc.limit = limit
+	doc.seconds = seconds
+	doc.ip_based = cint(ip_based)
+	doc.insert(ignore_permissions=True)
 
 
 def on_doctype_update() -> None:

--- a/mail/mail/doctype/rate_limit/test_rate_limit.py
+++ b/mail/mail/doctype/rate_limit/test_rate_limit.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestRateLimit(UnitTestCase):
+	"""
+	Unit tests for RateLimit.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestRateLimit(IntegrationTestCase):
+	"""
+	Integration tests for RateLimit.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -166,7 +166,7 @@ def get_rate_limits(method_path: str) -> list:
 			frappe.qb.from_(RATE_LIMIT)
 			.select(
 				RATE_LIMIT.ignore_in_developer_mode,
-				RATE_LIMIT.key,
+				RATE_LIMIT.key_.as_("key"),
 				RATE_LIMIT.limit,
 				RATE_LIMIT.seconds,
 				RATE_LIMIT.methods,

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -155,3 +155,37 @@ def get_primary_agents() -> list:
 		).run(pluck="name")
 
 	return frappe.cache.get_value("primary_agents", generator)
+
+
+def get_rate_limits(method_path: str) -> list:
+	"""Returns the rate limits for the method path."""
+
+	def generator() -> list:
+		RATE_LIMIT = frappe.qb.DocType("Rate Limit")
+		rate_limits = (
+			frappe.qb.from_(RATE_LIMIT)
+			.select(
+				RATE_LIMIT.ignore_in_developer_mode,
+				RATE_LIMIT.key,
+				RATE_LIMIT.limit,
+				RATE_LIMIT.seconds,
+				RATE_LIMIT.methods,
+				RATE_LIMIT.ip_based,
+			)
+			.where((RATE_LIMIT.enabled == 1) & (RATE_LIMIT.method_path == method_path))
+		).run(as_dict=True)
+
+		if not rate_limits:
+			return []
+
+		for rl in rate_limits:
+			rl["ignore_in_developer_mode"] = bool(rl["ignore_in_developer_mode"])
+			rl["methods"] = rl["methods"].split(",")
+			rl["ip_based"] = bool(rl["ip_based"])
+
+			if len(rl["methods"]) == 1 and rl["methods"][0] == "ALL":
+				rl["methods"] = "ALL"
+
+		return rate_limits
+
+	return frappe.cache.hget("rate_limits", method_path, generator)

--- a/mail/utils/rate_limiter.py
+++ b/mail/utils/rate_limiter.py
@@ -3,36 +3,28 @@ from functools import wraps
 import frappe
 from frappe.rate_limiter import rate_limit
 
+from mail.utils.cache import get_rate_limits
+
 
 def dynamic_rate_limit() -> callable:
+	"""A decorator to apply rate limits dynamically based on the method path."""
+
 	def decorator(fn):
 		@wraps(fn)
 		def wrapper(*args, **kwargs):
 			method_path = frappe.form_dict.cmd
-			rate_limits = get_rate_limit(method_path)
+			rate_limits = get_rate_limits(method_path)
 
 			wrapped_fn = fn
 			for rl in rate_limits:
 				if rl["ignore_in_developer_mode"] and frappe.conf.developer_mode:
 					continue
 
-				key = rl["key"]
-				limit = rl["limit"]
-				seconds = rl["seconds"]
-				methods = rl["methods"].split(",")
-				ip_based = bool(rl["ip_based"])
-				wrapped_fn = rate_limit(key, limit, seconds, methods, ip_based)(wrapped_fn)
+				rl.pop("ignore_in_developer_mode")
+				wrapped_fn = rate_limit(**rl)(wrapped_fn)
 
 			return wrapped_fn(*args, **kwargs)
 
 		return wrapper
 
 	return decorator
-
-
-def get_rate_limit(method_path: str) -> list:
-	return frappe.db.get_all(
-		"Rate Limit",
-		filters={"enabled": 1, "method_path": method_path},
-		fields=["ignore_in_developer_mode", "key", "limit", "seconds", "methods", "ip_based"],
-	)

--- a/mail/utils/rate_limiter.py
+++ b/mail/utils/rate_limiter.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+import frappe
+from frappe.rate_limiter import rate_limit
+
+
+def dynamic_rate_limit() -> callable:
+	def decorator(fn):
+		@wraps(fn)
+		def wrapper(*args, **kwargs):
+			method_path = frappe.form_dict.cmd
+			rate_limits = get_rate_limit(method_path)
+
+			wrapped_fn = fn
+			for rl in rate_limits:
+				if rl["ignore_in_developer_mode"] and frappe.conf.developer_mode:
+					continue
+
+				key = rl["key"]
+				limit = rl["limit"]
+				seconds = rl["seconds"]
+				methods = rl["methods"].split(",")
+				ip_based = bool(rl["ip_based"])
+				wrapped_fn = rate_limit(key, limit, seconds, methods, ip_based)(wrapped_fn)
+
+			return wrapped_fn(*args, **kwargs)
+
+		return wrapper
+
+	return decorator
+
+
+def get_rate_limit(method_path: str) -> list:
+	return frappe.db.get_all(
+		"Rate Limit",
+		filters={"enabled": 1, "method_path": method_path},
+		fields=["ignore_in_developer_mode", "key", "limit", "seconds", "methods", "ip_based"],
+	)


### PR DESCRIPTION
Wrapper over the `frappe.rate_limiter.rate_limit` to dynamically apply rate limits based on Rate Limit document(s). 

![image](https://github.com/user-attachments/assets/79a20ac6-2aca-448a-991d-33194bb4a2dd)

For 1K request:

```py
@rate_limit(limit=10, seconds=60)

CPU times: user 1.44 s, sys: 180 ms, total: 1.62 s
Wall time: 8 s
```

```py
@dynamic_rate_limit()

CPU times: user 1.51 s, sys: 203 ms, total: 1.71 s
Wall time: 8.28 s
```

After: https://github.com/frappe/frappe/pull/31209