### PR TITLE
refactor: cache

### DIFF
--- a/mail/mail/doctype/ip_blacklist/ip_blacklist.py
+++ b/mail/mail/doctype/ip_blacklist/ip_blacklist.py
@@ -72,7 +72,7 @@ class IPBlacklist(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value(f"blacklist|{self.ip_group}")
+		frappe.cache.hdel("ip-blacklist", self.ip_group)
 
 
 def get_ip_version(ip_address: str) -> Literal["IPv4", "IPv6"]:

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -156,8 +156,8 @@ class MailAccount(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value(f"user|{self.user}")
-		frappe.cache.delete_value(f"email|{self.email}")
+		frappe.cache.hdel(f"user|{self.user}", ["account", "default_outgoing_email"])
+		frappe.cache.hdel(f"email|{self.email}", "account")
 
 	def generate_secret(self) -> None:
 		"""Generates secret from password"""

--- a/mail/mail/doctype/mail_alias/mail_alias.py
+++ b/mail/mail/doctype/mail_alias/mail_alias.py
@@ -92,13 +92,13 @@ class MailAlias(Document):
 
 		if self.alias_for_type == "Mail Account":
 			user = frappe.db.get_value("Mail Account", self.alias_for_name, "user")
-			frappe.cache.delete_value(f"user|{user}")
+			frappe.cache.hdel(f"user|{user}", "aliases")
 
 		if self.has_value_changed("alias_for_type") or self.has_value_changed("alias_for_name"):
 			if previous_doc := self.get_doc_before_save():
 				if previous_doc.alias_for_type == "Mail Account":
 					user = frappe.db.get_value("Mail Account", previous_doc.alias_for_name, "user")
-					frappe.cache.delete_value(f"user|{user}")
+					frappe.cache.hdel(f"user|{user}", "aliases")
 
 	def remove_alias_set_as_default_outgoing_email(self) -> None:
 		"""Removes the alias set as the default outgoing email."""

--- a/mail/mail/doctype/mail_domain/mail_domain.py
+++ b/mail/mail/doctype/mail_domain/mail_domain.py
@@ -167,12 +167,12 @@ class MailDomain(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value(f"tenant|{self.tenant}")
+		frappe.cache.hdel(f"tenant|{self.tenant}", "domains")
 
 		if self.has_value_changed("tenant"):
 			if previous_doc := self.get_doc_before_save():
 				if previous_doc.tenant:
-					frappe.cache.delete_value(f"tenant|{previous_doc.tenant}")
+					frappe.cache.hdel(f"tenant|{previous_doc.tenant}", "domains")
 
 
 def get_dns_records(domain_name: str) -> list[dict]:

--- a/mail/mail/doctype/mail_group/mail_group.py
+++ b/mail/mail/doctype/mail_group/mail_group.py
@@ -94,12 +94,12 @@ class MailGroup(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value(f"tenant|{self.tenant}")
+		frappe.cache.hdel(f"tenant|{self.tenant}", "groups")
 
 		if self.has_value_changed("tenant"):
 			if previous_doc := self.get_doc_before_save():
 				if previous_doc.tenant:
-					frappe.cache.delete_value(f"tenant|{previous_doc.tenant}")
+					frappe.cache.hdel(f"tenant|{previous_doc.tenant}", "groups")
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -69,9 +69,7 @@ class MailSettings(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value("root_domain_name")
-		frappe.cache.delete_value("smtp_limits")
-		frappe.cache.delete_value("imap_limits")
+		frappe.cache.delete_value("mail-settings")
 
 
 def create_dmarc_dns_record_for_external_domains() -> None:

--- a/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
+++ b/mail/mail/doctype/mail_tenant_member/mail_tenant_member.py
@@ -96,7 +96,7 @@ class MailTenantMember(Document):
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""
 
-		frappe.cache.delete_value(f"user|{self.user}")
+		frappe.cache.hdel(f"user|{self.user}", "tenant")
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -140,7 +140,7 @@ def get_blacklist_for_ip_group(ip_group: str) -> list:
 			.where(IP_BLACKLIST.ip_group == ip_group)
 		).run(as_dict=True)
 
-	return frappe.cache.get_value(f"blacklist|{ip_group}", generator)
+	return frappe.cache.hget("ip-blacklist", ip_group, generator)
 
 
 def get_primary_agents() -> list:

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -8,7 +8,7 @@ def get_root_domain_name() -> str | None:
 	def generator() -> str | None:
 		return frappe.db.get_single_value("Mail Settings", "root_domain_name")
 
-	return frappe.cache.get_value("root_domain_name", generator)
+	return frappe.cache.hget("mail-settings", "root_domain_name", generator)
 
 
 def get_smtp_limits() -> dict:
@@ -24,7 +24,7 @@ def get_smtp_limits() -> dict:
 			"cleanup_interval": mail_settings.smtp_cleanup_interval,
 		}
 
-	return frappe.cache.get_value("smtp_limits", generator)
+	return frappe.cache.hget("mail-settings", "smtp_limits", generator)
 
 
 def get_imap_limits() -> dict:
@@ -40,7 +40,7 @@ def get_imap_limits() -> dict:
 			"cleanup_interval": mail_settings.imap_cleanup_interval,
 		}
 
-	return frappe.cache.get_value("imap_limits", generator)
+	return frappe.cache.hget("mail-settings", "imap_limits", generator)
 
 
 def get_domains_owned_by_tenant(tenant: str) -> list:


### PR DESCRIPTION
- Clear the key for the changed value instead of deleting the complete hash.
- Use hash to store mail-settings-related fields.
- Use hash to store IP Blacklist where the IP Groups are the key.