### PR TITLE
feat: Trash

### DIFF
--- a/frontend/src/components/HeaderActions.vue
+++ b/frontend/src/components/HeaderActions.vue
@@ -1,26 +1,35 @@
 <template>
 	<div>
-		<Button variant="subtle" size="md" @click="openSendModal()">
-			<template #prefix>
-				<SquarePen class="h-4 w-4 text-gray-600" />
-			</template>
-			{{ __('Compose') }}
+		<Button
+			:icon-left="currentFolder === 'Trash' ? 'trash-2' : 'edit'"
+			@click="performAction()"
+		>
+			{{ __(currentFolder === 'Trash' ? 'Empty Trash' : 'Compose') }}
 		</Button>
 	</div>
 	<SendMailModal v-model="showSendModal" @reload-mails="emit('reloadMails')" />
 </template>
 <script setup lang="ts">
 import { ref } from 'vue'
-import { SquarePen } from 'lucide-vue-next'
-import { Button } from 'frappe-ui'
+import { Button, createResource } from 'frappe-ui'
 
 import SendMailModal from '@/components/Modals/SendMailModal.vue'
+
+import type { Folder } from '@/types'
+
+const props = defineProps<{ currentFolder: Folder }>()
 
 const emit = defineEmits(['reloadMails'])
 
 const showSendModal = ref(false)
 
-const openSendModal = () => {
-	showSendModal.value = true
+const performAction = () => {
+	if (props.currentFolder === 'Trash') emptyTrash.submit()
+	else showSendModal.value = true
 }
+
+const emptyTrash = createResource({
+	url: 'mail.api.mail.empty_trash',
+	onSuccess: () => emit('reloadMails'),
+})
 </script>

--- a/frontend/src/components/HeaderActions.vue
+++ b/frontend/src/components/HeaderActions.vue
@@ -7,11 +7,12 @@
 			{{ __(currentFolder === 'Trash' ? 'Empty Trash' : 'Compose') }}
 		</Button>
 	</div>
-	<SendMailModal v-model="showSendModal" @reload-mails="emit('reloadMails')" />
+	<SendMailModal v-model="showSendModal" @reload-mails="emit('reloadMails', 'Drafts')" />
+	<Dialog v-model="showConfirmDialog" :options="confirmDialogOptions" />
 </template>
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Button, createResource } from 'frappe-ui'
+import { Button, Dialog, createResource } from 'frappe-ui'
 
 import SendMailModal from '@/components/Modals/SendMailModal.vue'
 
@@ -22,9 +23,10 @@ const props = defineProps<{ currentFolder: Folder }>()
 const emit = defineEmits(['reloadMails'])
 
 const showSendModal = ref(false)
+const showConfirmDialog = ref(false)
 
 const performAction = () => {
-	if (props.currentFolder === 'Trash') emptyTrash.submit()
+	if (props.currentFolder === 'Trash') showConfirmDialog.value = true
 	else showSendModal.value = true
 }
 
@@ -32,4 +34,20 @@ const emptyTrash = createResource({
 	url: 'mail.api.mail.empty_trash',
 	onSuccess: () => emit('reloadMails'),
 })
+
+const confirmDialogOptions = {
+	title: __('Empty Trash?'),
+	message: __('This action cannot be undone.'),
+	icon: { name: 'alert-triangle', appearance: 'warning' },
+	actions: [
+		{
+			label: __('Confirm'),
+			variant: 'solid',
+			onClick: () => {
+				emptyTrash.submit()
+				showConfirmDialog.value = false
+			},
+		},
+	],
+}
 </script>

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -113,7 +113,6 @@ import {
 	Trash2,
 } from 'lucide-vue-next'
 import { Avatar, Button, Dropdown, Tooltip, createResource } from 'frappe-ui'
-import { useDoctype } from 'frappe-ui/src/data-fetching'
 
 import { getRecipients } from '@/utils'
 import MailDate from '@/components/MailDate.vue'
@@ -121,7 +120,6 @@ import MailDetailsPopover from '@/components/MailDetailsPopover.vue'
 import SendMailModal from '@/components/Modals/SendMailModal.vue'
 
 const dayjs = inject('$dayjs')
-const outgoingMail = useDoctype('Outgoing Mail')
 
 const showSendModal = ref(false)
 const draftMailID = ref<string>()
@@ -144,12 +142,10 @@ const replyDetails = reactive({
 
 const mailThread = createResource({
 	url: 'mail.api.mail.get_mail_thread',
-	makeParams: () => {
-		return {
-			name: props.mailID,
-			mail_type: props.type,
-		}
-	},
+	makeParams: () => ({
+		name: props.mailID,
+		mail_type: props.type,
+	}),
 })
 
 const reloadThread = () => {
@@ -228,22 +224,33 @@ const moreActions = (mail): MailAction[] => [
 	},
 	{
 		label: __('Move to Trash'),
-		onClick: () => setFolder(mail, 'Trash'),
+		onClick: () => setFolder.submit({ mail, folder: 'Trash' }),
 		icon: Trash2,
-		condition: () => mail.mail_type === 'Outgoing Mail' && mail.folder !== 'Trash',
+		condition: () => mail.folder !== 'Trash',
 	},
 	{
 		label: __('Restore'),
-		onClick: () => setFolder(mail),
+		onClick: () => setFolder.submit({ mail }),
 		icon: ArchiveRestore,
 		condition: () => mail.folder === 'Trash',
 	},
 ]
 
-const setFolder = async (mail, folder: 'Trash' | 'Sent' = 'Sent') => {
-	await outgoingMail.setValue.submit({ name: mail.name, folder })
-	emit('reloadMails')
+interface SetFolderParams {
+	mail: object
+	folder?: 'Trash'
 }
+
+const setFolder = createResource({
+	url: 'mail.api.mail.set_folder',
+	method: 'POST',
+	makeParams: (values: SetFolderParams) => ({
+		mail_type: values.mail.mail_type,
+		name: values.mail.name,
+		folder: values.folder,
+	}),
+	onSuccess: () => emit('reloadMails'),
+})
 
 const openModal = (type: ActionType, mail) => {
 	if (props.type == 'Incoming Mail') {

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -92,7 +92,7 @@
 		v-model="showSendModal"
 		:mail-i-d="draftMailID"
 		:reply-details="replyDetails"
-		@reload-mails="emit('reloadMails')"
+		@reload-mails="emit('reloadMails', 'Drafts')"
 	/>
 </template>
 
@@ -107,8 +107,10 @@ import {
 	Reply,
 	ReplyAll,
 	SquarePen,
+	Trash2,
 } from 'lucide-vue-next'
 import { Avatar, Button, Dropdown, Tooltip, createResource } from 'frappe-ui'
+import { useDoctype } from 'frappe-ui/src/data-fetching'
 
 import { getRecipients } from '@/utils'
 import { userStore } from '@/stores/user'
@@ -120,6 +122,7 @@ import type { Folder } from '@/types'
 
 const { setCurrentMail } = userStore()
 const dayjs = inject('$dayjs')
+const outgoingMail = useDoctype('Outgoing Mail')
 
 const showSendModal = ref(false)
 const draftMailID = ref<string>()
@@ -229,6 +232,18 @@ const moreActions = (mail): MailAction[] => [
 		label: __('Mark as Unread'),
 		onClick: () => emit('markAsUnread'),
 		icon: MessageSquareDot,
+	},
+	{
+		label: __('Move to Trash'),
+		onClick: async () => {
+			await outgoingMail.setValue.submit({ name: mail.name, folder: 'Trash' })
+			const noRelevantMailInFolder =
+				mailThread.data.filter((m) => m.folder === mail.folder).length === 1
+			if (noRelevantMailInFolder) setCurrentMail(mail.folder as Folder, null)
+			emit('reloadMails')
+		},
+		icon: Trash2,
+		condition: () => mail.mail_type === 'Outgoing Mail' && mail.folder !== 'Trash',
 	},
 ]
 

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -88,7 +88,7 @@
 		class="my-auto flex h-full w-full flex-1 flex-col items-center justify-center space-y-2"
 	>
 		<div class="text-lg text-gray-500">
-			{{ __('No emails to show') }}
+			{{ __('Please select an email') }}
 		</div>
 	</div>
 	<SendMailModal
@@ -224,13 +224,13 @@ const moreActions = (mail): MailAction[] => [
 	},
 	{
 		label: __('Move to Trash'),
-		onClick: () => setFolder.submit({ mail, folder: 'Trash' }),
+		onClick: () => setFolder.submit({ mail, moveToTrash: true }),
 		icon: Trash2,
 		condition: () => mail.folder !== 'Trash',
 	},
 	{
 		label: __('Restore'),
-		onClick: () => setFolder.submit({ mail }),
+		onClick: () => setFolder.submit({ mail, moveToTrash: false }),
 		icon: ArchiveRestore,
 		condition: () => mail.folder === 'Trash',
 	},
@@ -238,7 +238,7 @@ const moreActions = (mail): MailAction[] => [
 
 interface SetFolderParams {
 	mail: object
-	folder?: 'Trash'
+	moveToTrash: boolean
 }
 
 const setFolder = createResource({
@@ -247,7 +247,7 @@ const setFolder = createResource({
 	makeParams: (values: SetFolderParams) => ({
 		mail_type: values.mail.mail_type,
 		name: values.mail.name,
-		folder: values.folder,
+		move_to_trash: values.moveToTrash,
 	}),
 	onSuccess: () => emit('reloadMails'),
 })

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -234,6 +234,12 @@ const moreActions = (mail): MailAction[] => [
 		icon: ArchiveRestore,
 		condition: () => mail.folder === 'Trash',
 	},
+	{
+		label: __('Delete Message'),
+		onClick: () => cancelMail.submit({ mail }),
+		icon: Trash2,
+		condition: () => mail.folder === 'Trash',
+	},
 ]
 
 interface SetFolderParams {
@@ -252,6 +258,14 @@ const setFolder = createResource({
 	onSuccess: () => emit('reloadMails'),
 })
 
+const cancelMail = createResource({
+	url: 'mail.api.mail.cancel_mail',
+	makeParams: (values: { mail: object }) => ({
+		mail_type: values.mail.mail_type,
+		name: values.mail.name,
+	}),
+	onSuccess: () => emit('reloadMails'),
+})
 const openModal = (type: ActionType, mail) => {
 	if (props.type == 'Incoming Mail') {
 		replyDetails.to = mail.reply_to || mail.sender

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -4,7 +4,10 @@
 			v-for="mail in mailThread.data"
 			:key="mail.name"
 			class="mb-4 p-3"
-			:class="{ 'rounded-md border': mailThread.data.length > 1 }"
+			:class="{
+				'rounded-md border': mailThread.data.length > 1,
+				'opacity-50': mail.folder === 'Trash',
+			}"
 		>
 			<div class="flex space-x-3 border-b pb-2">
 				<Avatar
@@ -98,7 +101,6 @@
 
 <script setup lang="ts">
 import { inject, reactive, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
 import {
 	ArchiveRestore,
 	Ellipsis,
@@ -114,14 +116,10 @@ import { Avatar, Button, Dropdown, Tooltip, createResource } from 'frappe-ui'
 import { useDoctype } from 'frappe-ui/src/data-fetching'
 
 import { getRecipients } from '@/utils'
-import { userStore } from '@/stores/user'
 import MailDate from '@/components/MailDate.vue'
 import MailDetailsPopover from '@/components/MailDetailsPopover.vue'
 import SendMailModal from '@/components/Modals/SendMailModal.vue'
 
-import type { Folder } from '@/types'
-
-const { setCurrentMail } = userStore()
 const dayjs = inject('$dayjs')
 const outgoingMail = useDoctype('Outgoing Mail')
 
@@ -144,8 +142,6 @@ const replyDetails = reactive({
 	in_reply_to_mail_name: '',
 })
 
-const route = useRoute()
-
 const mailThread = createResource({
 	url: 'mail.api.mail.get_mail_thread',
 	makeParams: () => {
@@ -153,10 +149,6 @@ const mailThread = createResource({
 			name: props.mailID,
 			mail_type: props.type,
 		}
-	},
-	onError: (error) => {
-		if (error.exc_type === 'DoesNotExistError')
-			setCurrentMail(String(route.name) as Folder, null)
 	},
 })
 
@@ -250,8 +242,6 @@ const moreActions = (mail): MailAction[] => [
 
 const setFolder = async (mail, folder: 'Trash' | 'Sent' = 'Sent') => {
 	await outgoingMail.setValue.submit({ name: mail.name, folder })
-	const isOnlyMailInFolder = !mailThread.data.some((m) => m.folder === mail.folder && m !== mail)
-	if (isOnlyMailInFolder) setCurrentMail(mail.folder as Folder, null)
 	emit('reloadMails')
 }
 

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -187,19 +187,19 @@ const mailActions = (mail): MailAction[] => [
 		label: __('Reply'),
 		onClick: () => openModal('reply', mail),
 		icon: Reply,
-		condition: mail.folder !== 'Drafts',
+		condition: mail.status !== 'Draft',
 	},
 	{
 		label: __('Reply All'),
 		onClick: () => openModal('replyAll', mail),
 		icon: ReplyAll,
-		condition: mail.folder !== 'Drafts',
+		condition: mail.status !== 'Draft',
 	},
 	{
 		label: __('Forward'),
 		onClick: () => openModal('forward', mail),
 		icon: Forward,
-		condition: mail.folder !== 'Drafts',
+		condition: mail.status !== 'Draft',
 	},
 ]
 
@@ -215,7 +215,7 @@ const moreActions = (mail): MailAction[] => [
 				?.focus()
 		},
 		icon: Mail,
-		condition: () => mail.folder !== 'Drafts',
+		condition: () => mail.status !== 'Draft',
 	},
 	{
 		label: __('Mark as Unread'),

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -100,6 +100,7 @@
 import { inject, reactive, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import {
+	ArchiveRestore,
 	Ellipsis,
 	Forward,
 	Mail,
@@ -235,17 +236,24 @@ const moreActions = (mail): MailAction[] => [
 	},
 	{
 		label: __('Move to Trash'),
-		onClick: async () => {
-			await outgoingMail.setValue.submit({ name: mail.name, folder: 'Trash' })
-			const noRelevantMailInFolder =
-				mailThread.data.filter((m) => m.folder === mail.folder).length === 1
-			if (noRelevantMailInFolder) setCurrentMail(mail.folder as Folder, null)
-			emit('reloadMails')
-		},
+		onClick: () => setFolder(mail, 'Trash'),
 		icon: Trash2,
 		condition: () => mail.mail_type === 'Outgoing Mail' && mail.folder !== 'Trash',
 	},
+	{
+		label: __('Restore'),
+		onClick: () => setFolder(mail),
+		icon: ArchiveRestore,
+		condition: () => mail.folder === 'Trash',
+	},
 ]
+
+const setFolder = async (mail, folder: 'Trash' | 'Sent' = 'Sent') => {
+	await outgoingMail.setValue.submit({ name: mail.name, folder })
+	const isOnlyMailInFolder = !mailThread.data.some((m) => m.folder === mail.folder && m !== mail)
+	if (isOnlyMailInFolder) setCurrentMail(mail.folder as Folder, null)
+	emit('reloadMails')
+}
 
 const openModal = (type: ActionType, mail) => {
 	if (props.type == 'Incoming Mail') {

--- a/frontend/src/components/MailDetails.vue
+++ b/frontend/src/components/MailDetails.vue
@@ -126,7 +126,7 @@ const draftMailID = ref<string>()
 
 const props = defineProps<{
 	mailID: string | null
-	type: string
+	type?: 'Incoming Mail' | 'Outgoing Mail'
 }>()
 
 const emit = defineEmits(['reloadMails', 'markAsUnread'])

--- a/frontend/src/components/Modals/SendMailModal.vue
+++ b/frontend/src/components/Modals/SendMailModal.vue
@@ -309,15 +309,13 @@ const addressOptions = createResource({
 const createDraftMail = createResource({
 	url: 'mail.api.outbound.send',
 	method: 'POST',
-	makeParams() {
-		return {
-			// TODO: use mail account display_name
-			from_: `${user.data?.full_name} <${mail.from}>`,
-			do_not_submit: !isSend.value,
-			...mail,
-		}
-	},
-	onSuccess(data: string) {
+	makeParams: () => ({
+		// TODO: use mail account display_name
+		from_: `${user.data?.full_name} <${mail.from}>`,
+		do_not_submit: !isSend.value,
+		...mail,
+	}),
+	onSuccess: (data: string) => {
 		if (isSend.value) Object.assign(mail, emptyMail)
 		else {
 			localMailID.value = data
@@ -329,61 +327,45 @@ const createDraftMail = createResource({
 
 const updateDraftMail = createResource({
 	url: 'mail.api.mail.update_draft_mail',
-	makeParams() {
-		return {
-			mail_id: localMailID.value,
-			from_: `${user.data?.full_name} <${mail.from}>`,
-			do_submit: isSend.value,
-			...mail,
-		}
-	},
-	onSuccess() {
-		if (isSend.value) setCurrentMail('Drafts', null)
-		emit('reloadMails')
-	},
+	makeParams: () => ({
+		mail_id: localMailID.value,
+		from_: `${user.data?.full_name} <${mail.from}>`,
+		do_submit: isSend.value,
+		...mail,
+	}),
+	onSuccess: () => emit('reloadMails'),
 })
 
 // TODO: delete using documentresource directly
 const deleteDraftMail = createResource({
 	url: 'frappe.client.delete',
-	makeParams() {
-		return {
-			doctype: 'Outgoing Mail',
-			name: localMailID.value,
-		}
-	},
-	onSuccess() {
-		setCurrentMail('Drafts', null)
-		emit('reloadMails')
-	},
+	makeParams: () => ({
+		doctype: 'Outgoing Mail',
+		name: localMailID.value,
+	}),
+	onSuccess: () => emit('reloadMails'),
 })
 
 const attachments = createResource({
 	url: 'mail.api.mail.get_attachments',
-	makeParams() {
-		return {
-			dt: 'Outgoing Mail',
-			dn: localMailID.value,
-		}
-	},
+	makeParams: () => ({
+		dt: 'Outgoing Mail',
+		dn: localMailID.value,
+	}),
 })
 
 const removeAttachment = createResource({
 	url: 'frappe.client.delete',
 	method: 'DELETE',
-	makeParams(values: { name: string }) {
-		return { doctype: 'File', name: values.name }
-	},
-	onSuccess() {
-		attachments.fetch()
-	},
+	makeParams: (values: { name: string }) => ({ doctype: 'File', name: values.name }),
+	onSuccess: () => attachments.fetch(),
 })
 
 const getDraftMail = (name: string) =>
 	createDocumentResource({
 		doctype: 'Outgoing Mail',
 		name: name,
-		onSuccess(data) {
+		onSuccess: (data) => {
 			isMailWatcherActive.value = false
 			const mailDetails = {
 				from_: `${data.display_name} <${data.sender}>`,

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -90,12 +90,8 @@ const createMailResource = (folder: Folder) =>
 		pageLength: 50,
 		cache: [`${folder}Mails`, user.data?.name],
 		onSuccess: (data) => {
-			if (!data.length) return setCurrentMail(folder, null)
-
-			if (!data.some((m) => m.name === currentMail[folder]))
-				setCurrentMail(folder, data.find((m) => m.seen)?.name || null)
-
-			mailDetails.value?.reloadThread()
+			if (data.some((m) => m.name === currentMail[folder])) mailDetails.value?.reloadThread()
+			else setCurrentMail(folder, data.find((m) => m.seen)?.name || null)
 		},
 	})
 

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -92,10 +92,9 @@ const createMailResource = (folder: Folder) =>
 		onSuccess: (data) => {
 			if (!data.length) return setCurrentMail(folder, null)
 
-			if (!data.some((m) => m.name === currentMail[folder])) {
-				const firstSeen = data.find((m) => m.seen)
-				if (firstSeen) setCurrentMail(folder, firstSeen.name)
-			}
+			if (!data.some((m) => m.name === currentMail[folder]))
+				setCurrentMail(folder, data.find((m) => m.seen)?.name || null)
+
 			mailDetails.value?.reloadThread()
 		},
 	})

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -14,7 +14,7 @@
 				</div>
 			</template>
 		</Breadcrumbs>
-		<HeaderActions :current-folder="currentFolder" @reload-mails="reloadMails('Drafts')" />
+		<HeaderActions :current-folder="currentFolder" @reload-mails="reloadMails" />
 	</header>
 	<div v-if="mails[currentFolder].data" class="flex h-[calc(100vh-3.2rem)]">
 		<div

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -48,7 +48,7 @@
 			<MailDetails
 				ref="mailDetails"
 				:mail-i-d="currentMail[currentFolder]"
-				:type="getMailType()"
+				:type="getMailType() || doctype"
 				@reload-mails="reloadMails"
 				@mark-as-unread="setSeen.submit({ name: currentMail[currentFolder], seen: 0 })"
 			/>

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -120,7 +120,10 @@ interface SetSeenParams {
 
 const setSeen = createResource({
 	url: 'mail.api.mail.set_seen',
-	makeParams: (values: SetSeenParams) => ({ mail_type: doctype.value, ...values }),
+	makeParams: (values: SetSeenParams) => ({
+		mail_type: getMailType() || doctype.value,
+		...values,
+	}),
 	onSuccess: (data: SetSeenParams) => {
 		mails[currentFolder.value].data.find((m) => m.name === data.name).seen = data.seen
 		if (!data.seen) setCurrentMail(currentFolder.value, null)

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -14,7 +14,7 @@
 				</div>
 			</template>
 		</Breadcrumbs>
-		<HeaderActions @reload-mails="reloadMails('Drafts')" />
+		<HeaderActions :current-folder="currentFolder" @reload-mails="reloadMails('Drafts')" />
 	</header>
 	<div v-if="mails[currentFolder].data" class="flex h-[calc(100vh-3.2rem)]">
 		<div
@@ -97,11 +97,11 @@ const createMailResource = (folder: Folder) =>
 
 const mails = Object.fromEntries(folders.map((folder) => [folder, createMailResource(folder)]))
 
-const mailCountFilters = computed(() =>
-	currentFolder.value === 'Inbox'
-		? { receiver: user.data.name }
-		: { sender: user.data.name, folder: currentFolder.value },
-)
+const mailCountFilters = computed(() => ({
+	folder: currentFolder.value,
+	docstatus: ['!=', 2],
+	[currentFolder.value === 'Inbox' ? 'receiver' : 'sender']: user.data.name,
+}))
 
 const mailCount = createResource({
 	url: 'frappe.client.get_count',

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -49,7 +49,7 @@
 				ref="mailDetails"
 				:mail-i-d="currentMail[currentFolder]"
 				:type="doctype"
-				@reload-mails="reloadMails('Drafts')"
+				@reload-mails="reloadMails"
 				@mark-as-unread="
 					setSeen.submit({ mail_name: currentMail[currentFolder], seen_value: 0 })
 				"
@@ -83,7 +83,7 @@ const doctype = computed(() =>
 
 const mailDetails = ref<typeof MailDetails>()
 
-const folders: Folder[] = ['Inbox', 'Sent', 'Outbox', 'Drafts']
+const folders: Folder[] = ['Inbox', 'Sent', 'Outbox', 'Drafts', 'Trash']
 
 const createMailResource = (folder: Folder) =>
 	createListResource({
@@ -139,8 +139,8 @@ const markAsRead = (mail) => {
 	if (!mail.seen) setSeen.submit({ mail_name: mail.name, seen_value: 1 })
 }
 
-const reloadMails = (folder?: Folder) => {
-	if (folder && folder !== currentFolder.value) return
+const reloadMails = (folder: Folder = currentFolder.value) => {
+	if (folder !== currentFolder.value) return
 	mails[currentFolder.value].reload()
 	mailCount.reload()
 }

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -50,9 +50,7 @@
 				:mail-i-d="currentMail[currentFolder]"
 				:type="doctype"
 				@reload-mails="reloadMails"
-				@mark-as-unread="
-					setSeen.submit({ mail_name: currentMail[currentFolder], seen_value: 0 })
-				"
+				@mark-as-unread="setSeen.submit({ name: currentMail[currentFolder], seen: 0 })"
 			/>
 		</div>
 	</div>
@@ -121,23 +119,22 @@ const mailCount = createResource({
 })
 
 interface SetSeenParams {
-	mail_name: string
-	seen_value: 1 | 0
+	name: string
+	seen: 1 | 0
 }
 
 const setSeen = createResource({
 	url: 'mail.api.mail.set_seen',
 	makeParams: (values: SetSeenParams) => ({ mail_type: doctype.value, ...values }),
 	onSuccess: (data: SetSeenParams) => {
-		mails[currentFolder.value].data.find((m) => m.name === data.mail_name).seen =
-			data.seen_value
-		if (!data.seen_value) setCurrentMail(currentFolder.value, null)
+		mails[currentFolder.value].data.find((m) => m.name === data.name).seen = data.seen
+		if (!data.seen) setCurrentMail(currentFolder.value, null)
 	},
 })
 
 const openMail = (mail) => {
 	setCurrentMail(currentFolder.value, mail.name)
-	if (!mail.seen) setSeen.submit({ mail_name: mail.name, seen_value: 1 })
+	if (!mail.seen) setSeen.submit({ name: mail.name, seen: 1 })
 }
 
 const reloadMails = (folder: Folder = currentFolder.value) => {

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -3,7 +3,7 @@
 		class="sticky top-0 z-10 flex items-center justify-between border-b bg-white px-3 py-2.5 sm:px-5"
 	>
 		<Breadcrumbs :items="[{ label: currentFolder }]">
-			<template #suffix>
+			<template v-if="currentFolder !== 'Trash'" #suffix>
 				<div class="ml-2 self-end text-xs text-gray-600">
 					{{
 						__('{0} {1}', [
@@ -48,7 +48,7 @@
 			<MailDetails
 				ref="mailDetails"
 				:mail-i-d="currentMail[currentFolder]"
-				:type="doctype"
+				:type="getMailType()"
 				@reload-mails="reloadMails"
 				@mark-as-unread="setSeen.submit({ name: currentMail[currentFolder], seen: 0 })"
 			/>
@@ -105,7 +105,7 @@ const mailCountFilters = computed(() =>
 
 const mailCount = createResource({
 	url: 'frappe.client.get_count',
-	auto: true,
+	auto: currentFolder.value !== 'Trash',
 	makeParams: () => ({
 		doctype: doctype.value,
 		filters: mailCountFilters.value,
@@ -135,7 +135,7 @@ const openMail = (mail) => {
 const reloadMails = (folder: Folder = currentFolder.value) => {
 	if (folder !== currentFolder.value) return
 	mails[currentFolder.value].reload()
-	mailCount.reload()
+	if (currentFolder.value !== 'Trash') mailCount.reload()
 }
 
 watch(() => currentFolder.value, reloadMails, { immediate: true })
@@ -144,6 +144,10 @@ onMounted(() => {
 	socket.on('outgoing_mail_sent', () => reloadMails('Sent'))
 	socket.on('incoming_mail_received', () => reloadMails('Inbox'))
 })
+
+const getMailType = () =>
+	mails[currentFolder.value].data.find((m) => m.name === currentMail[currentFolder.value])
+		?.mail_type
 
 const loadMoreEmails = useDebounceFn(() => {
 	if (mails[currentFolder.value].hasNextPage) mails[currentFolder.value].next()

--- a/frontend/src/pages/MailFolderView.vue
+++ b/frontend/src/pages/MailFolderView.vue
@@ -27,15 +27,15 @@
 				:key="idx"
 				class="flex cursor-pointer flex-col space-y-1 rounded"
 				:class="{ 'bg-gray-100': mail.name == currentMail[currentFolder] }"
-				@click="setCurrentMail(currentFolder, mail.name)"
+				@click="openMail(mail)"
 			>
-				<SidebarDetail :mail="mail" @click="markAsRead(mail)" />
+				<SidebarDetail :mail="mail" />
 				<div
 					:class="{
 						'mx-4 h-[0.25px] border-b border-gray-100':
 							idx < mails[currentFolder].data.length - 1,
 					}"
-				></div>
+				/>
 			</div>
 		</div>
 		<div class="flex w-px cursor-col-resize justify-center" @mousedown="startResizing">
@@ -92,8 +92,9 @@ const createMailResource = (folder: Folder) =>
 		pageLength: 50,
 		cache: [`${folder}Mails`, user.data?.name],
 		onSuccess: (data) => {
-			if (!data.length) return
-			if (!currentMail[folder]) {
+			if (!data.length) return setCurrentMail(folder, null)
+
+			if (!data.some((m) => m.name === currentMail[folder])) {
 				const firstSeen = data.find((m) => m.seen)
 				if (firstSeen) setCurrentMail(folder, firstSeen.name)
 			}
@@ -130,12 +131,12 @@ const setSeen = createResource({
 	onSuccess: (data: SetSeenParams) => {
 		mails[currentFolder.value].data.find((m) => m.name === data.mail_name).seen =
 			data.seen_value
-		if (data.seen_value) mailDetails.value?.reloadThread()
-		else setCurrentMail(currentFolder.value, null)
+		if (!data.seen_value) setCurrentMail(currentFolder.value, null)
 	},
 })
 
-const markAsRead = (mail) => {
+const openMail = (mail) => {
+	setCurrentMail(currentFolder.value, mail.name)
 	if (!mail.seen) setSeen.submit({ mail_name: mail.name, seen_value: 1 })
 }
 

--- a/frontend/src/pages/dashboard/DomainView.vue
+++ b/frontend/src/pages/dashboard/DomainView.vue
@@ -134,10 +134,7 @@ const confirmDialogOptions = computed(() => ({
 			: `Are you sure you want to rotate the DKIM keys? This will generate new keys for email signing and may take up to 10 minutes to propagate across DNS servers. Emails sent during this period may fail DKIM verification.`,
 	),
 	size: 'xl',
-	icon: {
-		name: 'alert-triangle',
-		appearance: 'warning',
-	},
+	icon: { name: 'alert-triangle', appearance: 'warning' },
 	actions: [
 		{
 			label: __('Confirm'),

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -5,10 +5,8 @@ import { createResource } from 'frappe-ui'
 import router from '@/router'
 import { userStore } from '@/stores/user'
 
-import type { Folder } from '@/types'
-
 export const sessionStore = defineStore('mail-session', () => {
-	const { userResource, setCurrentMail } = userStore()
+	const { userResource } = userStore()
 
 	const sessionUser = () => {
 		const cookies = new URLSearchParams(document.cookie.split('; ').join('&'))
@@ -40,8 +38,6 @@ export const sessionStore = defineStore('mail-session', () => {
 	const logout = createResource({
 		url: 'logout',
 		onSuccess() {
-			const folders: Folder[] = ['Inbox', 'Sent', 'Outbox', 'Drafts', 'Trash']
-			folders.forEach((folder) => setCurrentMail(folder, null))
 			userResource.reset()
 			user.value = null
 			window.location.reload()

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -6,7 +6,7 @@ import frappe
 from bs4 import BeautifulSoup
 from frappe import _
 from frappe.translate import get_all_translations
-from frappe.utils import is_html
+from frappe.utils import is_html, now
 
 from mail.utils.cache import get_account_for_user, get_default_outgoing_email_for_user
 from mail.utils.user import get_user_email_addresses, has_role, is_system_manager
@@ -548,11 +548,14 @@ def set_folder(mail_type: MailType, name: str, move_to_trash: bool = False) -> N
 
 	if move_to_trash:
 		doc.db_set("folder", "Trash")
-	elif mail_type == "Incoming Mail":
-		doc.db_set("folder", "Inbox")
+		doc.db_set("trashed_on", now())
 	else:
-		doc.folder = None
-		doc.set_folder(db_set=True)
+		doc.db_set("trashed_on")
+		if mail_type == "Incoming Mail":
+			doc.db_set("folder", "Inbox")
+		else:
+			doc.folder = None
+			doc.set_folder(db_set=True)
 
 
 @frappe.whitelist()

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -511,7 +511,7 @@ def get_mime_message(mail_type: MailType, name: str) -> dict:
 
 
 @frappe.whitelist()
-def set_seen(mail_type: MailType, name: str, seen: int) -> str:
+def set_seen(mail_type: MailType, name: str, seen: int) -> dict:
 	"""Sets seen for mail."""
 
 	doc = frappe.get_doc(mail_type, name)
@@ -520,11 +520,15 @@ def set_seen(mail_type: MailType, name: str, seen: int) -> str:
 
 
 @frappe.whitelist()
-def set_folder(mail_type: MailType, name: str, folder: Literal["Trash"] | None = None):
+def set_folder(mail_type: MailType, name: str, move_to_trash: bool = False) -> None:
 	"""Sets folder for mail."""
 
-	if mail_type == "Incoming Mail" and folder != "Trash":
-		folder = "Inbox"
-
 	doc = frappe.get_doc(mail_type, name)
-	doc.db_set("folder", folder)
+
+	if move_to_trash:
+		doc.db_set("folder", "Trash")
+	elif mail_type == "Incoming Mail":
+		doc.db_set("folder", "Inbox")
+	else:
+		doc.folder = None
+		doc.set_folder(db_set=True)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -122,6 +122,13 @@ def get_drafts_mails(start: int = 0) -> list:
 	return get_outgoing_mails("Drafts", start)
 
 
+@frappe.whitelist()
+def get_trash_mails(start: int = 0) -> list:
+	"""Returns trash mails for the current user."""
+
+	return get_outgoing_mails("Trash", start)
+
+
 def get_outgoing_mails(folder: str, start: int = 0) -> list:
 	"""Returns outgoing mails for the current user."""
 

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -1,5 +1,6 @@
 import re
 from email.utils import parseaddr
+from typing import Literal
 
 import frappe
 from bs4 import BeautifulSoup
@@ -9,6 +10,8 @@ from frappe.utils import is_html
 
 from mail.utils.cache import get_account_for_user, get_default_outgoing_email_for_user
 from mail.utils.user import get_user_email_addresses, has_role, is_system_manager
+
+MailType = Literal["Incoming Mail", "Outgoing Mail"]
 
 
 def check_app_permission() -> bool:
@@ -165,7 +168,7 @@ def get_outgoing_mails(folder: str, start: int = 0) -> list:
 	return get_mail_list(mails, "Outgoing Mail")
 
 
-def get_mail_list(mails, mail_type) -> list:
+def get_mail_list(mails, mail_type: MailType) -> list:
 	"""Returns a list of mails with additional details."""
 
 	for mail in mails[:]:
@@ -239,7 +242,7 @@ def get_snippet(content) -> str:
 
 
 @frappe.whitelist()
-def get_mail_thread(name, mail_type) -> list:
+def get_mail_thread(name, mail_type: MailType) -> list:
 	"""Returns the mail thread for the given mail."""
 
 	if not frappe.db.exists(mail_type, name):
@@ -287,7 +290,7 @@ def get_mail_thread(name, mail_type) -> list:
 	return thread
 
 
-def reverse_type(mail_type) -> str:
+def reverse_type(mail_type: MailType) -> str:
 	"""Returns the reverse mail type."""
 
 	return "Incoming Mail" if mail_type == "Outgoing Mail" else "Outgoing Mail"
@@ -302,7 +305,7 @@ def gather_thread_replies(mail_name) -> list:
 	return thread
 
 
-def get_thread_from_replies(mail_type, mail_name) -> list:
+def get_thread_from_replies(mail_type: MailType, mail_name) -> list:
 	"""Returns the thread from the replies."""
 
 	replies = []
@@ -315,7 +318,7 @@ def get_thread_from_replies(mail_type, mail_name) -> list:
 	return replies
 
 
-def find_replica(mail, mail_type) -> str:
+def find_replica(mail, mail_type: MailType) -> str:
 	"""Returns the replica of the mail."""
 
 	replica_type = reverse_type(mail_type)
@@ -474,7 +477,7 @@ def get_user_addresses():
 
 
 @frappe.whitelist()
-def get_mime_message(mail_type: str, name: str) -> dict:
+def get_mime_message(mail_type: MailType, name: str) -> dict:
 	"""Fetches mail mime message and related data."""
 
 	doc = frappe.get_doc(mail_type, name)
@@ -508,9 +511,20 @@ def get_mime_message(mail_type: str, name: str) -> dict:
 
 
 @frappe.whitelist()
-def set_seen(mail_type: str, mail_name: str, seen_value: int) -> str:
+def set_seen(mail_type: MailType, name: str, seen: int) -> str:
 	"""Sets seen for mail."""
 
-	doc = frappe.get_doc(mail_type, mail_name)
-	doc.db_set("seen", seen_value)
-	return {"mail_name": mail_name, "seen_value": seen_value}
+	doc = frappe.get_doc(mail_type, name)
+	doc.db_set("seen", seen)
+	return {"name": name, "seen": seen}
+
+
+@frappe.whitelist()
+def set_folder(mail_type: MailType, name: str, folder: Literal["Trash"] | None = None):
+	"""Sets folder for mail."""
+
+	if mail_type == "Incoming Mail" and folder != "Trash":
+		folder = "Inbox"
+
+	doc = frappe.get_doc(mail_type, name)
+	doc.db_set("folder", folder)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -545,6 +545,13 @@ def set_folder(mail_type: MailType, name: str, move_to_trash: bool = False) -> N
 
 
 @frappe.whitelist()
+def cancel_mail(mail_type: MailType, name: str) -> None:
+	"""Cancels mail."""
+
+	frappe.db.set_value(mail_type, name, "docstatus", 2)
+
+
+@frappe.whitelist()
 def empty_trash() -> None:
 	"""Empties trash for current user."""
 
@@ -561,4 +568,4 @@ def empty_trash() -> None:
 			pluck="name",
 		)
 		for d in mails:
-			frappe.db.set_value(doctype, d, "docstatus", 2)
+			cancel_message(doctype, d)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -200,6 +200,17 @@ def get_mail_list(mails) -> list:
 	return mails
 
 
+def has_in_reply_to_mail(mail) -> bool:
+	"""Check if the mail is a reply to an existing mail."""
+
+	if not mail.in_reply_to_mail_name:
+		return False
+
+	return frappe.db.exists(
+		mail.in_reply_to_mail_type, {"name": mail.in_reply_to_mail_name, "docstatus": ("!=", 2)}
+	)
+
+
 def get_list_thread(mail) -> list:
 	"""Returns a list of mails in the thread."""
 
@@ -212,7 +223,7 @@ def get_list_thread(mail) -> list:
 		processed.add(mail.name)
 		thread.append(mail)
 
-		if mail.in_reply_to_mail_name:
+		if has_in_reply_to_mail(mail):
 			reply_mail = get_mail_details(mail.in_reply_to_mail_name, mail.in_reply_to_mail_type, False)
 			add_to_thread(reply_mail)
 		if mail.message_id:
@@ -275,7 +286,7 @@ def get_mail_thread(name, mail_type: MailType) -> list:
 			return
 		visited.add(mail.name)
 
-		if mail.in_reply_to_mail_name:
+		if has_in_reply_to_mail(mail):
 			reply_mail = get_mail_details(mail.in_reply_to_mail_name, mail.in_reply_to_mail_type, True)
 			get_thread(reply_mail, thread)
 
@@ -568,4 +579,4 @@ def empty_trash() -> None:
 			pluck="name",
 		)
 		for d in mails:
-			cancel_message(doctype, d)
+			cancel_mail(doctype, d)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -155,7 +155,7 @@ def get_outgoing_mails(folder: str, start: int = 0, get_list: bool = True) -> li
 
 	mails = frappe.get_all(
 		"Outgoing Mail",
-		{"sender": account, "folder": folder},
+		{"sender": account, "docstatus": ["!=", 2], "folder": folder},
 		[
 			"name",
 			"subject",
@@ -542,3 +542,23 @@ def set_folder(mail_type: MailType, name: str, move_to_trash: bool = False) -> N
 	else:
 		doc.folder = None
 		doc.set_folder(db_set=True)
+
+
+@frappe.whitelist()
+def empty_trash() -> None:
+	"""Empties trash for current user."""
+
+	account = get_account_for_user(frappe.session.user)
+
+	for doctype in ["Incoming Mail", "Outgoing Mail"]:
+		mails = frappe.get_all(
+			doctype,
+			{
+				"receiver" if doctype == "Incoming Mail" else "sender": account,
+				"folder": "Trash",
+				"docstatus": ["!=", 2],
+			},
+			pluck="name",
+		)
+		for d in mails:
+			frappe.db.set_value(doctype, d, "docstatus", 2)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -105,14 +105,13 @@ def get_drafts_mails(start: int = 0) -> list:
 def get_trash_mails(start: int = 0) -> list:
 	"""Returns trash mails for the current user."""
 
-	all_mails = get_incoming_mails("Trash", start) + get_outgoing_mails("Trash", start)
-	all_mails.sort(key=lambda x: x.creation, reverse=True)
+	trash_mails = get_incoming_mails("Trash", start, False) + get_outgoing_mails("Trash", start, False)
+	trash_mails.sort(key=lambda x: x.creation, reverse=True)
 
-	return all_mails
+	return get_mail_list(trash_mails)
 
 
-@frappe.whitelist()
-def get_incoming_mails(folder: str, start: int = 0) -> list:
+def get_incoming_mails(folder: str, start: int = 0, get_list: bool = True) -> list:
 	"""Returns incoming mails for the current user."""
 
 	account = get_account_for_user(frappe.session.user)
@@ -133,16 +132,17 @@ def get_incoming_mails(folder: str, start: int = 0) -> list:
 			"type",
 			"seen",
 			"message_id",
+			"'Incoming Mail' as mail_type",
 		],
 		limit=50,
 		start=start,
 		order_by="created_at desc",
 	)
 
-	return get_mail_list(mails, "Incoming Mail")
+	return get_mail_list(mails) if get_list else mails
 
 
-def get_outgoing_mails(folder: str, start: int = 0) -> list:
+def get_outgoing_mails(folder: str, start: int = 0, get_list: bool = True) -> list:
 	"""Returns outgoing mails for the current user."""
 
 	account = get_account_for_user(frappe.session.user)
@@ -169,20 +169,20 @@ def get_outgoing_mails(folder: str, start: int = 0) -> list:
 			"status",
 			"message_id",
 			"seen",
+			"'Outgoing Mail' as mail_type",
 		],
 		limit=50,
 		start=start,
 		order_by=order_by,
 	)
 
-	return get_mail_list(mails, "Outgoing Mail")
+	return get_mail_list(mails) if get_list else mails
 
 
-def get_mail_list(mails, mail_type: MailType) -> list:
+def get_mail_list(mails) -> list:
 	"""Returns a list of mails with additional details."""
 
 	for mail in mails[:]:
-		mail.mail_type = mail_type
 		thread = get_list_thread(mail)
 		thread_with_names = [email.name for email in thread]
 		mails_in_original_list = [email for email in mails if email.name in thread_with_names]

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -75,33 +75,9 @@ def get_translations() -> dict:
 
 @frappe.whitelist()
 def get_inbox_mails(start: int = 0) -> list:
-	"""Returns incoming mails for the current user."""
+	"""Returns inbox mails for the current user."""
 
-	account = get_account_for_user(frappe.session.user)
-	mails = frappe.get_all(
-		"Incoming Mail",
-		{"receiver": account, "docstatus": 1},
-		[
-			"name",
-			"sender",
-			"body_html",
-			"body_plain",
-			"display_name",
-			"subject",
-			"creation",
-			"in_reply_to_mail_name",
-			"in_reply_to_mail_type",
-			"status",
-			"type",
-			"seen",
-			"message_id",
-		],
-		limit=50,
-		start=start,
-		order_by="created_at desc",
-	)
-
-	return get_mail_list(mails, "Incoming Mail")
+	return get_incoming_mails("Inbox", start)
 
 
 @frappe.whitelist()
@@ -129,7 +105,41 @@ def get_drafts_mails(start: int = 0) -> list:
 def get_trash_mails(start: int = 0) -> list:
 	"""Returns trash mails for the current user."""
 
-	return get_outgoing_mails("Trash", start)
+	all_mails = get_incoming_mails("Trash", start) + get_outgoing_mails("Trash", start)
+	all_mails.sort(key=lambda x: x.creation, reverse=True)
+
+	return all_mails
+
+
+@frappe.whitelist()
+def get_incoming_mails(folder: str, start: int = 0) -> list:
+	"""Returns incoming mails for the current user."""
+
+	account = get_account_for_user(frappe.session.user)
+	mails = frappe.get_all(
+		"Incoming Mail",
+		{"receiver": account, "docstatus": 1, "folder": folder},
+		[
+			"name",
+			"sender",
+			"body_html",
+			"body_plain",
+			"display_name",
+			"subject",
+			"creation",
+			"in_reply_to_mail_name",
+			"in_reply_to_mail_type",
+			"status",
+			"type",
+			"seen",
+			"message_id",
+		],
+		limit=50,
+		start=start,
+		order_by="created_at desc",
+	)
+
+	return get_mail_list(mails, "Incoming Mail")
 
 
 def get_outgoing_mails(folder: str, start: int = 0) -> list:

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -209,6 +209,7 @@ scheduler_events = {
 	# ],
 	"daily": [
 		"mail.tasks.enqueue_delete_newsletters",
+		"mail.tasks.enqueue_cancel_trashed_mails",
 	],
 	# "hourly": [
 	#     "mail.tasks.hourly"

--- a/mail/mail/doctype/incoming_mail/incoming_mail.js
+++ b/mail/mail/doctype/incoming_mail/incoming_mail.js
@@ -6,6 +6,13 @@ frappe.ui.form.on('Incoming Mail', {
 		frm.trigger('add_actions')
 	},
 
+	folder(frm) {
+		frm.set_value(
+			'trashed_on',
+			frm.doc.folder === 'Trash' ? frappe.datetime.now_datetime() : null,
+		)
+	},
+
 	add_actions(frm) {
 		if (frm.doc.docstatus === 1) {
 			frm.add_custom_button(

--- a/mail/mail/doctype/incoming_mail/incoming_mail.json
+++ b/mail/mail/doctype/incoming_mail/incoming_mail.json
@@ -6,6 +6,7 @@
  "field_order": [
   "type",
   "folder",
+  "trashed_on",
   "sender",
   "display_name",
   "reply_to",
@@ -445,6 +446,13 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Seen"
+  },
+  {
+   "depends_on": "eval: doc.folder == 'Trash'",
+   "fieldname": "trashed_on",
+   "fieldtype": "Datetime",
+   "label": "Trashed On",
+   "read_only": 1
   }
  ],
  "in_create": 1,
@@ -457,7 +465,7 @@
    "link_fieldname": "incoming_mail"
   }
  ],
- "modified": "2025-02-21 13:06:08.439042",
+ "modified": "2025-03-06 11:20:37.493167",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Incoming Mail",
@@ -493,6 +501,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/mail/mail/doctype/incoming_mail/incoming_mail.py
+++ b/mail/mail/doctype/incoming_mail/incoming_mail.py
@@ -374,15 +374,14 @@ def fetch_emails_from_mail_agents(
 	if not accounts:
 		return
 
-	if frappe.flags.do_not_enqueue:
-		for group in agent_groups:
-			fetch_emails_from_mail_agent(group, accounts)
-	else:
-		for group in agent_groups:
-			frappe.enqueue(
-				fetch_emails_from_mail_agent,
-				queue="long",
-				job_name=f"Fetch Emails from {group}",
-				agent_group=group,
-				accounts=accounts,
-			)
+	for group in agent_groups:
+		fetch_emails_from_mail_agent(group, accounts)
+	# else:
+	# 	for group in agent_groups:
+	# 		frappe.enqueue(
+	# 			fetch_emails_from_mail_agent,
+	# 			queue="long",
+	# 			job_name=f"Fetch Emails from {group}",
+	# 			agent_group=group,
+	# 			accounts=accounts,
+	# )

--- a/mail/mail/doctype/incoming_mail/incoming_mail.py
+++ b/mail/mail/doctype/incoming_mail/incoming_mail.py
@@ -374,14 +374,15 @@ def fetch_emails_from_mail_agents(
 	if not accounts:
 		return
 
-	for group in agent_groups:
-		fetch_emails_from_mail_agent(group, accounts)
-	# else:
-	# 	for group in agent_groups:
-	# 		frappe.enqueue(
-	# 			fetch_emails_from_mail_agent,
-	# 			queue="long",
-	# 			job_name=f"Fetch Emails from {group}",
-	# 			agent_group=group,
-	# 			accounts=accounts,
-	# )
+	if frappe.flags.do_not_enqueue:
+		for group in agent_groups:
+			fetch_emails_from_mail_agent(group, accounts)
+	else:
+		for group in agent_groups:
+			frappe.enqueue(
+				fetch_emails_from_mail_agent,
+				queue="long",
+				job_name=f"Fetch Emails from {group}",
+				agent_group=group,
+				accounts=accounts,
+			)

--- a/mail/mail/doctype/outgoing_mail/outgoing_mail.js
+++ b/mail/mail/doctype/outgoing_mail/outgoing_mail.js
@@ -9,6 +9,13 @@ frappe.ui.form.on('Outgoing Mail', {
 		frm.trigger('set_from_')
 	},
 
+	folder(frm) {
+		frm.set_value(
+			'trashed_on',
+			frm.doc.folder === 'Trash' ? frappe.datetime.now_datetime() : null,
+		)
+	},
+
 	hide_amend_button(frm) {
 		if (frm.doc.docstatus == 2) {
 			frm.page.btn_primary.hide()

--- a/mail/mail/doctype/outgoing_mail/outgoing_mail.json
+++ b/mail/mail/doctype/outgoing_mail/outgoing_mail.json
@@ -5,6 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "folder",
+  "trashed_on",
   "sender",
   "from_",
   "display_name",
@@ -594,13 +595,20 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Seen"
+  },
+  {
+   "depends_on": "eval: doc.folder == 'Trash'",
+   "fieldname": "trashed_on",
+   "fieldtype": "Datetime",
+   "label": "Trashed On",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-28 16:05:42.180799",
+ "modified": "2025-03-06 11:20:19.735257",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Outgoing Mail",

--- a/mail/mail/doctype/outgoing_mail/outgoing_mail.py
+++ b/mail/mail/doctype/outgoing_mail/outgoing_mail.py
@@ -141,15 +141,14 @@ class OutgoingMail(Document):
 	def set_folder(self, db_set: bool = False) -> None:
 		"""Validates the folder"""
 
-		if self.docstatus == 0:
-			self.folder = "Drafts"
-		elif self.docstatus == 1:
-			if self.status != "Sent":
-				self.folder = "Outbox"
-			elif self.folder != "Trash":
-				self.folder = "Sent"
-		else:
+		if self.docstatus == 2:
 			return
+
+		if self.folder != "Trash":
+			if self.docstatus == 0:
+				self.folder = "Drafts"
+			else:
+				self.folder = "Sent" if self.status == "Sent" else "Outbox"
 
 		if db_set:
 			self._db_set(folder=self.folder, notify_update=True)

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -27,8 +27,7 @@ def enqueue_fetch_emails_from_mail_agents() -> None:
 	"Called by the scheduler to enqueue the `fetch_emails_from_mail_agents` job."
 
 	frappe.session.user = "Administrator"
-	fetch_emails_from_mail_agents()
-	# enqueue_job(fetch_emails_from_mail_agents, queue="long", deduplicate=True)
+	enqueue_job(fetch_emails_from_mail_agents, queue="long", deduplicate=True)
 
 
 @frappe.whitelist()

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -27,7 +27,8 @@ def enqueue_fetch_emails_from_mail_agents() -> None:
 	"Called by the scheduler to enqueue the `fetch_emails_from_mail_agents` job."
 
 	frappe.session.user = "Administrator"
-	enqueue_job(fetch_emails_from_mail_agents, queue="long", deduplicate=True)
+	fetch_emails_from_mail_agents()
+	# enqueue_job(fetch_emails_from_mail_agents, queue="long", deduplicate=True)
 
 
 @frappe.whitelist()

--- a/mail/tasks.py
+++ b/mail/tasks.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import add_days, now
 
 from mail.mail.doctype.dns_record.dns_record import verify_all_dns_records
 from mail.mail.doctype.incoming_mail.incoming_mail import fetch_emails_from_mail_agents
@@ -38,3 +39,27 @@ def enqueue_verify_all_dns_records() -> None:
 
 	frappe.session.user = "Administrator"
 	enqueue_job(verify_all_dns_records, queue="long", deduplicate=True)
+
+
+def enqueue_cancel_trashed_mails() -> None:
+	"Called by the scheduler to enqueue the `cancel_trash_mails` job."
+
+	def cancel_trashed_mails() -> None:
+		"""Cancels mails that got trashed more than 30 days ago."""
+
+		thirty_days_ago = add_days(now(), -30)
+
+		for doctype in ["Incoming Mail", "Outgoing Mail"]:
+			mails = frappe.get_all(
+				doctype,
+				{
+					"folder": "Trash",
+					"trashed_on": ["<=", thirty_days_ago],
+					"docstatus": ["!=", 2],
+				},
+				pluck="name",
+			)
+			for d in mails:
+				frappe.db.set_value(doctype, d, "docstatus", 2)
+
+	enqueue_job(cancel_trashed_mails, queue="long", deduplicate=True)


### PR DESCRIPTION
- Mails can be moved to Trash from where they can be cancelled (Cancelled mails are not shown in the UI and, for the user, appear as 'deleted')
- Trashed mails can be restored to their previous folder or deleted (cancelled) permanently
- Mails that have been lying in the Trash for 30 days will be automatically deleted
- All mail actions can be performed from the Trash except for editing of drafts
- If a mail from a thread is deleted, the thread will be broken into two parts and so on
- 'Empty Trash' button deletes all Trash mails
- Trashed mails are greyed out in the UI (will work on cleaning up 'MailDetails' view later)

![image](https://github.com/user-attachments/assets/ad0795c4-b1be-40ab-a20c-a6b753a86209)
