### PR TITLE
feat: outbound-only Mail Server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           check-latest: true
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}

--- a/mail/mail/doctype/mail_server/mail_server.json
+++ b/mail/mail/doctype/mail_server/mail_server.json
@@ -8,6 +8,7 @@
   "details_tab",
   "section_break_excr",
   "enabled",
+  "outbound_only",
   "column_break_0mtp",
   "cluster",
   "server",
@@ -177,6 +178,13 @@
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "description": "Disable email delivery to local domains and perform an MX lookup to route emails externally.",
+   "fieldname": "outbound_only",
+   "fieldtype": "Check",
+   "label": "Outbound Only"
   }
  ],
  "grid_page_length": 50,
@@ -188,7 +196,7 @@
    "link_fieldname": "server"
   }
  ],
- "modified": "2025-03-06 16:36:47.193594",
+ "modified": "2025-03-11 14:52:11.298876",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Server",

--- a/mail/mail/doctype/mail_server_config/mail_server_config.py
+++ b/mail/mail/doctype/mail_server_config/mail_server_config.py
@@ -135,11 +135,15 @@ def get_config_toml(server: str) -> str | None:
 		num_digits = len(str(len(seed_nodes) - 1))
 		return {f"{str(i).zfill(num_digits)}": v for i, v in enumerate(seed_nodes)}
 
-	def get_local_keys() -> dict:
+	def get_local_keys(outbound_only: bool = False) -> dict:
 		"""Returns the local keys for the configuration."""
 
-		num_digits = len(str(len(LOCAL_KEYS) - 1))
-		return {f"{str(i).zfill(num_digits)}": v for i, v in enumerate(LOCAL_KEYS)}
+		local_keys = LOCAL_KEYS
+		if outbound_only:
+			local_keys.extend(["session.rcpt.directory", "queue.outbound.next-hop"])
+
+		num_digits = len(str(len(local_keys) - 1))
+		return {f"{str(i).zfill(num_digits)}": v for i, v in enumerate(local_keys)}
 
 	def get_stores(stores: list) -> dict:
 		"""Returns the store configuration for the Mail Server."""
@@ -229,7 +233,7 @@ def get_config_toml(server: str) -> str | None:
 			"seed-nodes": get_seed_nodes(server.name, cluster.name),
 		},
 		"config": {
-			"local-keys": get_local_keys(),
+			"local-keys": get_local_keys(bool(server.outbound_only)),
 		},
 		"directory": {
 			f"{cluster.directory_storage}": {
@@ -284,6 +288,10 @@ def get_config_toml(server: str) -> str | None:
 			}
 		},
 	}
+
+	if server.outbound_only:
+		config.setdefault("session", {}).setdefault("rcpt", {})["directory"] = False
+		config.setdefault("queue", {}).setdefault("outbound", {})["next-hop"] = False
 
 	toml_lines = []
 	for key, value in sorted(flatten_dict(config).items()):


### PR DESCRIPTION
```text 
config.local-keys.21 = "session.rcpt.directory"
config.local-keys.22 = "queue.outbound.next-hop"
queue.outbound.next-hop = false
session.rcpt.directory = false
```
Adds ^ if `MailServer.outbound_only` is checked.