### PR TITLE
feat: settings to enable Personal Signup

### DIFF
--- a/mail/install.py
+++ b/mail/install.py
@@ -47,4 +47,5 @@ def create_default_tenant() -> None:
 	tenant = frappe.new_doc("Mail Tenant")
 	tenant.tenant_name = "Frappe Mail"
 	tenant.user = "Administrator"
+	tenant.allow_personal_signup = 1
 	tenant.insert(ignore_permissions=True)

--- a/mail/mail/doctype/mail_settings/mail_settings.js
+++ b/mail/mail/doctype/mail_settings/mail_settings.js
@@ -2,8 +2,22 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Mail Settings', {
+	setup(frm) {
+		frm.trigger('set_queries')
+	},
+
 	refresh(frm) {
 		frm.trigger('add_comments')
+	},
+
+	set_queries(frm) {
+		frm.set_query('personal_signup_domains', () => ({
+			query: 'mail.utils.query.get_personal_signup_domains',
+			filters: {
+				enabled: 1,
+				is_verified: 1,
+			},
+		}))
 	},
 
 	add_comments(frm) {

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -55,7 +55,13 @@
   "enable_spamd_for_outbound",
   "spamd_outbound_block",
   "column_break_lhy4",
-  "spamd_outbound_threshold"
+  "spamd_outbound_threshold",
+  "client_tab",
+  "signup_section",
+  "allow_self_signup",
+  "column_break_daqm",
+  "allow_personal_signup",
+  "personal_signup_domains"
  ],
  "fields": [
   {
@@ -432,12 +438,47 @@
    "label": "Idle Session Timeout (Seconds)",
    "non_negative": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "client_tab",
+   "fieldtype": "Tab Break",
+   "label": "Client"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_self_signup",
+   "fieldtype": "Check",
+   "label": "Allow Self Signup"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.allow_self_signup",
+   "fieldname": "allow_personal_signup",
+   "fieldtype": "Check",
+   "label": "Allow Personal Signup"
+  },
+  {
+   "fieldname": "signup_section",
+   "fieldtype": "Section Break",
+   "label": "Signup"
+  },
+  {
+   "fieldname": "column_break_daqm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.allow_self_signup && doc.allow_personal_signup",
+   "fieldname": "personal_signup_domains",
+   "fieldtype": "Table MultiSelect",
+   "label": "Personal Signup Domains",
+   "mandatory_depends_on": "eval: doc.allow_self_signup && doc.allow_personal_signup",
+   "options": "Personal Signup Domain"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-02-13 15:46:36.560834",
+ "modified": "2025-03-26 11:48:26.531773",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",
@@ -454,6 +495,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -446,6 +446,7 @@
   },
   {
    "default": "0",
+   "description": "Allows users to sign up from the Mail UI.",
    "fieldname": "allow_self_signup",
    "fieldtype": "Check",
    "label": "Allow Self Signup"
@@ -453,6 +454,7 @@
   {
    "default": "0",
    "depends_on": "eval: doc.allow_self_signup",
+   "description": "Allows users to sign up for personal use and select a preferred username.",
    "fieldname": "allow_personal_signup",
    "fieldtype": "Check",
    "label": "Allow Personal Signup"
@@ -468,6 +470,7 @@
   },
   {
    "depends_on": "eval: doc.allow_self_signup && doc.allow_personal_signup",
+   "description": "Domains allowed for personal signup.",
    "fieldname": "personal_signup_domains",
    "fieldtype": "Table MultiSelect",
    "label": "Personal Signup Domains",
@@ -478,7 +481,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-26 11:48:26.531773",
+ "modified": "2025-03-26 12:54:30.461350",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -13,6 +13,7 @@ class MailSettings(Document):
 		self.validate_root_domain_name()
 		self.validate_dns_provider()
 		self.validate_spf_host()
+		self.validate_personal_signup_domains()
 
 	def on_update(self) -> None:
 		self.clear_cache()
@@ -65,6 +66,30 @@ class MailSettings(Document):
 				frappe.delete_doc("DNS Record", spf_dns_record, ignore_permissions=True)
 
 		create_or_update_spf_dns_record(self.spf_host)
+
+	def validate_personal_signup_domains(self) -> None:
+		"""Validates the Personal Signup Domains."""
+
+		if not self.personal_signup_domains:
+			return
+
+		for signup_domain in self.personal_signup_domains:
+			enabled, is_verified, tenant = frappe.db.get_value(
+				"Mail Domain", signup_domain.domain_name, ["enabled", "is_verified", "tenant"]
+			)
+
+			if not frappe.db.get_value("Mail Tenant", tenant, "allow_personal_signup"):
+				frappe.throw(
+					_("Personal Signup is not allowed for the Mail Domain {0}.").format(
+						frappe.bold(signup_domain.domain_name)
+					)
+				)
+			elif not enabled:
+				frappe.throw(_("Mail Domain {0} is disabled.").format(frappe.bold(signup_domain.domain_name)))
+			elif not is_verified:
+				frappe.throw(
+					_("Mail Domain {0} is not verified.").format(frappe.bold(signup_domain.domain_name))
+				)
 
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""

--- a/mail/mail/doctype/mail_tenant/mail_tenant.json
+++ b/mail/mail/doctype/mail_tenant/mail_tenant.json
@@ -9,6 +9,7 @@
   "user",
   "logo",
   "column_break_kaqu",
+  "allow_personal_signup",
   "max_domains",
   "max_accounts",
   "max_groups"
@@ -68,6 +69,14 @@
    "permlevel": 1,
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_personal_signup",
+   "fieldtype": "Check",
+   "label": "Allow Personal Signup",
+   "permlevel": 1,
+   "search_index": 1
   }
  ],
  "image_field": "logo",
@@ -109,7 +118,7 @@
    "link_fieldname": "tenant"
   }
  ],
- "modified": "2025-02-05 10:27:16.023689",
+ "modified": "2025-03-26 11:30:38.129809",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Tenant",
@@ -161,6 +170,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/mail/mail/doctype/personal_signup_domain/personal_signup_domain.json
+++ b/mail/mail/doctype/personal_signup_domain/personal_signup_domain.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-03-26 11:42:30.621300",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "domain_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "domain_name",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Domain Name",
+   "options": "Mail Domain",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-03-26 11:43:10.481605",
+ "modified_by": "Administrator",
+ "module": "Mail",
+ "name": "Personal Signup Domain",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/mail/doctype/personal_signup_domain/personal_signup_domain.py
+++ b/mail/mail/doctype/personal_signup_domain/personal_signup_domain.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PersonalSignupDomain(Document):
+	pass

--- a/mail/utils/cache.py
+++ b/mail/utils/cache.py
@@ -43,6 +43,16 @@ def get_imap_limits() -> dict:
 	return frappe.cache.hget("mail-settings", "imap_limits", generator)
 
 
+def get_personal_signup_domains() -> list:
+	"""Returns the personal signup domains."""
+
+	def generator() -> list:
+		mail_settings = frappe.get_cached_doc("Mail Settings")
+		return [signup_domain.domain_name for signup_domain in mail_settings.personal_signup_domains]
+
+	return frappe.cache.hget("mail-settings", "personal_signup_domains", generator)
+
+
 def get_domains_owned_by_tenant(tenant: str) -> list:
 	"""Returns the domains owned by the tenant."""
 

--- a/mail/utils/query.py
+++ b/mail/utils/query.py
@@ -102,3 +102,31 @@ def get_users_with_mail_user_role(
 			& (HAS_ROLE.parenttype == "User")
 		)
 	).run(as_dict=False)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_personal_signup_domains(
+	doctype: str | None = None,
+	txt: str | None = None,
+	searchfield: str | None = None,
+	start: int = 0,
+	page_len: int = 20,
+	filters: dict | None = None,
+) -> list:
+	"""Returns a list of Mail Domains that allow personal signup."""
+
+	MAIL_DOMAIN = frappe.qb.DocType("Mail Domain")
+	MAIL_TENANT = frappe.qb.DocType("Mail Tenant")
+	return (
+		frappe.qb.from_(MAIL_DOMAIN)
+		.left_join(MAIL_TENANT)
+		.on(MAIL_DOMAIN.tenant == MAIL_TENANT.name)
+		.select(MAIL_DOMAIN.name)
+		.where(
+			(MAIL_DOMAIN.enabled == 1)
+			& (MAIL_DOMAIN.is_verified == 1)
+			& (MAIL_DOMAIN.name.like(f"%{txt}%"))
+			& (MAIL_TENANT.allow_personal_signup == 1)
+		)
+	).run(as_dict=False)


### PR DESCRIPTION
- [x] `Allow Personal Signup` field in Mail Tenant.
- [x] Check `Allow Personal Signup` for `Frappe Mail` Tenant.
- [x] Mail Settings > Client
   - [x] `Allow Self Signup` check field.
   - [x] `Allow Personal Signup` field.
   - [x] `Personal Signup Domains` field.
   - [x] Add field description.
- [x] `set_query` for `Personal Signup Domains`.
- [x] Validate `Personal Signup Domains`.
- [x] Cache `Personal Signup Domains`.

![image](https://github.com/user-attachments/assets/03be5000-abc9-4d8f-ae4e-8497a61f4ca8)

Part of: https://github.com/frappe/mail/issues/144
