### PR TITLE
refactor: use `dns-lexicon` to manage DNS Records

### DIFF
--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -43,13 +43,15 @@ class DNSProvider:
 		self,
 		provider: DNSProviderLiteral,
 		domain: str,
-		username: str | None = None,
-		password: str | None = None,
+		access_key: str | None = None,
+		access_secret: str | None = None,
 		auth_key: str | None = None,
 		auth_secret: str | None = None,
+		username: str | None = None,
 		token: str | None = None,
 		client_ip: str | None = None,
 		zone_id: str | None = None,
+		private_zone: bool = False,
 	) -> None:
 		"""Initializes the DNSProvider with credentials and domain."""
 
@@ -58,13 +60,15 @@ class DNSProvider:
 
 		self.provider = DNS_PROVIDER_MAP[provider]
 		self.domain = domain
-		self.__username = username
-		self.__password = password
+		self.__access_key = access_key
+		self.__access_secret = access_secret
 		self.__auth_key = auth_key
 		self.__auth_secret = auth_secret
+		self.__username = username
 		self.__token = token
 		self.client_ip = client_ip
 		self.zone_id = zone_id
+		self.private_zone = private_zone
 
 	def get_client(self, config: dict) -> Client:
 		"""Internal helper to return a configured Lexicon client."""
@@ -73,13 +77,15 @@ class DNSProvider:
 			{
 				"provider_name": self.provider,
 				"domain": self.domain,
-				"auth_username": self.__username,
-				"auth_password": self.__password,
+				"auth_access_key": self.__access_key,
+				"auth_access_secret": self.__access_secret,
 				"auth_key": self.__auth_key,
 				"auth_secret": self.__auth_secret,
+				"auth_username": self.__username,
 				"auth_token": self.__token,
 				"auth_client_ip": self.client_ip,
 				"zone_id": self.zone_id,
+				"private_zone": self.private_zone,
 			}
 		)
 		client = Client(config)

--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -30,7 +30,7 @@ DNS_PROVIDER_MAP = {
 	DNSProviderEnum.DIGITALOCEAN: "digitalocean",
 	DNSProviderEnum.CLOUDFLARE: "cloudflare",
 	DNSProviderEnum.HETZNER: "hetzner",
-	DNSProviderEnum.LINODE: "linode4",
+	DNSProviderEnum.LINODE: "linode",
 	DNSProviderEnum.NAMECHEAP: "namecheap",
 	DNSProviderEnum.GODADDY: "godaddy",
 }

--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -48,6 +48,7 @@ class DNSProvider:
 		auth_key: str | None = None,
 		auth_secret: str | None = None,
 		token: str | None = None,
+		client_ip: str | None = None,
 		zone_id: str | None = None,
 	) -> None:
 		"""Initializes the DNSProvider with credentials and domain."""
@@ -62,6 +63,7 @@ class DNSProvider:
 		self.__auth_key = auth_key
 		self.__auth_secret = auth_secret
 		self.__token = token
+		self.client_ip = client_ip
 		self.zone_id = zone_id
 
 	def get_client(self, config: dict) -> Client:
@@ -76,6 +78,7 @@ class DNSProvider:
 				"auth_key": self.__auth_key,
 				"auth_secret": self.__auth_secret,
 				"auth_token": self.__token,
+				"auth_client_ip": self.client_ip,
 				"zone_id": self.zone_id,
 			}
 		)

--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -45,6 +45,8 @@ class DNSProvider:
 		domain: str,
 		username: str | None = None,
 		password: str | None = None,
+		auth_key: str | None = None,
+		auth_secret: str | None = None,
 		token: str | None = None,
 		zone_id: str | None = None,
 	) -> None:
@@ -57,6 +59,8 @@ class DNSProvider:
 		self.domain = domain
 		self.__username = username
 		self.__password = password
+		self.__auth_key = auth_key
+		self.__auth_secret = auth_secret
 		self.__token = token
 		self.zone_id = zone_id
 
@@ -69,6 +73,8 @@ class DNSProvider:
 				"domain": self.domain,
 				"auth_username": self.__username,
 				"auth_password": self.__password,
+				"auth_key": self.__auth_key,
+				"auth_secret": self.__auth_secret,
 				"auth_token": self.__token,
 				"zone_id": self.zone_id,
 			}

--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -1,143 +1,168 @@
-from abc import ABC, abstractmethod
+from enum import Enum
 from typing import Literal
 
-import digitalocean
+from lexicon.client import Client
 
 
-class BaseDNSProvider(ABC):
-	"""An abstract base class for DNS providers."""
-
-	@abstractmethod
-	def create_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Creates a DNS record."""
-		pass
-
-	@abstractmethod
-	def read_dns_records(self, domain: str) -> list:
-		"""Reads DNS records for a domain."""
-		pass
-
-	@abstractmethod
-	def update_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Updates a DNS record."""
-		pass
-
-	@abstractmethod
-	def delete_dns_record(self, domain: str, type: str, host: str) -> bool:
-		"""Deletes a DNS record."""
-		pass
+class DNSProviderEnum(str, Enum):
+	AMAZON_ROUTE53 = "AmazonRoute53"
+	DIGITALOCEAN = "DigitalOcean"
+	CLOUDFLARE = "Cloudflare"
+	HETZNER = "Hetzner"
+	LINODE = "Linode"
+	NAMECHEAP = "Namecheap"
+	GODADDY = "GoDaddy"
 
 
-class DigitalOceanDNS(BaseDNSProvider):
-	"""A DNS provider for DigitalOcean."""
+DNSProviderLiteral = Literal[
+	DNSProviderEnum.AMAZON_ROUTE53,
+	DNSProviderEnum.DIGITALOCEAN,
+	DNSProviderEnum.CLOUDFLARE,
+	DNSProviderEnum.HETZNER,
+	DNSProviderEnum.LINODE,
+	DNSProviderEnum.NAMECHEAP,
+	DNSProviderEnum.GODADDY,
+]
 
-	def __init__(self, token: str) -> None:
-		"""Initializes the DigitalOceanDNS provider."""
 
-		self.token = token
-
-	def create_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Creates a DNS record."""
-
-		record = (
-			digitalocean.Domain(token=self.token, name=domain)
-			.create_new_domain_record(type=type, name=host, data=value, priority=priority, ttl=ttl)
-			.get("domain_record", {})
-		)
-		return bool(record.get("id"))
-
-	def read_dns_records(self, domain: str) -> list:
-		"""Reads DNS records for a domain."""
-
-		return digitalocean.Domain(token=self.token, name=domain).get_records()
-
-	def update_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Updates a DNS record."""
-
-		records = self.read_dns_records(domain)
-		for record in records:
-			if record.name == host and record.type == type:
-				if record.data == value:
-					return True
-
-				record.data = value
-				record.priority = priority
-				record.ttl = ttl
-				record.save()
-
-				return True
-
-		return False
-
-	def delete_dns_record(self, domain: str, type: str, host: str) -> bool:
-		"""Deletes a DNS record."""
-
-		records = self.read_dns_records(domain)
-
-		if not records:
-			return True
-
-		for record in records:
-			if record.name == host and record.type == type:
-				record.destroy()
-				return True
-
-		return False
+DNS_PROVIDER_MAP = {
+	DNSProviderEnum.AMAZON_ROUTE53: "route53",
+	DNSProviderEnum.DIGITALOCEAN: "digitalocean",
+	DNSProviderEnum.CLOUDFLARE: "cloudflare",
+	DNSProviderEnum.HETZNER: "hetzner",
+	DNSProviderEnum.LINODE: "linode4",
+	DNSProviderEnum.NAMECHEAP: "namecheap",
+	DNSProviderEnum.GODADDY: "godaddy",
+}
 
 
 class DNSProvider:
-	"""A DNS provider class that uses a specific DNS provider."""
+	"""A DNS provider utility wrapper using Lexicon to interact with major DNS services."""
 
-	def __init__(self, provider: Literal["DigitalOcean"], token: str) -> None:
-		"""Initializes the DNS provider with the specified provider and token."""
+	def __init__(
+		self,
+		provider: DNSProviderLiteral,
+		domain: str,
+		username: str | None = None,
+		password: str | None = None,
+		token: str | None = None,
+	) -> None:
+		"""Initializes the DNSProvider with credentials and domain."""
 
-		self.provider = self._get_dns_provider(provider, token)
-
-	def _get_dns_provider(self, provider: str, token: str) -> BaseDNSProvider:
-		"""Returns the DNS provider based on the provider name."""
-
-		if provider == "DigitalOcean":
-			return DigitalOceanDNS(token=token)
-		else:
+		if provider not in DNS_PROVIDER_MAP:
 			raise ValueError(f"Unsupported DNS Provider: {provider}")
 
-	def create_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
-	) -> bool:
-		"""Creates a DNS record."""
+		self.provider = DNS_PROVIDER_MAP[provider]
+		self.domain = domain
+		self.__username = username
+		self.__password = password
+		self.__token = token
 
-		return self.provider.create_dns_record(domain, type, host, value, ttl, priority)
+	def get_client(self, config: dict) -> Client:
+		"""Internal helper to return a configured Lexicon client."""
 
-	def read_dns_records(self, domain: str) -> list:
-		"""Reads DNS records for a domain."""
+		config.update(
+			{
+				"provider_name": self.provider,
+				"domain": self.domain,
+				"auth_token": self.__token,
+				"auth_username": self.__username,
+				"auth_password": self.__password,
+			}
+		)
+		client = Client(config)
+		return client
 
-		return self.provider.read_dns_records(domain)
+	def create_dns_record(self, type: str, host: str, value: str, ttl: int, priority: int = 0) -> bool:
+		"""Creates a new DNS record."""
+
+		config = {
+			"action": "create",
+			"type": type,
+			"name": host,
+			"content": value,
+			"ttl": ttl,
+			"priority": priority,
+		}
+		client = self.get_client(config)
+		return client.execute()
+
+	def read_dns_records(self, type: str, host: str | None = None) -> list[dict]:
+		"""Fetches DNS records matching type and optional host."""
+
+		config = {
+			"action": "list",
+		}
+		if type:
+			config["type"] = type
+		if host:
+			config["name"] = host
+
+		client = self.get_client(config)
+		return client.execute()
 
 	def update_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
+		self,
+		type: str,
+		host: str,
+		value: str,
+		ttl: int,
+		priority: int = 0,
+		record_id: int | str | None = None,
 	) -> bool:
-		"""Updates a DNS record."""
+		"""Updates an existing DNS record."""
 
-		return self.provider.update_dns_record(domain, type, host, value, ttl, priority)
+		if not record_id:
+			records = self.read_dns_records(type=type, host=host)
+			if not records:
+				raise ValueError(f"No record found for {host}")
 
-	def delete_dns_record(self, domain: str, type: str, host: str) -> bool:
-		"""Deletes a DNS record."""
+			record_id = records[0]["id"]
 
-		return self.provider.delete_dns_record(domain, type, host)
+		config = {
+			"action": "update",
+			"type": type,
+			"name": host,
+			"content": value,
+			"ttl": ttl,
+			"priority": priority,
+			"identifier": record_id,
+		}
+		client = self.get_client(config)
+		return client.execute()
+
+	def delete_dns_record(self, type: str, host: str, delete_all: bool = False) -> bool:
+		"""Deletes DNS record(s) for a given type and host."""
+
+		records = self.read_dns_records(type=type, host=host)
+		if not records:
+			return True
+
+		success = True
+
+		for record in records if delete_all else [records[0]]:
+			config = {
+				"action": "delete",
+				"type": type,
+				"name": host,
+				"identifier": record["id"],
+			}
+			client = self.get_client(config)
+			try:
+				client.execute()
+			except Exception:
+				success = False
+
+		return success
 
 	def create_or_update_dns_record(
-		self, domain: str, type: str, host: str, value: str, ttl: int, priority: int = 0
+		self, type: str, host: str, value: str, ttl: int, priority: int = 0
 	) -> bool:
-		"""Creates or updates a DNS record based on the existence of the record."""
+		"""Creates a new record if none exists; otherwise, updates the first matching record."""
 
-		return self.update_dns_record(domain, type, host, value, ttl, priority) or self.create_dns_record(
-			domain, type, host, value, ttl, priority
-		)
+		records = self.read_dns_records(type=type, host=host)
+		if records:
+			record_id = records[0]["id"]
+			return self.update_dns_record(type, host, value, ttl, priority, record_id=record_id)
+		else:
+			return self.create_dns_record(type, host, value, ttl, priority)

--- a/mail/mail/doctype/dns_record/dns_provider.py
+++ b/mail/mail/doctype/dns_record/dns_provider.py
@@ -46,6 +46,7 @@ class DNSProvider:
 		username: str | None = None,
 		password: str | None = None,
 		token: str | None = None,
+		zone_id: str | None = None,
 	) -> None:
 		"""Initializes the DNSProvider with credentials and domain."""
 
@@ -57,6 +58,7 @@ class DNSProvider:
 		self.__username = username
 		self.__password = password
 		self.__token = token
+		self.zone_id = zone_id
 
 	def get_client(self, config: dict) -> Client:
 		"""Internal helper to return a configured Lexicon client."""
@@ -65,9 +67,10 @@ class DNSProvider:
 			{
 				"provider_name": self.provider,
 				"domain": self.domain,
-				"auth_token": self.__token,
 				"auth_username": self.__username,
 				"auth_password": self.__password,
+				"auth_token": self.__token,
+				"zone_id": self.zone_id,
 			}
 		)
 		client = Client(config)

--- a/mail/mail/doctype/dns_record/dns_record.py
+++ b/mail/mail/doctype/dns_record/dns_record.py
@@ -7,6 +7,7 @@ from frappe.model.document import Document
 from frappe.utils import cint, now
 
 from mail.mail.doctype.dns_record.dns_provider import DNSProvider
+from mail.utils import password_or_none
 from mail.utils.cache import get_root_domain_name
 from mail.utils.dns import verify_dns_record
 
@@ -64,14 +65,9 @@ class DNSRecord(Document):
 		"""Creates or Updates the DNS Record in the DNS Provider"""
 
 		result = False
-		mail_settings = frappe.get_single("Mail Settings")
+		dns_provider = get_dns_provider()
 
-		if mail_settings.dns_provider:
-			dns_provider = DNSProvider(
-				provider=mail_settings.dns_provider,
-				domain=mail_settings.root_domain_name,
-				token=mail_settings.get_password("dns_provider_token"),
-			)
+		if dns_provider:
 			result = dns_provider.create_or_update_dns_record(
 				type=self.type,
 				host=self.host,
@@ -85,16 +81,11 @@ class DNSRecord(Document):
 	def delete_record_from_dns_provider(self) -> None:
 		"""Deletes the DNS Record from the DNS Provider"""
 
-		mail_settings = frappe.get_single("Mail Settings")
+		dns_provider = get_dns_provider()
 
-		if not mail_settings.dns_provider:
+		if not dns_provider:
 			return
 
-		dns_provider = DNSProvider(
-			provider=mail_settings.dns_provider,
-			domain=mail_settings.root_domain_name,
-			token=mail_settings.get_password("dns_provider_token"),
-		)
 		dns_provider.delete_dns_record(type=self.type, host=self.host)
 
 	def get_fqdn(self) -> str:
@@ -183,6 +174,24 @@ def verify_all_dns_records() -> None:
 	for dns_record in dns_records:
 		dns_record = frappe.get_doc("DNS Record", dns_record)
 		dns_record.verify_dns_record(save=True)
+
+
+def get_dns_provider(mail_settings: str | None = None) -> DNSProvider | None:
+	"""Returns an instance of the DNS Provider"""
+
+	mail_settings = mail_settings or frappe.get_single("Mail Settings")
+
+	if not mail_settings.dns_provider:
+		return
+
+	return DNSProvider(
+		provider=mail_settings.dns_provider,
+		domain=mail_settings.root_domain_name,
+		username=mail_settings.dns_provider_username,
+		password=password_or_none(mail_settings, "dns_provider_password"),
+		token=password_or_none(mail_settings, "dns_provider_token"),
+		zone_id=mail_settings.dns_provider_zone_id,
+	)
 
 
 def after_doctype_insert() -> None:

--- a/mail/mail/doctype/dns_record/dns_record.py
+++ b/mail/mail/doctype/dns_record/dns_record.py
@@ -189,6 +189,8 @@ def get_dns_provider(mail_settings: str | None = None) -> DNSProvider | None:
 		domain=mail_settings.root_domain_name,
 		username=mail_settings.dns_provider_username,
 		password=password_or_none(mail_settings, "dns_provider_password"),
+		auth_key=mail_settings.dns_provider_key,
+		auth_secret=password_or_none(mail_settings, "dns_provider_secret"),
 		token=password_or_none(mail_settings, "dns_provider_token"),
 		zone_id=mail_settings.dns_provider_zone_id,
 	)

--- a/mail/mail/doctype/dns_record/dns_record.py
+++ b/mail/mail/doctype/dns_record/dns_record.py
@@ -66,13 +66,13 @@ class DNSRecord(Document):
 		result = False
 		mail_settings = frappe.get_single("Mail Settings")
 
-		if mail_settings.dns_provider and mail_settings.dns_provider_token:
+		if mail_settings.dns_provider:
 			dns_provider = DNSProvider(
 				provider=mail_settings.dns_provider,
+				domain=mail_settings.root_domain_name,
 				token=mail_settings.get_password("dns_provider_token"),
 			)
 			result = dns_provider.create_or_update_dns_record(
-				domain=mail_settings.root_domain_name,
 				type=self.type,
 				host=self.host,
 				value=self.value,
@@ -87,14 +87,15 @@ class DNSRecord(Document):
 
 		mail_settings = frappe.get_single("Mail Settings")
 
-		if not mail_settings.dns_provider or not mail_settings.dns_provider_token:
+		if not mail_settings.dns_provider:
 			return
 
 		dns_provider = DNSProvider(
 			provider=mail_settings.dns_provider,
+			domain=mail_settings.root_domain_name,
 			token=mail_settings.get_password("dns_provider_token"),
 		)
-		dns_provider.delete_dns_record(domain=mail_settings.root_domain_name, type=self.type, host=self.host)
+		dns_provider.delete_dns_record(type=self.type, host=self.host)
 
 	def get_fqdn(self) -> str:
 		"""Returns the Fully Qualified Domain Name"""

--- a/mail/mail/doctype/dns_record/dns_record.py
+++ b/mail/mail/doctype/dns_record/dns_record.py
@@ -187,13 +187,15 @@ def get_dns_provider(mail_settings: str | None = None) -> DNSProvider | None:
 	return DNSProvider(
 		provider=mail_settings.dns_provider,
 		domain=mail_settings.root_domain_name,
-		username=mail_settings.dns_provider_username,
-		password=password_or_none(mail_settings, "dns_provider_password"),
+		access_key=mail_settings.dns_provider_access_key,
+		access_secret=password_or_none(mail_settings, "dns_provider_access_secret"),
 		auth_key=mail_settings.dns_provider_key,
 		auth_secret=password_or_none(mail_settings, "dns_provider_secret"),
+		username=mail_settings.dns_provider_username,
 		token=password_or_none(mail_settings, "dns_provider_token"),
 		client_ip=mail_settings.dns_provider_client_ip,
 		zone_id=mail_settings.dns_provider_zone_id,
+		private_zone=bool(mail_settings.dns_provider_private_zone),
 	)
 
 

--- a/mail/mail/doctype/dns_record/dns_record.py
+++ b/mail/mail/doctype/dns_record/dns_record.py
@@ -192,6 +192,7 @@ def get_dns_provider(mail_settings: str | None = None) -> DNSProvider | None:
 		auth_key=mail_settings.dns_provider_key,
 		auth_secret=password_or_none(mail_settings, "dns_provider_secret"),
 		token=password_or_none(mail_settings, "dns_provider_token"),
+		client_ip=mail_settings.dns_provider_client_ip,
 		zone_id=mail_settings.dns_provider_zone_id,
 	)
 

--- a/mail/mail/doctype/mail_server_config/mail_server_config.py
+++ b/mail/mail/doctype/mail_server_config/mail_server_config.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.model.document import Document
 
-from mail.utils import flatten_dict
+from mail.utils import flatten_dict, password_or_none
 
 LOCAL_KEYS = [
 	"store.*",
@@ -98,9 +98,6 @@ def get_config_toml(server: str) -> str | None:
 
 	def wrap_in_triple_quotes(value: str) -> str:
 		return f"'''{value}'''"
-
-	def password_or_none(doc, field: str) -> str | None:
-		return doc.get_password(field) if doc.get(field) else None
 
 	def split_lines(value: str) -> list:
 		return value.split("\n")

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -14,6 +14,8 @@
   "dns_provider_username",
   "dns_provider_zone_id",
   "dns_provider_token",
+  "dns_provider_key",
+  "dns_provider_secret",
   "section_break_l9un",
   "default_dkim_rsa_key_size",
   "default_newsletter_retention",
@@ -91,7 +93,7 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode"
+   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode\nGoDaddy"
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)",
@@ -501,12 +503,26 @@
    "fieldname": "dns_provider_zone_id",
    "fieldtype": "Data",
    "label": "Zone ID"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_key",
+   "fieldtype": "Data",
+   "label": "Key",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_secret",
+   "fieldtype": "Password",
+   "label": "Secret",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-05 22:15:49.514416",
+ "modified": "2025-04-05 22:36:33.521732",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -87,10 +87,10 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean"
+   "options": "\nDigitalOcean\nHetzner"
   },
   {
-   "depends_on": "eval: doc.dns_provider",
+   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Hetzner\"].includes(doc.dns_provider)",
    "description": "The token used to authenticate with your DNS provider.",
    "fieldname": "dns_provider_token",
    "fieldtype": "Password",
@@ -481,7 +481,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-05 18:38:08.624542",
+ "modified": "2025-04-05 21:31:05.380931",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -498,6 +498,7 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"Cloudflare\", \"Namecheap\"].includes(doc.dns_provider)",
+   "description": "Account username for the DNS provider.",
    "fieldname": "dns_provider_username",
    "fieldtype": "Data",
    "label": "Username",
@@ -505,12 +506,14 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\", \"Cloudflare\"].includes(doc.dns_provider)",
+   "description": "Unique identifier for your DNS zone.",
    "fieldname": "dns_provider_zone_id",
    "fieldtype": "Data",
    "label": "Zone ID"
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)",
+   "description": "Key used for authorization with the DNS provider.",
    "fieldname": "dns_provider_key",
    "fieldtype": "Data",
    "label": "Key",
@@ -518,6 +521,7 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)",
+   "description": "Secret used along with the auth key for secure access.",
    "fieldname": "dns_provider_secret",
    "fieldtype": "Password",
    "label": "Secret",
@@ -525,6 +529,7 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)",
+   "description": "IP address whitelisted to make API calls.",
    "fieldname": "dns_provider_client_ip",
    "fieldtype": "Data",
    "label": "Client IP",
@@ -533,6 +538,7 @@
   {
    "default": "0",
    "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "description": "Indicates whether the DNS zone is private.",
    "fieldname": "dns_provider_private_zone",
    "fieldtype": "Check",
    "label": "Private Zone",
@@ -540,6 +546,7 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "description": "Public key used to authenticate API requests.",
    "fieldname": "dns_provider_access_key",
    "fieldtype": "Data",
    "label": "Access Key",
@@ -547,6 +554,7 @@
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "description": "Secret key paired with the access key for authentication.",
    "fieldname": "dns_provider_access_secret",
    "fieldtype": "Password",
    "label": "Access Secret",
@@ -556,7 +564,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-06 10:14:46.572759",
+ "modified": "2025-04-06 11:32:30.467716",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -481,7 +481,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-26 12:54:30.461350",
+ "modified": "2025-04-05 18:38:08.624542",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -87,10 +87,10 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean\nHetzner"
+   "options": "\nDigitalOcean\nHetzner\nLinode"
   },
   {
-   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Hetzner\"].includes(doc.dns_provider)",
+   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)",
    "description": "The token used to authenticate with your DNS provider.",
    "fieldname": "dns_provider_token",
    "fieldtype": "Password",
@@ -481,7 +481,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-05 21:31:05.380931",
+ "modified": "2025-04-05 21:41:46.101896",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -12,6 +12,7 @@
   "dns_provider",
   "column_break_pntn",
   "dns_provider_username",
+  "dns_provider_client_ip",
   "dns_provider_zone_id",
   "dns_provider_token",
   "dns_provider_key",
@@ -93,15 +94,15 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode\nGoDaddy"
+   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode\nNamecheap\nGoDaddy"
   },
   {
-   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)",
+   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\", \"Namecheap\"].includes(doc.dns_provider)",
    "description": "The token used to authenticate with your DNS provider.",
    "fieldname": "dns_provider_token",
    "fieldtype": "Password",
    "label": "Token",
-   "mandatory_depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)"
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\", \"Namecheap\"].includes(doc.dns_provider)"
   },
   {
    "fieldname": "section_break_hrww",
@@ -493,10 +494,11 @@
    "label": "DNS Provider"
   },
   {
-   "depends_on": "eval: doc.dns_provider && [\"Cloudflare\"].includes(doc.dns_provider)",
+   "depends_on": "eval: doc.dns_provider && [\"Cloudflare\", \"Namecheap\"].includes(doc.dns_provider)",
    "fieldname": "dns_provider_username",
    "fieldtype": "Data",
-   "label": "Username"
+   "label": "Username",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)"
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"Cloudflare\"].includes(doc.dns_provider)",
@@ -517,12 +519,19 @@
    "fieldtype": "Password",
    "label": "Secret",
    "mandatory_depends_on": "eval: doc.dns_provider && [\"GoDaddy\"].includes(doc.dns_provider)"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_client_ip",
+   "fieldtype": "Data",
+   "label": "Client IP",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-05 22:36:33.521732",
+ "modified": "2025-04-06 09:28:05.330178",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -11,12 +11,15 @@
   "dns_provider_section",
   "dns_provider",
   "column_break_pntn",
-  "dns_provider_username",
-  "dns_provider_client_ip",
   "dns_provider_zone_id",
-  "dns_provider_token",
+  "dns_provider_access_key",
+  "dns_provider_access_secret",
   "dns_provider_key",
   "dns_provider_secret",
+  "dns_provider_username",
+  "dns_provider_client_ip",
+  "dns_provider_token",
+  "dns_provider_private_zone",
   "section_break_l9un",
   "default_dkim_rsa_key_size",
   "default_newsletter_retention",
@@ -94,7 +97,7 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode\nNamecheap\nGoDaddy"
+   "options": "\nAmazonRoute53\nDigitalOcean\nCloudflare\nHetzner\nLinode\nNamecheap\nGoDaddy"
   },
   {
    "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\", \"Namecheap\"].includes(doc.dns_provider)",
@@ -501,7 +504,7 @@
    "mandatory_depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)"
   },
   {
-   "depends_on": "eval: doc.dns_provider && [\"Cloudflare\"].includes(doc.dns_provider)",
+   "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\", \"Cloudflare\"].includes(doc.dns_provider)",
    "fieldname": "dns_provider_zone_id",
    "fieldtype": "Data",
    "label": "Zone ID"
@@ -526,12 +529,34 @@
    "fieldtype": "Data",
    "label": "Client IP",
    "mandatory_depends_on": "eval: doc.dns_provider && [\"Namecheap\"].includes(doc.dns_provider)"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_private_zone",
+   "fieldtype": "Check",
+   "label": "Private Zone",
+   "options": "0"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_access_key",
+   "fieldtype": "Data",
+   "label": "Access Key",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_access_secret",
+   "fieldtype": "Password",
+   "label": "Access Secret",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"AmazonRoute53\"].includes(doc.dns_provider)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-06 09:28:05.330178",
+ "modified": "2025-04-06 10:14:46.572759",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -6,9 +6,13 @@
  "field_order": [
   "section_break_hrww",
   "root_domain_name",
-  "spf_host",
   "column_break_4ccc",
+  "spf_host",
+  "dns_provider_section",
   "dns_provider",
+  "column_break_pntn",
+  "dns_provider_username",
+  "dns_provider_zone_id",
   "dns_provider_token",
   "section_break_l9un",
   "default_dkim_rsa_key_size",
@@ -87,15 +91,15 @@
    "fieldname": "dns_provider",
    "fieldtype": "Select",
    "label": "DNS Provider",
-   "options": "\nDigitalOcean\nHetzner\nLinode"
+   "options": "\nDigitalOcean\nCloudflare\nHetzner\nLinode"
   },
   {
-   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)",
+   "depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)",
    "description": "The token used to authenticate with your DNS provider.",
    "fieldname": "dns_provider_token",
    "fieldtype": "Password",
-   "label": "DNS Provider Token",
-   "mandatory_depends_on": "eval: doc.dns_provider"
+   "label": "Token",
+   "mandatory_depends_on": "eval: doc.dns_provider && [\"DigitalOcean\", \"Cloudflare\", \"Hetzner\", \"Linode\"].includes(doc.dns_provider)"
   },
   {
    "fieldname": "section_break_hrww",
@@ -476,12 +480,33 @@
    "label": "Personal Signup Domains",
    "mandatory_depends_on": "eval: doc.allow_self_signup && doc.allow_personal_signup",
    "options": "Personal Signup Domain"
+  },
+  {
+   "fieldname": "column_break_pntn",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "dns_provider_section",
+   "fieldtype": "Section Break",
+   "label": "DNS Provider"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"Cloudflare\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_username",
+   "fieldtype": "Data",
+   "label": "Username"
+  },
+  {
+   "depends_on": "eval: doc.dns_provider && [\"Cloudflare\"].includes(doc.dns_provider)",
+   "fieldname": "dns_provider_zone_id",
+   "fieldtype": "Data",
+   "label": "Zone ID"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-05 21:41:46.101896",
+ "modified": "2025-04-05 22:15:49.514416",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -43,7 +43,7 @@ class MailSettings(Document):
 		if not self.dns_provider:
 			return
 
-		if self.dns_provider in ["DigitalOcean", "Hetzner", "Linode"]:
+		if self.dns_provider in ["DigitalOcean", "Cloudflare", "Hetzner", "Linode"]:
 			if not self.dns_provider_token:
 				frappe.throw(_("Please set the DNS Provider Token."))
 

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -44,14 +44,17 @@ class MailSettings(Document):
 		if not self.dns_provider:
 			return
 
-		match self.dns_provider:
-			case "DigitalOcean" | "Cloudflare" | "Hetzner" | "Linode":
-				if not self.dns_provider_token:
-					frappe.throw(_("Please set the DNS Provider Token."))
+		if self.dns_provider in ["DigitalOcean", "Cloudflare", "Hetzner", "Linode", "Namecheap"]:
+			if not self.dns_provider_token:
+				frappe.throw(_("Please set the DNS Provider Token."))
 
-			case "GoDaddy":
-				if not self.dns_provider_key or not self.dns_provider_secret:
-					frappe.throw(_("Please set the DNS Provider Key and Secret."))
+		if self.dns_provider in ["Namecheap"]:
+			if not self.dns_provider_username or not self.dns_provider_client_ip:
+				frappe.throw(_("Please set the DNS Provider Username and Client IP."))
+
+		if self.dns_provider in ["GoDaddy"]:
+			if not self.dns_provider_key or not self.dns_provider_secret:
+				frappe.throw(_("Please set the DNS Provider Key and Secret."))
 
 		dns_provider = get_dns_provider(self)
 		dns_provider.read_dns_records("A")

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -20,23 +20,13 @@ class MailSettings(Document):
 		self.clear_cache()
 
 		if self.has_value_changed("root_domain_name"):
+			self.handle_root_domain_change()
 			create_dmarc_dns_record_for_external_domains()
 
 	def validate_root_domain_name(self) -> None:
 		"""Validates the Root Domain Name."""
 
 		self.root_domain_name = self.root_domain_name.lower()
-
-		if self.has_value_changed("root_domain_name"):
-			frappe.db.set_value("DNS Record", {"is_verified": 1}, "is_verified", 0)
-
-			if self.get_doc_before_save().get("root_domain_name"):
-				dns_record_list_link = f'<a href="/app/dns-record">{_("DNS Records")}</a>'
-				frappe.msgprint(
-					_("Please verify the {0} for the new {1} to ensure proper email authentication.").format(
-						dns_record_list_link, frappe.bold("Root Domain Name")
-					)
-				)
 
 	def validate_dns_provider(self) -> None:
 		"""Validates the DNS Provider."""
@@ -110,6 +100,19 @@ class MailSettings(Document):
 				frappe.throw(
 					_("Mail Domain {0} is not verified.").format(frappe.bold(signup_domain.domain_name))
 				)
+
+	def handle_root_domain_change(self) -> None:
+		"""Resets DNS Record verification and notifies user after root domain change."""
+
+		frappe.db.set_value("DNS Record", {"is_verified": 1}, "is_verified", 0)
+
+		if self.has_value_changed("root_domain_name"):
+			dns_record_list_link = f'<a href="/app/dns-record">{_("DNS Records")}</a>'
+			frappe.msgprint(
+				_("Please verify the {0} for the new {1} to ensure proper email authentication.").format(
+					dns_record_list_link, frappe.bold("Root Domain Name")
+				)
+			)
 
 	def clear_cache(self) -> None:
 		"""Clears the Cache."""

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -44,17 +44,21 @@ class MailSettings(Document):
 		if not self.dns_provider:
 			return
 
-		if self.dns_provider in ["DigitalOcean", "Cloudflare", "Hetzner", "Linode", "Namecheap"]:
-			if not self.dns_provider_token:
-				frappe.throw(_("Please set the DNS Provider Token."))
+		match self.dns_provider:
+			case "AmazonRoute53":
+				if not self.dns_provider_access_key or not self.dns_provider_access_secret:
+					frappe.throw(_("Please set the DNS Provider Access Key and Secret."))
 
-		if self.dns_provider in ["Namecheap"]:
-			if not self.dns_provider_username or not self.dns_provider_client_ip:
-				frappe.throw(_("Please set the DNS Provider Username and Client IP."))
+			case "DigitalOcean" | "Cloudflare" | "Hetzner" | "Linode" | "Namecheap":
+				if not self.dns_provider_token:
+					frappe.throw(_("Please set the DNS Provider Token."))
+				elif self.dns_provider == "Namecheap":
+					if not self.dns_provider_username or not self.dns_provider_client_ip:
+						frappe.throw(_("Please set the DNS Provider Username and Client IP."))
 
-		if self.dns_provider in ["GoDaddy"]:
-			if not self.dns_provider_key or not self.dns_provider_secret:
-				frappe.throw(_("Please set the DNS Provider Key and Secret."))
+			case "GoDaddy":
+				if not self.dns_provider_key or not self.dns_provider_secret:
+					frappe.throw(_("Please set the DNS Provider Key and Secret."))
 
 		dns_provider = get_dns_provider(self)
 		dns_provider.read_dns_records("A")

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from mail.mail.doctype.dns_record.dns_record import get_dns_provider
 from mail.utils.validation import is_valid_host
 
 
@@ -46,6 +47,9 @@ class MailSettings(Document):
 		if self.dns_provider in ["DigitalOcean", "Cloudflare", "Hetzner", "Linode"]:
 			if not self.dns_provider_token:
 				frappe.throw(_("Please set the DNS Provider Token."))
+
+		dns_provider = get_dns_provider(self)
+		dns_provider.read_dns_records("A")
 
 	def validate_spf_host(self) -> None:
 		"""Validates the SPF Host."""

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -44,9 +44,14 @@ class MailSettings(Document):
 		if not self.dns_provider:
 			return
 
-		if self.dns_provider in ["DigitalOcean", "Cloudflare", "Hetzner", "Linode"]:
-			if not self.dns_provider_token:
-				frappe.throw(_("Please set the DNS Provider Token."))
+		match self.dns_provider:
+			case "DigitalOcean" | "Cloudflare" | "Hetzner" | "Linode":
+				if not self.dns_provider_token:
+					frappe.throw(_("Please set the DNS Provider Token."))
+
+			case "GoDaddy":
+				if not self.dns_provider_key or not self.dns_provider_secret:
+					frappe.throw(_("Please set the DNS Provider Key and Secret."))
 
 		dns_provider = get_dns_provider(self)
 		dns_provider.read_dns_records("A")

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -43,7 +43,7 @@ class MailSettings(Document):
 		if not self.dns_provider:
 			return
 
-		if self.dns_provider in ["DigitalOcean", "Hetzner"]:
+		if self.dns_provider in ["DigitalOcean", "Hetzner", "Linode"]:
 			if not self.dns_provider_token:
 				frappe.throw(_("Please set the DNS Provider Token."))
 

--- a/mail/mail/doctype/mail_settings/mail_settings.py
+++ b/mail/mail/doctype/mail_settings/mail_settings.py
@@ -40,8 +40,12 @@ class MailSettings(Document):
 	def validate_dns_provider(self) -> None:
 		"""Validates the DNS Provider."""
 
-		if self.dns_provider and not self.dns_provider_token:
-			frappe.throw(_("Please set the DNS Provider Token."))
+		if not self.dns_provider:
+			return
+
+		if self.dns_provider in ["DigitalOcean", "Hetzner"]:
+			if not self.dns_provider_token:
+				frappe.throw(_("Please set the DNS Provider Token."))
 
 	def validate_spf_host(self) -> None:
 		"""Validates the SPF Host."""

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -227,6 +227,10 @@ def flatten_dict(d, parent_key="", sep="."):
 	return items
 
 
+def password_or_none(doc, field: str) -> str | None:
+	return doc.get_password(field) if doc.get(field) else None
+
+
 def get_dkim_host(domain_name: str, type: Literal["rsa", "ed25519"]) -> str:
 	"""
 	Returns DKIM host.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "py3dns~=4.0.2",
     "dnspython~=2.4.2",
     "xmltodict~=0.14.2",
-    "python-digitalocean~=1.17.0",
+    "dns-lexicon~=3.20.1",
     "validate-email-address~=1.0.0",
 ]
 


### PR DESCRIPTION
![Screenshot 2025-04-06 11-34-12](https://github.com/user-attachments/assets/e9f63e25-02de-432f-95b1-0ab00eb1ea67)

- [x] AmazonRoute53
- [x] DigitalOcean
- [x] Cloudflare
- [x] Hetzner
- [x] Linode
- [x] Namecheap
- [x] GoDaddy

<hr />

- [x] Validate credentials when saving Mail Settings.
- [x] Manual Test.
   - [x] ~~AmazonRoute53~~
   - [x] DigitalOcean
   - [x] Cloudflare
   - [x] Hetzner
   - [x] ~~Linode~~
   - [x] ~~Namecheap~~
   - [x] ~~GoDaddy~~
- [x] Field Description.

Ref: https://dns-lexicon.github.io/dns-lexicon/configuration_reference.html#providers-options