### PR TITLE
refactor: use iframe via `@iframe-resizer` to render mail html

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "copy-html-entry": "cp ../mail/public/frontend/index.html ../mail/www/mail.html"
   },
   "dependencies": {
+    "@iframe-resizer/vue": "5.4.4",
     "@vueuse/core": "^10.4.1",
     "dayjs": "^1.11.11",
     "frappe-ui": "^0.1.108",

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -140,10 +140,11 @@
 					</div>
 				</div>
 
-				<iframe
+				<IframeResizer
 					v-if="mail.body_html"
 					class="w-full"
-					@load="loadContent($event.target, mail.body_html)"
+					license="GPLv3"
+					:src="getSrc(mail.body_html)"
 				/>
 
 				<pre v-else-if="mail.body_plain" class="text-wrap pt-4 text-sm leading-5">{{
@@ -182,6 +183,7 @@
 
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from 'vue'
+import IframeResizer from '@iframe-resizer/vue/sfc'
 import {
 	Code,
 	Ellipsis,
@@ -245,51 +247,58 @@ const reload = () => {
 
 defineExpose({ reload })
 
-const loadContent = (iframe: HTMLIFrameElement, content: string) => {
-	const doc = iframe?.contentDocument
-	if (!doc) return
-
-	doc.head.innerHTML = `
-		<style>
-			body {
-				font-family: InterVar, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-				font-size: 13px;
-				line-height: 1.25rem;
-			}
-			blockquote {
-				margin: 8px 0;
-				padding-left: 16px;
-				border-left: 4px solid #e5e7eb;
-			}
-			button {
-				background: none;
-				border: none;
-				cursor: pointer;
-				padding: 0
-			}
-			.hidden {
-				display: none;
-			}
-		</style>
+const getSrc = (content: string) => {
+	/* eslint-disable no-useless-escape */
+	const html = `
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<style>
+				body {
+					font-family: InterVar, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+					font-size: 13px;
+					line-height: 1.25rem;
+				}
+				blockquote {
+					margin: 8px 0;
+					padding-left: 16px;
+					border-left: 4px solid #e5e7eb;
+				}
+				button {
+					background: none;
+					border: none;
+					cursor: pointer;
+					padding: 0
+				}
+				.hidden {
+					display: none;
+				}
+			</style>
+		</head>
+		<body>
+			${content.replace(
+				/<blockquote>/g,
+				'<button onclick="this.nextElementSibling.classList.toggle(\'hidden\');">...</button><blockquote class="hidden">',
+			)}
+			<script>
+				document.addEventListener('click', (e) => {
+					if (e.target.tagName === 'A') {
+						e.preventDefault();
+						window.open(e.target.href, '_blank');
+					}
+				});
+			<\/script>
+			<script
+			src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@5.4.5"
+			type="text/javascript"
+			async
+			><\/script>
+		</body>
+		</html>
 	`
 
-	doc.body.innerHTML = content.replace(
-		/<blockquote>/g,
-		'<button onclick="this.nextElementSibling.classList.toggle(\'hidden\');">...</button><blockquote class="hidden">',
-	)
-
-	const script = doc.createElement('script')
-	script.textContent = `
-		document.addEventListener('click', (e) => {
-			if (e.target.tagName === 'A') {
-				e.preventDefault();
-				window.open(e.target.href, '_blank');
-			}
-		});
-	`
-	doc.body.appendChild(script)
-
-	iframe.height = doc.body.scrollHeight + 'px'
+	const blob = new Blob([html], { type: 'text/html' })
+	return URL.createObjectURL(blob)
 }
 
 type ActionType = 'editDraft' | 'reply' | 'replyAll' | 'forward'

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -144,6 +144,7 @@
 					v-if="mail.body_html"
 					class="w-full"
 					license="GPLv3"
+					:scrolling="true"
 					:src="getSrc(mail.body_html)"
 				/>
 
@@ -183,6 +184,7 @@
 
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from 'vue'
+// eslint-disable-next-line import/no-unresolved
 import IframeResizer from '@iframe-resizer/vue/sfc'
 import {
 	Code,
@@ -289,7 +291,7 @@ const getSrc = (content: string) => {
 				});
 			<\/script>
 			<script
-			src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@5.4.5"
+			src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@5.4.4"
 			type="text/javascript"
 			async
 			><\/script>

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -139,11 +139,7 @@
 						</div>
 					</div>
 				</div>
-				<div
-					v-if="mail.body_html"
-					class="mail-body ProseMirror prose-sm"
-					v-html="mailBody(mail.body_html)"
-				/>
+				<div v-if="mail.body_html" class="mail-body" v-html="mailBody(mail.body_html)" />
 				<pre v-else-if="mail.body_plain" class="mail-body text-wrap">{{
 					mail.body_plain
 				}}</pre>
@@ -246,9 +242,9 @@ const mailBody = (bodyHTML: string) => {
 	bodyHTML = bodyHTML.replace(/<br\s*\/?>/, '')
 	bodyHTML = bodyHTML.replace(
 		/<blockquote>/g,
-		'<div class="blockquote-container"><a href="#" class="font-medium text-gray-900 text-xs no-underline" onclick="this.nextElementSibling.style.display=\'block\'; this.style.display=\'none\'; return false;">Show more from this thread</a><blockquote style="display:none;">',
+		'<button onclick="this.nextElementSibling.classList.toggle(`hidden`);">...</button><blockquote class="hidden">',
 	)
-	bodyHTML = bodyHTML.replace(/<\/blockquote>/g, '</blockquote></div>')
+	bodyHTML = bodyHTML.replace(/<\/blockquote>/g, '</blockquote>')
 	return bodyHTML
 }
 
@@ -431,15 +427,13 @@ const generatePLaceholderWidth = () => {
 
 watch(() => props.mailID, reload)
 </script>
+
 <style>
-.prose
-	:where(blockquote p:first-of-type):not(
-		:where([class~='not-prose'], [class~='not-prose'] *)
-	)::before {
-	content: '';
+.mail-body blockquote {
+	@apply my-2 border-l-4 border-gray-200 pl-4;
 }
 
 .mail-body {
-	@apply prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-gray-300 prose-th:border-gray-300 prose-td:relative prose-th:relative prose-th:bg-gray-100 prose-sm max-w-none pt-4 text-sm leading-5;
+	@apply pt-4 text-sm leading-5;
 }
 </style>

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -139,10 +139,17 @@
 						</div>
 					</div>
 				</div>
-				<div v-if="mail.body_html" class="mail-body" v-html="mailBody(mail.body_html)" />
-				<pre v-else-if="mail.body_plain" class="mail-body text-wrap">{{
+
+				<iframe
+					v-if="mail.body_html"
+					class="w-full"
+					@load="loadContent($event.target, mail.body_html)"
+				/>
+
+				<pre v-else-if="mail.body_plain" class="text-wrap pt-4 text-sm leading-5">{{
 					mail.body_plain
 				}}</pre>
+
 				<div v-if="mail.attachments.length" class="mt-8 flex flex-wrap space-x-2">
 					<AttachmentCapsule
 						v-for="attachment in mail.attachments"
@@ -238,14 +245,51 @@ const reload = () => {
 
 defineExpose({ reload })
 
-const mailBody = (bodyHTML: string) => {
-	bodyHTML = bodyHTML.replace(/<br\s*\/?>/, '')
-	bodyHTML = bodyHTML.replace(
+const loadContent = (iframe: HTMLIFrameElement, content: string) => {
+	const doc = iframe?.contentDocument
+	if (!doc) return
+
+	doc.head.innerHTML = `
+		<style>
+			body {
+				font-family: InterVar, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+				font-size: 13px;
+				line-height: 1.25rem;
+			}
+			blockquote {
+				margin: 8px 0;
+				padding-left: 16px;
+				border-left: 4px solid #e5e7eb;
+			}
+			button {
+				background: none;
+				border: none;
+				cursor: pointer;
+				padding: 0
+			}
+			.hidden {
+				display: none;
+			}
+		</style>
+	`
+
+	doc.body.innerHTML = content.replace(
 		/<blockquote>/g,
-		'<button onclick="this.nextElementSibling.classList.toggle(`hidden`);">...</button><blockquote class="hidden">',
+		'<button onclick="this.nextElementSibling.classList.toggle(\'hidden\');">...</button><blockquote class="hidden">',
 	)
-	bodyHTML = bodyHTML.replace(/<\/blockquote>/g, '</blockquote>')
-	return bodyHTML
+
+	const script = doc.createElement('script')
+	script.textContent = `
+		document.addEventListener('click', (e) => {
+			if (e.target.tagName === 'A') {
+				e.preventDefault();
+				window.open(e.target.href, '_blank');
+			}
+		});
+	`
+	doc.body.appendChild(script)
+
+	iframe.height = doc.body.scrollHeight + 'px'
 }
 
 type ActionType = 'editDraft' | 'reply' | 'replyAll' | 'forward'
@@ -427,13 +471,3 @@ const generatePLaceholderWidth = () => {
 
 watch(() => props.mailID, reload)
 </script>
-
-<style>
-.mail-body blockquote {
-	@apply my-2 border-l-4 border-gray-200 pl-4;
-}
-
-.mail-body {
-	@apply pt-4 text-sm leading-5;
-}
-</style>

--- a/frontend/src/types/@iframe-resizer.d.ts
+++ b/frontend/src/types/@iframe-resizer.d.ts
@@ -1,0 +1,1 @@
+declare module '@iframe-resizer/vue/sfc'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+	define: {
+		__VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
+	},
 	plugins: [
 		frappeui(),
 		vue({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -183,6 +183,20 @@
   dependencies:
     "@tanstack/vue-virtual" "^3.0.0-beta.60"
 
+"@iframe-resizer/core@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@iframe-resizer/core/-/core-5.4.4.tgz#ae9c0d754e86fa86285831e45d1141f23962f8bf"
+  integrity sha512-4gUll8twzfrGOKsCHRCZM45E+q/EmTaQqwXjKUdBPJZaQauN3OPZo217h36Q3L8bUV7K6iKSaHQxngjA5/mLmg==
+  dependencies:
+    auto-console-group "1.2.5"
+
+"@iframe-resizer/vue@5.4.4":
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/@iframe-resizer/vue/-/vue-5.4.4.tgz#2535a325a71b78368b2a97bee0b911de5d8466b7"
+  integrity sha512-CnMX7hBxlTo3Aaa8XrT3TzJ1d0zx4f9xHv1/07Y2jufxBbut4YX/YrNiKHpkPSrYBfFKXVabCr8iE3qfc2wqjA==
+  dependencies:
+    "@iframe-resizer/core" "5.4.4"
+
 "@internationalized/date@^3.5.4":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@internationalized/date/-/date-3.7.0.tgz#23a4956308ee108e308517a7137c69ab8f5f2ad9"
@@ -856,6 +870,11 @@ aria-hidden@^1.2.4:
   integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
   dependencies:
     tslib "^2.0.0"
+
+auto-console-group@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/auto-console-group/-/auto-console-group-1.2.5.tgz#fdf48f00a4853b50f57c15a7e239786c3a87310c"
+  integrity sha512-04gZ21WgVHlzfC/Kp+Zvel7tKGgSXX9KSm3pezrh1OU4KElxiEJCdRm2T8ntiOWkTHfFMIrX0/OhiTUO74K27Q==
 
 autoprefixer@^10.4.2:
   version "10.4.20"
@@ -2003,6 +2022,7 @@ source-map-js@^1.2.0, source-map-js@^1.2.1:
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
#### Summary

The previous implementation of mail HTML body rendering had several issues with it:-
- It was using [ProseMirror](https://prosemirror.net/) which was adding weird borders and paddings to child elements 
- The styles of the body were bleeding out, into the rest of the application
- Rendering was done using the [v-html](https://vuejs.org/guide/essentials/template-syntax.html#raw-html) directive, which is susceptible to XSS

Using iframe solves all of these problems:-
- Renders the body as is
- Sandboxed, and so no chance of styles bleeding out or XSS

Iframes come with their own issue though, which is resizing. While rendering, the iframe should take up the size of its content - no more, no less. This is especially problematic if the body changes its size, as can happen if there are images (because of loading times), or blockquotes (whose display is toggleable).

Using [@iframe-resizer](https://iframe-resizer.com/) helps take care of this.

#### Screenshots

##### Before

![image](https://github.com/user-attachments/assets/4bcffdbc-48b1-4eab-851c-07594c116dc1)

##### After

![image](https://github.com/user-attachments/assets/350eea45-7ba8-48cd-8a25-c70f9cbfb073)
