### PR TITLE
feat: JMAP Push Subscription

### DIFF
--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe import _
+
+from mail.mail.doctype.email_message.email_message import enqueue_fetch_changes
+from mail.mail.doctype.jmap_push_subscription.jmap_push_subscription import JMAPPushSubscription
+
+
+@frappe.whitelist(methods=["POST"], allow_guest=True)
+def push_notification(account: str) -> dict:
+	try:
+		data = frappe.request.get_json()
+
+		if data["@type"] == "PushVerification":
+			JMAPPushSubscription.verify_push_subscription(
+				account, data["pushSubscriptionId"], data["verificationCode"]
+			)
+			return {}
+		elif data["@type"] == "StateChange":
+			enqueue_fetch_changes(account)
+			return {}
+		else:
+			frappe.throw(_("Invalid Push Notification @type = {0}").format(data["@type"]))
+	except Exception as e:
+		frappe.log_error(_("JMAP Push Notification Error"), data)
+		return {"status": "error", "message": str(e)}

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -10,18 +10,18 @@ def push_notification(account: str) -> dict:
 	"""Handle JMAP Push Notification."""
 
 	try:
-		data = frappe.request.get_json()
+		request_data = frappe.request.get_json()
 
-		if data["@type"] == "PushVerification":
+		if request_data["@type"] == "PushVerification":
 			JMAPPushSubscription.verify_push_subscription(
-				account, data["pushSubscriptionId"], data["verificationCode"]
+				account, request_data["pushSubscriptionId"], request_data["verificationCode"]
 			)
 			return {}
-		elif data["@type"] == "StateChange":
-			enqueue_fetch_changes(account)
+		elif request_data["@type"] == "StateChange":
+			enqueue_fetch_changes(account, request_data)
 			return {}
 		else:
-			frappe.throw(_("Invalid Push Notification @type = {0}").format(data["@type"]))
+			frappe.throw(_("Invalid Push Notification @type = {0}").format(request_data["@type"]))
 	except Exception:
 		frappe.log_error(
 			title=_("Failed to handle JMAP Push Notification"),

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -7,6 +7,8 @@ from mail.mail.doctype.jmap_push_subscription.jmap_push_subscription import JMAP
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
 def push_notification(account: str) -> dict:
+	"""Handle JMAP Push Notification."""
+
 	try:
 		data = frappe.request.get_json()
 
@@ -20,6 +22,9 @@ def push_notification(account: str) -> dict:
 			return {}
 		else:
 			frappe.throw(_("Invalid Push Notification @type = {0}").format(data["@type"]))
-	except Exception as e:
-		frappe.log_error(_("JMAP Push Notification Error"), data)
-		return {"status": "error", "message": str(e)}
+	except Exception:
+		frappe.log_error(
+			title=_("Failed to handle JMAP Push Notification"),
+			message=frappe.get_traceback(with_context=True),
+		)
+		return {"status": "error", "message": _("Failed to handle JMAP Push Notification.")}

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -1,3 +1,5 @@
+from urllib.parse import unquote
+
 import frappe
 from frappe import _
 
@@ -6,10 +8,15 @@ from mail.mail.doctype.jmap_push_subscription.jmap_push_subscription import JMAP
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
-def push_notification(account: str) -> dict:
+def push_notification() -> dict:
 	"""Handle JMAP Push Notification."""
 
 	try:
+		account = frappe.request.args.get("account")
+		if not account:
+			frappe.throw(_("Missing account query parameter."))
+
+		account = unquote(account)
 		request_data = frappe.request.get_json()
 
 		if request_data["@type"] == "PushVerification":

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -214,7 +214,10 @@ scheduler_events = {
 		"mail.tasks.enqueue_delete_newsletters",
 		"mail.tasks.enqueue_cancel_trashed_mails",
 	],
-	"daily_long": ["mail.mail.doctype.email_message.email_message.delete_destroyed_emails"],
+	"daily_long": [
+		"mail.mail.doctype.email_message.email_message.delete_destroyed_emails",
+		"mail.mail.doctype.jmap_push_subscription.jmap_push_subscription.renew_push_subscriptions",
+	],
 	# "hourly": [
 	#     "mail.tasks.hourly"
 	# ],

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -497,6 +497,12 @@ def get_jmap_client(account: str) -> "JMAPClient":
 	return client
 
 
+def invalidate_jmap_client_cache() -> None:
+	"""Invalidates the JMAP client cache."""
+
+	get_jmap_client.clear_cache()
+
+
 def get_mailboxes(account: str) -> list[dict]:
 	"""Returns the mailboxes for the given account."""
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -368,6 +368,102 @@ class JMAPClient:
 				],
 			)
 
+	def push_subscription_get(self, subscription_ids: list[str] | None = None) -> list[dict]:
+		"""Returns the push subscriptions for the provided subscription IDs."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"PushSubscription/get",
+					{
+						"ids": subscription_ids,
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]["list"]
+
+	def push_subscription_create(
+		self, unique_id: str, device_client_id: str, url: str, types: list[str] | None = None
+	) -> dict:
+		"""Creates a push subscription."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"PushSubscription/set",
+					{
+						"create": {
+							unique_id: {
+								"deviceClientId": device_client_id,
+								"url": url,
+								"types": types,
+							}
+						},
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]
+
+	def push_subscription_set_verification_code(self, subscription_id: str, verification_code: str) -> dict:
+		"""Sets the verification code for a push subscription."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"PushSubscription/set",
+					{
+						"update": {subscription_id: {"verificationCode": verification_code}},
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]
+
+	def push_subscription_set_expires(self, subscription_id: str, expires: str | None = None) -> dict:
+		"""Sets the expiration date for a push subscription."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"PushSubscription/set",
+					{
+						"update": {subscription_id: {"expires": expires}},
+					},
+					"0",
+				]
+			],
+		)
+		return response["methodResponses"][0][1]
+
+	def push_subscription_set_destroy(self, subscription_ids: list[str]) -> None:
+		"""Destroys push subscriptions."""
+
+		for ids_batch in create_batch(subscription_ids, self.max_objects_in_set):
+			self._make_request(
+				using=["urn:ietf:params:jmap:mail"],
+				method_calls=[
+					[
+						"PushSubscription/set",
+						{
+							"destroy": ids_batch,
+						},
+						"0",
+					]
+				],
+			)
+
 
 @redis_cache(ttl=300)
 def get_jmap_client(account: str) -> "JMAPClient":

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -412,7 +412,9 @@ class JMAPClient:
 
 		return response["methodResponses"][0][1]
 
-	def push_subscription_set_verification_code(self, subscription_id: str, verification_code: str) -> dict:
+	def push_subscription_set_verification_code(
+		self, subscription_id: str, verification_code: str
+	) -> list[list]:
 		"""Sets the verification code for a push subscription."""
 
 		response = self._make_request(
@@ -424,13 +426,20 @@ class JMAPClient:
 						"update": {subscription_id: {"verificationCode": verification_code}},
 					},
 					"0",
-				]
+				],
+				[
+					"PushSubscription/get",
+					{
+						"ids": [subscription_id],
+					},
+					"1",
+				],
 			],
 		)
 
-		return response["methodResponses"][0][1]
+		return response["methodResponses"]
 
-	def push_subscription_set_expires(self, subscription_id: str, expires: str | None = None) -> dict:
+	def push_subscription_set_expires(self, subscription_id: str, expires: str | None = None) -> list[list]:
 		"""Sets the expiration date for a push subscription."""
 
 		response = self._make_request(
@@ -442,10 +451,17 @@ class JMAPClient:
 						"update": {subscription_id: {"expires": expires}},
 					},
 					"0",
-				]
+				],
+				[
+					"PushSubscription/get",
+					{
+						"ids": [subscription_id],
+					},
+					"1",
+				],
 			],
 		)
-		return response["methodResponses"][0][1]
+		return response["methodResponses"]
 
 	def push_subscription_set_destroy(self, subscription_ids: list[str]) -> None:
 		"""Destroys push subscriptions."""

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -38,7 +38,7 @@ class JMAPClient:
 		except Exception:
 			frappe.log_error(
 				title=_("Failed to discover JMAP configuration for {0}").format(self.__session.auth[0]),
-				message=frappe.get_traceback(with_context=False),
+				message=frappe.get_traceback(with_context=True),
 			)
 			frappe.throw(_("Failed to discover JMAP configuration."))
 

--- a/mail/mail/doctype/email_message/email_message.json
+++ b/mail/mail/doctype/email_message/email_message.json
@@ -31,6 +31,7 @@
   "sent_at",
   "received_at",
   "received_after",
+  "fetched_after",
   "column_break_fdul",
   "sender_name",
   "sender_email",
@@ -415,13 +416,20 @@
    "label": "Destroyed",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "fetched_after",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Fetched After (Seconds)",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-22 15:08:53.551762",
+ "modified": "2025-04-28 14:14:50.862198",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Email Message",

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -17,6 +17,7 @@ from mail.mail.doctype.jmap_sync_state.jmap_sync_state import (
 	get_current_state,
 	update_current_state,
 )
+from mail.utils import enqueue_job, user_context
 from mail.utils.cache import get_account_for_user
 from mail.utils.dt import parse_iso_datetime
 from mail.utils.email_parser import EmailParser
@@ -485,6 +486,13 @@ def fetch_changes(account: str) -> None:
 			title=_("Failed to fetch changes"),
 			message=frappe.get_traceback(with_context=True),
 		)
+
+
+def enqueue_fetch_changes(account: str) -> None:
+	"""Enqueue the fetch_changes job for the specified account."""
+
+	with user_context("Administrator"):
+		enqueue_job(fetch_changes, account=account, queue="short", deduplicate=True)
 
 
 def create_email_message(account: str, email: dict, do_not_save: bool = False) -> "EmailMessage":

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -450,13 +450,15 @@ def fetch_emails(account: str, position: int = 0, batch_size: int = 1000) -> Non
 		)
 
 
-def fetch_changes(account: str) -> None:
+def fetch_changes(account: str, email_states: list[str] | None = None) -> None:
 	"""Fetch changes from the server and update EmailMessage documents."""
 
 	current_state = get_current_state(account)
 
 	if not current_state:
 		return fetch_emails(account)
+	elif email_states and current_state in email_states:
+		return
 
 	client = get_jmap_client(account)
 
@@ -488,12 +490,25 @@ def fetch_changes(account: str) -> None:
 		)
 
 
-def enqueue_fetch_changes(account: str) -> None:
+def enqueue_fetch_changes(account: str, request_data: dict | None = None) -> None:
 	"""Enqueue the fetch_changes job for the specified account."""
+
+	email_states = None
+	if request_data:
+		email_states = list(
+			set([s["Email"] for s in list(request_data["changed"].values()) if s.get("Email")])
+		)
 
 	with user_context("Administrator"):
 		job_id = f"fetch_changes:{account}"
-		enqueue_job(fetch_changes, account=account, queue="short", job_id=job_id, deduplicate=True)
+		enqueue_job(
+			fetch_changes,
+			account=account,
+			email_states=email_states,
+			queue="short",
+			job_id=job_id,
+			deduplicate=True,
+		)
 
 
 def create_email_message(account: str, email: dict, do_not_save: bool = False) -> "EmailMessage":

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -492,7 +492,8 @@ def enqueue_fetch_changes(account: str) -> None:
 	"""Enqueue the fetch_changes job for the specified account."""
 
 	with user_context("Administrator"):
-		enqueue_job(fetch_changes, account=account, queue="short", deduplicate=True)
+		job_id = f"fetch_changes:{account}"
+		enqueue_job(fetch_changes, account=account, queue="short", job_id=job_id, deduplicate=True)
 
 
 def create_email_message(account: str, email: dict, do_not_save: bool = False) -> "EmailMessage":

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -35,6 +35,12 @@ class EmailMessage(Document):
 		return time_diff_in_seconds(self.received_at, self.sent_at)
 
 	@property
+	def fetched_after(self) -> int:
+		"""Returns the time difference in seconds between creation and received time."""
+
+		return time_diff_in_seconds(self.creation, self.received_at)
+
+	@property
 	def spf_pass(self) -> int:
 		"""Returns SPF pass status."""
 

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
@@ -40,6 +40,16 @@ frappe.ui.form.on('JMAP Push Subscription', {
 				__('Actions'),
 			)
 		}
+
+		frm.add_custom_button(
+			__('Destroy All Subscriptions'),
+			() => {
+				frappe.confirm(__('Are you sure you want to destroy all subscriptions?'), () =>
+					frm.trigger('destroy_all_subscriptions'),
+				)
+			},
+			__('Actions'),
+		)
 	},
 
 	renew(frm) {
@@ -62,6 +72,20 @@ frappe.ui.form.on('JMAP Push Subscription', {
 			method: 'resubscribe',
 			freeze: true,
 			freeze_message: __('Resubscribing...'),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh()
+				}
+			},
+		})
+	},
+
+	destroy_all_subscriptions(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: 'destroy_all_subscriptions',
+			freeze: true,
+			freeze_message: __('Destroying all subscriptions...'),
 			callback: (r) => {
 				if (!r.exc) {
 					frm.refresh()

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("JMAP Push Subscription", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
@@ -1,8 +1,40 @@
 // Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("JMAP Push Subscription", {
-// 	refresh(frm) {
+frappe.ui.form.on('JMAP Push Subscription', {
+	refresh(frm) {
+		frm.trigger('add_actions')
+	},
 
-// 	},
-// });
+	add_actions(frm) {
+		if (!frappe.user_roles.includes('System Manager')) return
+
+		if (
+			frm.doc.verified &&
+			frm.doc.subscription_id &&
+			['Active', 'Expired', 'Failed to Renew'].includes(frm.doc.status)
+		) {
+			frm.add_custom_button(
+				__('Renew'),
+				() => {
+					frm.trigger('renew')
+				},
+				__('Actions'),
+			)
+		}
+	},
+
+	renew(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: 'renew',
+			freeze: true,
+			freeze_message: __('Renewing...'),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh()
+				}
+			},
+		})
+	},
+})

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('JMAP Push Subscription', {
 	},
 
 	add_actions(frm) {
-		if (!frappe.user_roles.includes('System Manager')) return
+		if (frm.doc.__islocal || !frappe.user_roles.includes('System Manager')) return
 
 		if (
 			frm.doc.verified &&
@@ -22,6 +22,24 @@ frappe.ui.form.on('JMAP Push Subscription', {
 				__('Actions'),
 			)
 		}
+
+		if (
+			[
+				'Expired',
+				'Failed to Verify',
+				'Failed to Renew',
+				'Failed to Subscribe',
+				'Pending Verification',
+			].includes(frm.doc.status)
+		) {
+			frm.add_custom_button(
+				__('Resubscribe'),
+				() => {
+					frm.trigger('resubscribe')
+				},
+				__('Actions'),
+			)
+		}
 	},
 
 	renew(frm) {
@@ -30,6 +48,20 @@ frappe.ui.form.on('JMAP Push Subscription', {
 			method: 'renew',
 			freeze: true,
 			freeze_message: __('Renewing...'),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh()
+				}
+			},
+		})
+	},
+
+	resubscribe(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: 'resubscribe',
+			freeze: true,
+			freeze_message: __('Resubscribing...'),
 			callback: (r) => {
 				if (!r.exc) {
 					frm.refresh()

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
@@ -1,0 +1,154 @@
+{
+ "actions": [],
+ "creation": "2025-04-25 13:11:49.985072",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_xjjk",
+  "verified",
+  "section_break_ktdh",
+  "status",
+  "account",
+  "endpoint",
+  "expires_at",
+  "subscription_id",
+  "column_break_wbrq",
+  "notification_types",
+  "section_break_gjbl",
+  "subscription_response",
+  "verification_response",
+  "renew_response"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_xjjk",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account",
+   "options": "Mail Account",
+   "reqd": 1,
+   "set_only_once": 1,
+   "unique": 1
+  },
+  {
+   "default": "Email\nMailbox\nEmailDelivery",
+   "fieldname": "notification_types",
+   "fieldtype": "Small Text",
+   "label": "Notification Types",
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "expires_at",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Expires At",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "\nActive\nExpired\nFailed to Verify\nFailed to Renew\nFailed to Subscribe\nPending Verification",
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_gjbl",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "endpoint",
+   "fieldtype": "Data",
+   "label": "Endpoint",
+   "length": 255,
+   "no_copy": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "column_break_wbrq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "subscription_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Subscription ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.verified",
+   "fieldname": "verified",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Verified",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_ktdh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "verification_response",
+   "fieldtype": "JSON",
+   "label": "Verification Response",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "renew_response",
+   "fieldtype": "JSON",
+   "label": "Renew Response",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "subscription_response",
+   "fieldtype": "JSON",
+   "label": "Subscription Response",
+   "no_copy": 1,
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-04-27 22:29:39.804052",
+ "modified_by": "Administrator",
+ "module": "Mail",
+ "name": "JMAP Push Subscription",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "autoname": "field:account",
  "creation": "2025-04-25 13:11:49.985072",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -142,10 +143,11 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-27 22:46:46.263756",
+ "modified": "2025-04-29 15:18:11.627398",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "JMAP Push Subscription",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.json
@@ -6,6 +6,8 @@
  "field_order": [
   "section_break_xjjk",
   "verified",
+  "column_break_ivre",
+  "verified_at",
   "section_break_ktdh",
   "status",
   "account",
@@ -123,12 +125,24 @@
    "label": "Subscription Response",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_ivre",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.verified",
+   "fieldname": "verified_at",
+   "fieldtype": "Datetime",
+   "label": "Verified At",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-04-27 22:29:39.804052",
+ "modified": "2025-04-27 22:46:46.263756",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "JMAP Push Subscription",

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -46,8 +46,8 @@ class JMAPPushSubscription(Document):
 		if response[0][1].get("updated"):
 			kwargs.update(
 				{
-					"verified": 1,
 					"status": "Active",
+					"verified": 1,
 					"verified_at": frappe.utils.now(),
 				}
 			)
@@ -101,17 +101,29 @@ class JMAPPushSubscription(Document):
 		client = get_jmap_client(self.account)
 		response = client.push_subscription_create(self.name, device_client_id, self.endpoint, types)
 
-		kwargs = {"subscription_response": json.dumps(response, indent=4)}
+		kwargs = {
+			"verified": 0,
+			"verified_at": None,
+			"renew_response": None,
+			"verification_response": None,
+			"subscription_response": json.dumps(response, indent=4),
+		}
 		if response.get("created"):
 			kwargs.update(
 				{
 					"status": "Pending Verification",
-					"subscription_id": response["created"][self.name]["id"],
 					"expires_at": parse_iso_datetime(response["created"][self.name]["expires"]),
+					"subscription_id": response["created"][self.name]["id"],
 				}
 			)
 		elif response.get("notCreated"):
-			kwargs["status"] = "Failed to Subscribe"
+			kwargs.update(
+				{
+					"status": "Failed to Subscribe",
+					"expires_at": None,
+					"subscription_id": None,
+				}
+			)
 		else:
 			frappe.throw(_("Failed to subscribe to JMAP Push Subscription."))
 
@@ -148,6 +160,24 @@ class JMAPPushSubscription(Document):
 			frappe.throw(_("Failed to renew JMAP Push Subscription."))
 
 		self._db_set(**kwargs)
+
+	@frappe.whitelist()
+	def resubscribe(self) -> None:
+		"""Resubscribes to the JMAP push subscription."""
+
+		if self.status not in [
+			"Expired",
+			"Failed to Verify",
+			"Failed to Renew",
+			"Failed to Subscribe",
+			"Pending Verification",
+		]:
+			frappe.throw(_("Cannot resubscribe a subscription that is not expired or failed."))
+
+		if self.subscription_id:
+			JMAPPushSubscription.destroy_push_subscriptions(self.account, [self.subscription_id])
+
+		self._subscribe()
 
 	def _db_set(
 		self,

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -8,9 +8,9 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Interval
 from frappe.query_builder.functions import IfNull, Now
-from uuid_utils import uuid7
 
 from mail.jmap import get_jmap_client
+from mail.utils import generate_uuid_style_hash
 from mail.utils.dt import parse_iso_datetime
 
 
@@ -22,27 +22,14 @@ class JMAPPushSubscription(Document):
 		if not account or not subscription_id or not verification_code:
 			frappe.throw(_("Invalid parameters for push subscription verification."))
 
-		subscription = frappe.db.get_value(
-			"JMAP Push Subscription",
-			{"account": account, "subscription_id": subscription_id, "verified": 0},
-			"name",
-		)
+		subscription = frappe.get_doc("JMAP Push Subscription", account)
 
-		if not subscription:
-			frappe.log_error(
-				title="JMAP Push Subscription Not Found",
-				message=str(
-					{
-						"account": account,
-						"subscription_id": subscription_id,
-						"verification_code": verification_code,
-					}
-				),
-			)
-			frappe.throw(_("JMAP Push Subscription Not Found."))
+		if subscription.verified:
+			frappe.throw(_("Subscription already verified."))
+		elif subscription.subscription_id != subscription_id:
+			frappe.throw(_("Invalid subscription ID."))
 
 		client = get_jmap_client(account)
-		subscription = frappe.get_doc("JMAP Push Subscription", subscription)
 		response = client.push_subscription_set_verification_code(subscription_id, verification_code)
 
 		kwargs = {"verification_response": json.dumps(response, indent=4)}
@@ -79,8 +66,11 @@ class JMAPPushSubscription(Document):
 
 		client.push_subscription_set_destroy(subscription_ids)
 
-	def autoname(self) -> None:
-		self.name = str(uuid7())
+	@property
+	def account_uuid_hash(self) -> str:
+		"""Returns a UUID-style hash of the account name."""
+
+		return generate_uuid_style_hash(self.account)
 
 	def before_insert(self) -> None:
 		self.set_endpoint()
@@ -106,7 +96,9 @@ class JMAPPushSubscription(Document):
 		device_client_id = f"frappe-{frappe.local.site.replace('.', '-')}-{self.account}"
 		types = self.notification_types.split("\n") if self.notification_types else None
 		client = get_jmap_client(self.account)
-		response = client.push_subscription_create(self.name, device_client_id, self.endpoint, types)
+		response = client.push_subscription_create(
+			self.account_uuid_hash, device_client_id, self.endpoint, types
+		)
 
 		kwargs = {
 			"verified": 0,
@@ -119,8 +111,8 @@ class JMAPPushSubscription(Document):
 			kwargs.update(
 				{
 					"status": "Pending Verification",
-					"expires_at": parse_iso_datetime(response["created"][self.name]["expires"]),
-					"subscription_id": response["created"][self.name]["id"],
+					"expires_at": parse_iso_datetime(response["created"][self.account_uuid_hash]["expires"]),
+					"subscription_id": response["created"][self.account_uuid_hash]["id"],
 				}
 			)
 		elif response.get("notCreated"):
@@ -211,8 +203,8 @@ class JMAPPushSubscription(Document):
 def create_jmap_push_subscription(account: str) -> "JMAPPushSubscription":
 	"""Creates a JMAP Push Subscription for the given account."""
 
-	if subscription := frappe.db.get_value("JMAP Push Subscription", {"account": account}, "name"):
-		return frappe.get_doc("JMAP Push Subscription", subscription)
+	if frappe.db.exists("JMAP Push Subscription", account):
+		return frappe.get_doc("JMAP Push Subscription", account)
 
 	push_subscription = frappe.new_doc("JMAP Push Subscription")
 	push_subscription.account = account
@@ -224,8 +216,7 @@ def create_jmap_push_subscription(account: str) -> "JMAPPushSubscription":
 def delete_jmap_push_subscription(account: str) -> None:
 	"""Deletes the JMAP Push Subscription for the given account."""
 
-	if subscription := frappe.db.get_value("JMAP Push Subscription", {"account": account}, "name"):
-		frappe.delete_doc("JMAP Push Subscription", subscription)
+	frappe.delete_doc("JMAP Push Subscription", account, ignore_permissions=True)
 
 
 def renew_push_subscriptions() -> None:

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -44,8 +44,13 @@ class JMAPPushSubscription(Document):
 
 		kwargs = {"verification_response": json.dumps(response, indent=4)}
 		if response.get("updated"):
-			kwargs["verified"] = 1
-			kwargs["status"] = "Active"
+			kwargs.update(
+				{
+					"verified": 1,
+					"status": "Active",
+					"verified_at": frappe.utils.now(),
+				}
+			)
 		elif response.get("notUpdated"):
 			kwargs["status"] = "Failed to Verify"
 
@@ -98,9 +103,13 @@ class JMAPPushSubscription(Document):
 
 		kwargs = {"subscription_response": json.dumps(response, indent=4)}
 		if response.get("created"):
-			kwargs["status"] = "Pending Verification"
-			kwargs["subscription_id"] = response["created"][self.name]["id"]
-			kwargs["expires_at"] = parse_iso_datetime(response["created"][self.name]["expires"])
+			kwargs.update(
+				{
+					"status": "Pending Verification",
+					"subscription_id": response["created"][self.name]["id"],
+					"expires_at": parse_iso_datetime(response["created"][self.name]["expires"]),
+				}
+			)
 		elif response.get("notCreated"):
 			kwargs["status"] = "Failed to Subscribe"
 		else:
@@ -121,7 +130,12 @@ class JMAPPushSubscription(Document):
 
 		kwargs = {"renew_response": json.dumps(response, indent=4)}
 		if response.get("updated"):
-			kwargs["expires_at"] = parse_iso_datetime(response["updated"][self.name]["expires"])
+			kwargs.update(
+				{
+					"status": "Active",
+					"expires_at": parse_iso_datetime(response["updated"][self.name]["expires"]),
+				}
+			)
 		elif response.get("notUpdated"):
 			kwargs["status"] = "Failed to Renew"
 		else:

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -43,7 +43,7 @@ class JMAPPushSubscription(Document):
 		response = client.push_subscription_set_verification_code(subscription_id, verification_code)
 
 		kwargs = {"verification_response": json.dumps(response, indent=4)}
-		if response.get("updated"):
+		if response[0][1].get("updated"):
 			kwargs.update(
 				{
 					"verified": 1,
@@ -51,7 +51,7 @@ class JMAPPushSubscription(Document):
 					"verified_at": frappe.utils.now(),
 				}
 			)
-		elif response.get("notUpdated"):
+		elif response[0][1].get("notUpdated"):
 			kwargs["status"] = "Failed to Verify"
 
 		frappe.db.set_value("JMAP Push Subscription", subscription, kwargs)
@@ -117,7 +117,8 @@ class JMAPPushSubscription(Document):
 
 		self._db_set(**kwargs)
 
-	def _renew(self) -> None:
+	@frappe.whitelist()
+	def renew(self) -> None:
 		"""Renews the JMAP push subscription."""
 
 		if not self.verified or not self.subscription_id:
@@ -129,14 +130,19 @@ class JMAPPushSubscription(Document):
 		response = client.push_subscription_set_expires(self.subscription_id)
 
 		kwargs = {"renew_response": json.dumps(response, indent=4)}
-		if response.get("updated"):
-			kwargs.update(
-				{
-					"status": "Active",
-					"expires_at": parse_iso_datetime(response["updated"][self.name]["expires"]),
-				}
-			)
-		elif response.get("notUpdated"):
+		if response[0][1].get("updated"):
+			new_expires = parse_iso_datetime(response[1][1]["list"][0]["expires"])
+
+			if new_expires == self.expires_at:
+				kwargs["status"] = "Failed to Renew"
+			else:
+				kwargs.update(
+					{
+						"status": "Active",
+						"expires_at": new_expires,
+					}
+				)
+		elif response[0][1].get("notUpdated"):
 			kwargs["status"] = "Failed to Renew"
 		else:
 			frappe.throw(_("Failed to renew JMAP Push Subscription."))

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -6,6 +6,8 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import IfNull, Now
 from uuid_utils import uuid7
 
 from mail.jmap import get_jmap_client
@@ -203,3 +205,26 @@ class JMAPPushSubscription(Document):
 
 		if notify_update:
 			self.notify_update()
+
+
+def renew_push_subscriptions() -> None:
+	"""Renews push subscriptions that are about to expire within the next 2 days."""
+
+	PS = frappe.qb.DocType("JMAP Push Subscription")
+	subscriptions = (
+		frappe.qb.from_(PS)
+		.select(PS.name)
+		.where(
+			(PS.verified == 1)
+			& (IfNull(PS.subscription_id, "") != "")
+			& (PS.expires_at < (Now() + Interval(days=2)))
+			& (PS.status.isin(["Active", "Expired", "Failed to Renew"]))
+		)
+	).run(pluck="name")
+
+	if not subscriptions:
+		return
+
+	for subscription in subscriptions:
+		push_subscription = frappe.get_doc("JMAP Push Subscription", subscription)
+		push_subscription.renew()

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+from contextlib import suppress
 
 import frappe
 from frappe import _
@@ -51,7 +52,15 @@ class JMAPPushSubscription(Document):
 		"""Returns a list of push subscriptions for the given account."""
 
 		client = get_jmap_client(account)
-		return client.push_subscription_get()
+
+		try:
+			return client.push_subscription_get()
+		except Exception:
+			frappe.log_error(
+				title=_("Failed to get push subscriptions"),
+				message=frappe.get_traceback(with_context=True),
+			)
+			frappe.throw(_("Failed to get push subscriptions."))
 
 	@staticmethod
 	def destroy_push_subscriptions(account: str, subscription_ids: list[str] | None = None) -> None:
@@ -59,12 +68,19 @@ class JMAPPushSubscription(Document):
 
 		client = get_jmap_client(account)
 
-		if not subscription_ids:
-			subscription_ids = []
-			for subscription in client.push_subscription_get():
-				subscription_ids.append(subscription["id"])
+		try:
+			if not subscription_ids:
+				subscription_ids = []
+				for subscription in client.push_subscription_get():
+					subscription_ids.append(subscription["id"])
 
-		client.push_subscription_set_destroy(subscription_ids)
+			client.push_subscription_set_destroy(subscription_ids)
+		except Exception:
+			frappe.log_error(
+				title=_("Failed to destroy push subscription(s)"),
+				message=frappe.get_traceback(with_context=True),
+			)
+			frappe.throw(_("Failed to destroy push subscription(s)."))
 
 	@property
 	def account_uuid_hash(self) -> str:
@@ -96,37 +112,47 @@ class JMAPPushSubscription(Document):
 		device_client_id = f"frappe-{frappe.local.site.replace('.', '-')}-{self.account}"
 		types = self.notification_types.split("\n") if self.notification_types else None
 		client = get_jmap_client(self.account)
-		response = client.push_subscription_create(
-			self.account_uuid_hash, device_client_id, self.endpoint, types
-		)
 
-		kwargs = {
-			"verified": 0,
-			"verified_at": None,
-			"renew_response": None,
-			"verification_response": None,
-			"subscription_response": json.dumps(response, indent=4),
-		}
-		if response.get("created"):
-			kwargs.update(
-				{
-					"status": "Pending Verification",
-					"expires_at": parse_iso_datetime(response["created"][self.account_uuid_hash]["expires"]),
-					"subscription_id": response["created"][self.account_uuid_hash]["id"],
-				}
+		try:
+			response = client.push_subscription_create(
+				self.account_uuid_hash, device_client_id, self.endpoint, types
 			)
-		elif response.get("notCreated"):
-			kwargs.update(
-				{
-					"status": "Failed to Subscribe",
-					"expires_at": None,
-					"subscription_id": None,
-				}
-			)
-		else:
-			frappe.throw(_("Failed to subscribe to JMAP Push Subscription."))
 
-		self._db_set(**kwargs)
+			kwargs = {
+				"verified": 0,
+				"verified_at": None,
+				"renew_response": None,
+				"verification_response": None,
+				"subscription_response": json.dumps(response, indent=4),
+			}
+			if response.get("created"):
+				kwargs.update(
+					{
+						"status": "Pending Verification",
+						"expires_at": parse_iso_datetime(
+							response["created"][self.account_uuid_hash]["expires"]
+						),
+						"subscription_id": response["created"][self.account_uuid_hash]["id"],
+					}
+				)
+			elif response.get("notCreated"):
+				kwargs.update(
+					{
+						"status": "Failed to Subscribe",
+						"expires_at": None,
+						"subscription_id": None,
+					}
+				)
+			else:
+				frappe.throw(_("Failed to subscribe to JMAP Push Subscription."))
+
+			self._db_set(**kwargs)
+		except Exception:
+			frappe.log_error(
+				title=_("Failed to create push subscription"),
+				message=frappe.get_traceback(with_context=True),
+			)
+			frappe.throw(_("Failed to create push subscription."))
 
 	@frappe.whitelist()
 	def renew(self) -> None:
@@ -138,27 +164,35 @@ class JMAPPushSubscription(Document):
 			frappe.throw(_("Cannot renew a subscription that is not active or expired."))
 
 		client = get_jmap_client(self.account)
-		response = client.push_subscription_set_expires(self.subscription_id)
 
-		kwargs = {"renew_response": json.dumps(response, indent=4)}
-		if response[0][1].get("updated"):
-			new_expires = parse_iso_datetime(response[1][1]["list"][0]["expires"])
+		try:
+			response = client.push_subscription_set_expires(self.subscription_id)
 
-			if new_expires == self.expires_at:
+			kwargs = {"renew_response": json.dumps(response, indent=4)}
+			if response[0][1].get("updated"):
+				new_expires = parse_iso_datetime(response[1][1]["list"][0]["expires"])
+
+				if new_expires == self.expires_at:
+					kwargs["status"] = "Failed to Renew"
+				else:
+					kwargs.update(
+						{
+							"status": "Active",
+							"expires_at": new_expires,
+						}
+					)
+			elif response[0][1].get("notUpdated"):
 				kwargs["status"] = "Failed to Renew"
 			else:
-				kwargs.update(
-					{
-						"status": "Active",
-						"expires_at": new_expires,
-					}
-				)
-		elif response[0][1].get("notUpdated"):
-			kwargs["status"] = "Failed to Renew"
-		else:
-			frappe.throw(_("Failed to renew JMAP Push Subscription."))
+				frappe.throw(_("Failed to renew JMAP Push Subscription."))
 
-		self._db_set(**kwargs)
+			self._db_set(**kwargs)
+		except Exception:
+			frappe.log_error(
+				title=_("Failed to renew push subscription"),
+				message=frappe.get_traceback(with_context=True),
+			)
+			frappe.throw(_("Failed to renew push subscription."))
 
 	@frappe.whitelist()
 	def resubscribe(self) -> None:
@@ -238,5 +272,6 @@ def renew_push_subscriptions() -> None:
 		return
 
 	for subscription in subscriptions:
-		push_subscription = frappe.get_doc("JMAP Push Subscription", subscription)
-		push_subscription.renew()
+		with suppress(Exception):
+			push_subscription = frappe.get_doc("JMAP Push Subscription", subscription)
+			push_subscription.renew()

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -85,6 +85,10 @@ class JMAPPushSubscription(Document):
 	def after_insert(self) -> None:
 		self._subscribe()
 
+	def on_trash(self) -> None:
+		if self.subscription_id:
+			JMAPPushSubscription.destroy_push_subscriptions(self.account, [self.subscription_id])
+
 	def set_endpoint(self) -> None:
 		"""Sets the endpoint URL for the push subscription."""
 

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -42,6 +42,7 @@ class JMAPPushSubscription(Document):
 			frappe.throw(_("JMAP Push Subscription Not Found."))
 
 		client = get_jmap_client(account)
+		subscription = frappe.get_doc("JMAP Push Subscription", subscription)
 		response = client.push_subscription_set_verification_code(subscription_id, verification_code)
 
 		kwargs = {"verification_response": json.dumps(response, indent=4)}
@@ -56,7 +57,7 @@ class JMAPPushSubscription(Document):
 		elif response[0][1].get("notUpdated"):
 			kwargs["status"] = "Failed to Verify"
 
-		frappe.db.set_value("JMAP Push Subscription", subscription, kwargs)
+		subscription._db_set(notify_update=True, **kwargs)
 
 	@staticmethod
 	def get_push_subscriptions(account: str) -> list[dict]:

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -179,6 +179,13 @@ class JMAPPushSubscription(Document):
 
 		self._subscribe()
 
+	@frappe.whitelist()
+	def destroy_all_subscriptions(self) -> None:
+		"""Destroys all push subscriptions for the account."""
+
+		JMAPPushSubscription.destroy_push_subscriptions(self.account)
+		self._subscribe()
+
 	def _db_set(
 		self,
 		update_modified: bool = True,

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -208,6 +208,26 @@ class JMAPPushSubscription(Document):
 			self.notify_update()
 
 
+def create_jmap_push_subscription(account: str) -> "JMAPPushSubscription":
+	"""Creates a JMAP Push Subscription for the given account."""
+
+	if subscription := frappe.db.get_value("JMAP Push Subscription", {"account": account}, "name"):
+		return frappe.get_doc("JMAP Push Subscription", subscription)
+
+	push_subscription = frappe.new_doc("JMAP Push Subscription")
+	push_subscription.account = account
+	push_subscription.insert(ignore_permissions=True)
+
+	return push_subscription
+
+
+def delete_jmap_push_subscription(account: str) -> None:
+	"""Deletes the JMAP Push Subscription for the given account."""
+
+	if subscription := frappe.db.get_value("JMAP Push Subscription", {"account": account}, "name"):
+		frappe.delete_doc("JMAP Push Subscription", subscription)
+
+
 def renew_push_subscriptions() -> None:
 	"""Renews push subscriptions that are about to expire within the next 2 days."""
 

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from uuid_utils import uuid7
+
+from mail.jmap import get_jmap_client
+from mail.utils.dt import parse_iso_datetime
+
+
+class JMAPPushSubscription(Document):
+	@staticmethod
+	def verify_push_subscription(account: str, subscription_id: str, verification_code: str) -> None:
+		"""Verifies a push subscription using the provided verification code."""
+
+		if not account or not subscription_id or not verification_code:
+			frappe.throw(_("Invalid parameters for push subscription verification."))
+
+		subscription = frappe.db.get_value(
+			"JMAP Push Subscription",
+			{"account": account, "subscription_id": subscription_id, "verified": 0},
+			"name",
+		)
+
+		if not subscription:
+			frappe.log_error(
+				title="JMAP Push Subscription Not Found",
+				message=str(
+					{
+						"account": account,
+						"subscription_id": subscription_id,
+						"verification_code": verification_code,
+					}
+				),
+			)
+			frappe.throw(_("JMAP Push Subscription Not Found."))
+
+		client = get_jmap_client(account)
+		response = client.push_subscription_set_verification_code(subscription_id, verification_code)
+
+		kwargs = {"verification_response": json.dumps(response, indent=4)}
+		if response.get("updated"):
+			kwargs["verified"] = 1
+			kwargs["status"] = "Active"
+		elif response.get("notUpdated"):
+			kwargs["status"] = "Failed to Verify"
+
+		frappe.db.set_value("JMAP Push Subscription", subscription, kwargs)
+
+	@staticmethod
+	def get_push_subscriptions(account: str) -> list[dict]:
+		"""Returns a list of push subscriptions for the given account."""
+
+		client = get_jmap_client(account)
+		return client.push_subscription_get()
+
+	@staticmethod
+	def destroy_push_subscriptions(account: str, subscription_ids: list[str] | None = None) -> None:
+		"""Destroys the push subscriptions for the given account."""
+
+		client = get_jmap_client(account)
+
+		if not subscription_ids:
+			subscription_ids = []
+			for subscription in client.push_subscription_get():
+				subscription_ids.append(subscription["id"])
+
+		client.push_subscription_set_destroy(subscription_ids)
+
+	def autoname(self) -> None:
+		self.name = str(uuid7())
+
+	def before_insert(self) -> None:
+		self.set_endpoint()
+
+	def after_insert(self) -> None:
+		self._subscribe()
+
+	def set_endpoint(self) -> None:
+		"""Sets the endpoint URL for the push subscription."""
+
+		if not self.endpoint:
+			self.endpoint = (
+				f"{frappe.utils.get_url()}/api/method/mail.api.jmap.push_notification?account={self.account}"
+			)
+
+	def _subscribe(self) -> None:
+		"""Subscribes to the JMAP push subscription."""
+
+		device_client_id = f"frappe-{frappe.local.site.replace('.', '-')}-{self.account}"
+		types = self.notification_types.split("\n") if self.notification_types else None
+		client = get_jmap_client(self.account)
+		response = client.push_subscription_create(self.name, device_client_id, self.endpoint, types)
+
+		kwargs = {"subscription_response": json.dumps(response, indent=4)}
+		if response.get("created"):
+			kwargs["status"] = "Pending Verification"
+			kwargs["subscription_id"] = response["created"][self.name]["id"]
+			kwargs["expires_at"] = parse_iso_datetime(response["created"][self.name]["expires"])
+		elif response.get("notCreated"):
+			kwargs["status"] = "Failed to Subscribe"
+		else:
+			frappe.throw(_("Failed to subscribe to JMAP Push Subscription."))
+
+		self._db_set(**kwargs)
+
+	def _renew(self) -> None:
+		"""Renews the JMAP push subscription."""
+
+		if not self.verified or not self.subscription_id:
+			frappe.throw(_("Cannot renew a non-verified subscription."))
+		elif self.status not in ["Active", "Expired", "Failed to Renew"]:
+			frappe.throw(_("Cannot renew a subscription that is not active or expired."))
+
+		client = get_jmap_client(self.account)
+		response = client.push_subscription_set_expires(self.subscription_id)
+
+		kwargs = {"renew_response": json.dumps(response, indent=4)}
+		if response.get("updated"):
+			kwargs["expires_at"] = parse_iso_datetime(response["updated"][self.name]["expires"])
+		elif response.get("notUpdated"):
+			kwargs["status"] = "Failed to Renew"
+		else:
+			frappe.throw(_("Failed to renew JMAP Push Subscription."))
+
+		self._db_set(**kwargs)
+
+	def _db_set(
+		self,
+		update_modified: bool = True,
+		commit: bool = False,
+		notify_update: bool = False,
+		**kwargs,
+	) -> None:
+		"""Updates the document with the given key-value pairs."""
+
+		self.db_set(kwargs, update_modified=update_modified, commit=commit)
+
+		if notify_update:
+			self.notify_update()

--- a/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription_list.js
+++ b/mail/mail/doctype/jmap_push_subscription/jmap_push_subscription_list.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings['JMAP Push Subscription'] = {
+	get_indicator: (doc) => {
+		const status_colors = {
+			Active: 'green',
+			Expired: 'red',
+			'Failed to Verify': 'red',
+			'Failed to Renew': 'red',
+			'Failed to Subscribe': 'red',
+			'Pending Verification': 'yellow',
+		}
+		return [__(doc.status), status_colors[doc.status], 'status,=,' + doc.status]
+	},
+}

--- a/mail/mail/doctype/jmap_push_subscription/test_jmap_push_subscription.py
+++ b/mail/mail/doctype/jmap_push_subscription/test_jmap_push_subscription.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestJMAPPushSubscription(UnitTestCase):
+	"""
+	Unit tests for JMAPPushSubscription.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestJMAPPushSubscription(IntegrationTestCase):
+	"""
+	Integration tests for JMAPPushSubscription.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import random_string, validate_email_address
 
+from mail.jmap import invalidate_jmap_client_cache
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import create_jmap_sync_state
 from mail.mail_server import (
 	create_account_on_cluster,
@@ -69,6 +70,10 @@ class MailAccount(Document):
 					self.secret,
 					self.get_doc_before_save().secret,
 				)
+
+				if self.has_value_changed("secret"):
+					invalidate_jmap_client_cache()
+
 		elif self.has_value_changed("enabled"):
 			delete_account_from_cluster(get_cluster_for_tenant(self.tenant), self.email)
 

--- a/mail/mail/doctype/mail_cluster/mail_cluster.json
+++ b/mail/mail/doctype/mail_cluster/mail_cluster.json
@@ -55,7 +55,19 @@
   "jmap_changes_history_days",
   "jmap_trash_auto_expunge_days",
   "listeners_tab",
-  "listeners"
+  "listeners",
+  "jmap_tab",
+  "push_subscription_section",
+  "jmap_push_max_total",
+  "jmap_push_throttle",
+  "jmap_push_retry_interval",
+  "column_break_0q0i",
+  "jmap_push_attempts_max",
+  "jmap_push_attempts_interval",
+  "push_timeouts_section",
+  "jmap_push_timeout_request",
+  "column_break_68lj",
+  "jmap_push_timeout_verify"
  ],
  "fields": [
   {
@@ -397,6 +409,92 @@
    "fieldtype": "Check",
    "label": "Public",
    "search_index": 1
+  },
+  {
+   "fieldname": "jmap_tab",
+   "fieldtype": "Tab Break",
+   "label": "JMAP"
+  },
+  {
+   "fieldname": "push_subscription_section",
+   "fieldtype": "Section Break",
+   "label": "Push Subscription"
+  },
+  {
+   "fieldname": "push_timeouts_section",
+   "fieldtype": "Section Break",
+   "label": "Push Timeouts"
+  },
+  {
+   "default": "1000",
+   "description": "Time to wait between retry attempts.",
+   "fieldname": "jmap_push_retry_interval",
+   "fieldtype": "Int",
+   "label": "Retry Interval (Milliseconds)",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_0q0i",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_68lj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "100",
+   "description": "Total number of push subscriptions that a given user can activate.",
+   "fieldname": "jmap_push_max_total",
+   "fieldtype": "Int",
+   "label": "Max Subscriptions",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "1000",
+   "description": "Time to wait before sending a new request to the push service.",
+   "fieldname": "jmap_push_throttle",
+   "fieldtype": "Int",
+   "label": "Throttle (Milliseconds)",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "3",
+   "description": "Maximum number of push attempts before a notification is discarded.",
+   "fieldname": "jmap_push_attempts_max",
+   "fieldtype": "Int",
+   "label": "Max Attempts",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "60000",
+   "description": "Time to wait between push attempts.",
+   "fieldname": "jmap_push_attempts_interval",
+   "fieldtype": "Int",
+   "label": "Attempt Interval (Milliseconds)",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "10000",
+   "description": "Time before a connection with a push service URL times out.",
+   "fieldname": "jmap_push_timeout_request",
+   "fieldtype": "Int",
+   "label": "Request Timeout (Milliseconds)",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "default": "60000",
+   "description": "Time to wait for the push service to verify a subscription.",
+   "fieldname": "jmap_push_timeout_verify",
+   "fieldtype": "Int",
+   "label": "Verification Timeout (Milliseconds)",
+   "non_negative": 1,
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
@@ -428,7 +526,7 @@
    "link_fieldname": "cluster"
   }
  ],
- "modified": "2025-04-09 19:12:03.632706",
+ "modified": "2025-04-29 16:41:53.466047",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Cluster",

--- a/mail/mail/doctype/mail_server_config/mail_server_config.py
+++ b/mail/mail/doctype/mail_server_config/mail_server_config.py
@@ -26,6 +26,7 @@ LOCAL_KEYS = [
 	"jmap.account.*",
 	"jmap.email.*",
 	"jmap.protocol.*",
+	"jmap.push.*",
 	"queue.outbound.tls.allow-invalid-certs",
 	"queue.outbound.tls.starttls",
 	"authentication.fallback-admin.*",
@@ -397,6 +398,21 @@ def get_config_toml(server: str) -> str | None:
 			"email": {"auto-expunge": format_value_or_zero(cluster.jmap_trash_auto_expunge_days, "d")},
 			"protocol": {
 				"changes": {"max-history": format_value_or_zero(cluster.jmap_changes_history_days, "d")}
+			},
+			"push": {
+				"max-total": cluster.jmap_push_max_total,
+				"throttle": format_value_or_zero(cluster.jmap_push_throttle, "ms"),
+				"attempts": {
+					"interval": format_value_or_zero(cluster.jmap_push_attempts_interval, "ms"),
+					"max": cluster.jmap_push_attempts_max,
+				},
+				"retry": {
+					"interval": format_value_or_zero(cluster.jmap_push_retry_interval, "ms"),
+				},
+				"timeout": {
+					"request": format_value_or_zero(cluster.jmap_push_timeout_request, "ms"),
+					"verify": format_value_or_zero(cluster.jmap_push_timeout_verify, "ms"),
+				},
 			},
 		},
 		"queue": {

--- a/mail/mail/doctype/mail_server_request/mail_server_request.py
+++ b/mail/mail/doctype/mail_server_request/mail_server_request.py
@@ -3,6 +3,7 @@
 
 
 import json
+from collections.abc import Callable
 from urllib.parse import quote
 
 import frappe
@@ -10,6 +11,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now, time_diff_in_seconds
 from uuid_utils import uuid7
+
+from mail.utils import get_dotted_path
 
 
 class MailServerRequest(Document):
@@ -135,8 +138,8 @@ def create_mail_server_request(
 	request_params: dict | None = None,
 	request_data: str | None = None,
 	request_json: dict | None = None,
-	execute_on_start: str | None = None,
-	execute_on_end: str | None = None,
+	execute_on_start: Callable | str | None = None,
+	execute_on_end: Callable | str | None = None,
 	do_not_enqueue: bool = False,
 ) -> "MailServerRequest":
 	"""Creates a new Mail Server Request."""
@@ -152,8 +155,10 @@ def create_mail_server_request(
 	request.request_params = request_params
 	request.request_data = request_data
 	request.request_json = request_json
-	request.execute_on_start = execute_on_start
-	request.execute_on_end = execute_on_end
+	request.execute_on_start = (
+		get_dotted_path(execute_on_start) if callable(execute_on_start) else execute_on_start
+	)
+	request.execute_on_end = get_dotted_path(execute_on_end) if callable(execute_on_end) else execute_on_end
 	request.insert(ignore_permissions=True)
 
 	return request

--- a/mail/mail/doctype/mail_tenant/mail_tenant.py
+++ b/mail/mail/doctype/mail_tenant/mail_tenant.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
 
+from mail.jmap import invalidate_jmap_client_cache
 from mail.utils.cache import get_tenant_for_user
 from mail.utils.user import has_role, is_system_manager, is_tenant_admin
 
@@ -36,6 +37,9 @@ class MailTenant(Document):
 
 	def on_update(self) -> None:
 		self.clear_cache()
+
+		if self.has_value_changed("cluster"):
+			invalidate_jmap_client_cache()
 
 	def after_insert(self) -> None:
 		"""Add the user as a member of the tenant."""

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -255,6 +255,12 @@ def batch_dict(d: dict[str, Any], batch_size: int) -> list[dict[str, Any]]:
 	return [{k: d[k] for k in keys[i : i + batch_size]} for i in range(0, len(keys), batch_size)]
 
 
+def get_dotted_path(func: Callable) -> str:
+	"""Returns the dotted path of a function."""
+
+	return f"{func.__module__}.{func.__qualname__}"
+
+
 def get_dkim_host(domain_name: str, type: Literal["rsa", "ed25519"]) -> str:
 	"""
 	Returns DKIM host.

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -1,5 +1,6 @@
 import base64
 import gzip
+import hashlib
 import os
 import re
 import secrets
@@ -259,6 +260,13 @@ def get_dotted_path(func: Callable) -> str:
 	"""Returns the dotted path of a function."""
 
 	return f"{func.__module__}.{func.__qualname__}"
+
+
+def generate_uuid_style_hash(input_str: str) -> str:
+	"""Generates a UUID-style hash from the input string."""
+
+	hash = hashlib.md5(input_str.encode()).hexdigest()
+	return f"{hash[:8]}-{hash[8:12]}-{hash[12:16]}-{hash[16:20]}-{hash[20:]}"
 
 
 def get_dkim_host(domain_name: str, type: Literal["rsa", "ed25519"]) -> str:

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -122,11 +122,12 @@ def load_compressed_file(file_path: str | None = None, file_data: bytes | None =
 	frappe.throw(_("Failed to load content from the compressed file."))
 
 
-def enqueue_job(method: str | Callable, deduplicate: bool = False, **kwargs) -> None:
+def enqueue_job(
+	method: str | Callable, job_id: str | None = None, deduplicate: bool = False, **kwargs
+) -> None:
 	"""Enqueues a background job."""
 
-	job_id = None
-	if deduplicate:
+	if deduplicate and not job_id:
 		job_id = method.split(".")[-1] if isinstance(method, str) else method.__name__
 
 	frappe.enqueue(method, job_id=job_id, deduplicate=deduplicate, **kwargs)


### PR DESCRIPTION
Extends: https://github.com/frappe/mail/pull/169

<hr />

- [x] Button for Renew
- [x] Button for Resubscribe
- [x] Button to destroy all existing subscriptions
- [x] Destroy subscription on trash
- [x] Trigger `fetch_changes`
  - [x] Deduplicate based on account
  - [x] Fetch only if the state has changed
- [x] JMAP configurations in Mail Cluster
  - [x] Throttle - 3s
  - [x] Max Attempts - 10
  - [x] Verify - 5s
  - [x] ...
- [x] Job to Renew JMAP Push Subscription
- [x] Fetched After (Creation - Received At) - Virtual Field
- [x] JMAP Exception Handling
- [x] Clear `get_jmap_client` cache on Mail Account secret change or Mail Tenant cluster change

<hr />

**Next**
  - On Mail Account disable - Delete Push Subscription
  - On Mail Account enable - Create Push Subscription
  - Handle Mailbox Changes