### PR TITLE
fix: calling `get_mailboxes` query for non mail users

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -135,7 +135,7 @@ router.beforeEach(async (to, from, next) => {
 	const { userResource } = userStore()
 	await userResource.promise
 	const user = userResource.data
-	const mailboxRoute = { name: 'Mailbox', params: { mailbox: user.mailboxes[0].role } }
+	const mailboxRoute = { name: 'Mailbox', params: { mailbox: user.mailboxes[0]?.role } }
 
 	if (user.is_mail_admin) {
 		if (!user.tenant) return next(to.meta.isSetup ? undefined : { name: 'Setup' })

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -4,7 +4,7 @@ from frappe.utils import cint, get_datetime, get_url, now_datetime
 from frappe.utils.data import sha256_hash
 
 from mail.api.admin import add_member
-from mail.jmap import get_mailboxes_for_account
+from mail.api.mail import get_mailboxes
 from mail.mail.doctype.mail_account.mail_account import create_user
 from mail.utils import user_context
 from mail.utils.cache import (
@@ -153,7 +153,7 @@ def get_user_info() -> dict | None:
 	)
 	user_dict["roles"] = frappe.get_roles(user_dict.name)
 	user_dict.tenant = get_user_tenant()
-	user_dict.is_mail_user = "Mail User" in user_dict.roles
+	user_dict.is_mail_user = "Mail User" in user_dict.roles and user != "Administrator"
 	user_dict.is_mail_admin = "Mail Admin" in user_dict.roles
 
 	if user_dict.tenant:
@@ -164,7 +164,7 @@ def get_user_info() -> dict | None:
 
 	user_dict.email_addresses = get_user_email_addresses(user)
 	user_dict.default_outgoing = get_default_outgoing_email_for_user(user)
-	user_dict.mailboxes = get_mailboxes_for_account(user)
+	user_dict.mailboxes = get_mailboxes()
 
 	return user_dict
 

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -11,6 +11,7 @@ from mail.jmap import get_mailboxes_for_account
 from mail.mail.doctype.email_message.email_message import EmailMessage, enqueue_fetch_changes
 from mail.mail.doctype.mail_queue.mail_queue import MailQueue
 from mail.utils.rate_limiter import dynamic_rate_limit
+from mail.utils.user import has_role
 from mail.utils.validation import validate_permission_for_account
 
 
@@ -18,7 +19,11 @@ from mail.utils.validation import validate_permission_for_account
 def get_mailboxes() -> list:
 	"""Returns mailboxes for the current user."""
 
-	return get_mailboxes_for_account(frappe.session.user)
+	user = frappe.session.user
+	if not has_role(user, "Mail User") or user == "Administrator":
+		return []
+
+	return get_mailboxes_for_account(user)
 
 
 def get_mailbox_id(mailbox: str) -> str:


### PR DESCRIPTION
Closes: https://github.com/frappe/mail/issues/197