### PR TITLE
fix(MailThread): rendering mails on mobile

### DIFF
--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -137,13 +137,24 @@
 						</div>
 					</div>
 
-					<IframeResizer
-						v-if="mail.html_body"
-						class="w-full"
-						license="GPLv3"
-						:scrolling="true"
-						:srcdoc="getSrc(mail.html_body)"
-					/>
+					<template v-if="mail.html_body">
+						<div v-if="!iframeReady[mail.name]" class="animate-pulse space-y-2 py-4">
+							<div
+								v-for="i in 5"
+								:key="i"
+								class="bg-surface-gray-3 h-2"
+								:style="{ width: `${Math.floor(Math.random() * 40) + 60}%` }"
+							/>
+						</div>
+						<IframeResizer
+							v-show="iframeReady[mail.name]"
+							class="w-full"
+							license="GPLv3"
+							:scrolling="true"
+							:srcdoc="getSrc(mail.html_body)"
+							@on-ready="iframeReady[mail.name] = true"
+						/>
+					</template>
 
 					<pre v-else-if="mail.text_body" class="text-wrap pt-4 text-sm leading-5">{{
 						mail.text_body
@@ -224,6 +235,7 @@ const { setCurrentThread } = userStore()
 
 const showSendModal = ref(false)
 const draftMailID = ref<string>()
+const iframeReady = reactive<Record<string, boolean>>({})
 
 const mailDetails = reactive<ComposeMailData>({
 	from_email: '',
@@ -247,6 +259,7 @@ const mailThread = createResource({
 })
 
 const reload = () => {
+	Object.keys(iframeReady).forEach((key) => delete iframeReady[key])
 	if (threadID) mailThread.reload()
 }
 
@@ -285,11 +298,12 @@ const getSrc = (content: string) => {
 				.hidden {
 					display: none;
 				}
-				@media (max-width: 640px) {
-					[style*="width:"] {
-						width: auto !important;
-					}
-				}
+                @media (max-width: 640px) {
+                    /* Only override specific problematic patterns */
+                    table[width="600"], table[width="600px"] {
+                        width: 100% !important;
+                    }
+                }
 			</style>
 			<script
 			src="https://cdn.jsdelivr.net/npm/@iframe-resizer/child@5.4.6"

--- a/frontend/src/components/MailThreadPlaceholder.vue
+++ b/frontend/src/components/MailThreadPlaceholder.vue
@@ -20,7 +20,7 @@
 					v-for="j in Math.ceil(Math.random() * 5)"
 					:key="j"
 					class="bg-surface-gray-3 h-2"
-					:style="{ width: generatePLaceholderWidth() }"
+					:style="{ width: `${Math.floor(Math.random() * 40) + 60}%` }"
 				/>
 			</div>
 			<div v-if="Math.random() > 0.8" class="mt-5 flex flex-wrap space-x-2">
@@ -33,16 +33,3 @@
 		</div>
 	</div>
 </template>
-
-<script setup lang="ts">
-import { useScreenSize } from '@/utils/composables'
-
-const { size } = useScreenSize()
-
-const generatePLaceholderWidth = () => {
-	const width = size.width
-	const max = width < 640 ? width - 50 : width / 2
-	const min = width < 640 ? width / 2 : width / 3
-	return `${Math.floor(Math.random() * (max - min + 1) + min)}px`
-}
-</script>

--- a/frontend/src/types/doctypes.ts
+++ b/frontend/src/types/doctypes.ts
@@ -38,7 +38,7 @@ export interface MailHeader extends ChildDocType {
 	value?: string
 }
 
-// Last updated: 2025-04-05 17:13:59.621031
+// Last updated: 2025-07-03 15:08:35.572464
 export interface MailAccountRequest extends DocType {
 	/** Request Key: Data */
 	request_key?: string
@@ -168,7 +168,7 @@ export interface MailDomainRequest extends DocType {
 	tenant: string
 }
 
-// Last updated: 2025-06-16 11:14:11.831446
+// Last updated: 2025-06-26 11:21:00.562086
 export interface MailAccount extends DocType {
 	/** Enabled: Check */
 	enabled: 0 | 1
@@ -200,6 +200,24 @@ export interface MailAccount extends DocType {
 	override_display_name: 0 | 1
 	/** Override Reply To: Check */
 	override_reply_to: 0 | 1
+	/** Enabled: Check */
+	vacation_response_enabled: 0 | 1
+	/** From Date: Datetime */
+	vacation_from_date?: string
+	/** To Date: Datetime */
+	vacation_to_date?: string
+	/** Subject: Small Text */
+	vacation_response_subject?: string
+	/** Text Body: Code */
+	vacation_response_text_body?: string
+	/** HTML Body: Code */
+	vacation_response_html_body?: string
+	/** State: Data */
+	vacation_response_state?: string
+	/** Destroy Email After Submission: Check */
+	destroy_email_after_submission: 0 | 1
+	/** Destroy Newsletter After Submission: Check */
+	destroy_newsletter_after_submission: 0 | 1
 }
 
 // Last updated: 2025-03-26 11:43:10.481605
@@ -318,7 +336,7 @@ export interface EmailMessagePart extends ChildDocType {
 	file_url?: any
 }
 
-// Last updated: 2025-05-26 16:21:22.094482
+// Last updated: 2025-06-18 17:10:58.660997
 export interface EmailMessage extends DocType {
 	/** Subject: Small Text */
 	subject?: string

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Mail {
 	text_body: string
 	received_at: string
 	draft: 0 | 1
+	flagged: 0 | 1
 	mailbox_role: string
 	recipients: {
 		To: Recipient[]


### PR DESCRIPTION
### Fix scaling on smaller viewports

600px is the standard width for email templates. On screens smaller than 640px, instead of having a fixed 600px width (which would cause horizontal scrolling), the table cell becomes:
- width: 100% !important - Taking up the full width of its container
- This makes the email content fit within the mobile screen width

Mails that aren't using tables for structuring are scaled down naturally.

Before:

https://github.com/user-attachments/assets/34097cc0-1ccd-48a8-b5c7-df7b0ccddd7c

Now:

![image](https://github.com/user-attachments/assets/acf346ea-4ada-478d-9040-02f7a96bf776)

### Show skeleton till iframe is ready

iframe-resizer listens for content size changes and then resizes the iframe.
On slow hydration or heavy mail content:
- It initially shows a smaller height (cutting off the bottom).
- Then it resizes, causing a jumpy layout or the user seeing “half mail” briefly.

In this PR, the iframe is replaced with a loading skeleton animation till it has completed loading, leading to better UX.

Before:

https://github.com/user-attachments/assets/7c1c7ba5-4b60-4e02-aab6-97d7464f0412

Now:

https://github.com/user-attachments/assets/f8f5f7d2-9558-471b-ae64-287e6bc31672



