### PR TITLE
feat(pwa): UI enhancements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,9 @@
 		<title>Frappe Mail</title>
 		<link rel="apple-touch-icon" href="public/manifest/apple-icon-180.png" />
 		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="theme-color" content="#ffffff" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
+		<meta name="msapplication-navbutton-color" content="#ffffff" />
 		<link
 			rel="apple-touch-startup-image"
 			href="public/manifest/apple-splash-2048-2732.jpg"

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -5,50 +5,50 @@
 		@click="closeSidebar"
 	/>
 
-	<div
-		v-if="!isMobile || isSidebarOpen"
-		class="flex h-full flex-col justify-between border-r bg-gray-50 transition-all duration-300 ease-in-out"
-		:class="[
-			isSidebarCollapsed && !isMobile ? 'w-14' : 'w-56',
-			isMobile ? 'fixed left-0 top-0 z-50 shadow-lg' : 'relative',
-		]"
-	>
+	<Transition>
 		<div
-			class="flex flex-col overflow-hidden"
-			:class="{ 'items-center': isSidebarCollapsed && !isMobile }"
+			v-if="!isMobile || isSidebarOpen"
+			class="flex h-full flex-col justify-between border-r bg-gray-50 duration-300 ease-in-out"
+			:class="[
+				isSidebarCollapsed && !isMobile ? 'w-14' : 'w-56',
+				isMobile ? 'fixed left-0 top-0 z-50 shadow-lg' : 'relative',
+			]"
 		>
-			<UserDropdown class="p-2" :is-collapsed="isSidebarCollapsed && !isMobile" />
-			<div class="flex flex-col">
-				<SidebarLink
-					v-for="link in sidebarLinks"
-					:key="link.label"
-					:link="link"
-					:is-collapsed="isSidebarCollapsed && !isMobile"
-					class="mx-2 my-0.5"
-				/>
-			</div>
-		</div>
-		<SidebarLink
-			v-if="!isMobile"
-			:link="{
-				label: isSidebarCollapsed ? 'Expand' : 'Collapse',
-			}"
-			:is-collapsed="isSidebarCollapsed"
-			class="m-2"
-			@click="isSidebarCollapsed = !isSidebarCollapsed"
-		>
-			<template #icon>
-				<span class="grid h-5 w-6 flex-shrink-0 place-items-center">
-					<ArrowLeftFromLine
-						class="h-4 w-4 text-gray-700 duration-300 ease-in-out"
-						:class="{
-							'[transform:rotateY(180deg)]': isSidebarCollapsed,
-						}"
+			<div
+				class="flex flex-col overflow-hidden"
+				:class="{ 'items-center': isSidebarCollapsed && !isMobile }"
+			>
+				<UserDropdown class="p-2" :is-collapsed="isSidebarCollapsed && !isMobile" />
+				<div class="flex flex-col">
+					<SidebarLink
+						v-for="link in sidebarLinks"
+						:key="link.label"
+						:link="link"
+						:is-collapsed="isSidebarCollapsed && !isMobile"
+						class="mx-2 my-0.5"
 					/>
-				</span>
-			</template>
-		</SidebarLink>
-	</div>
+				</div>
+			</div>
+			<SidebarLink
+				v-if="!isMobile"
+				:link="{ label: isSidebarCollapsed ? 'Expand' : 'Collapse' }"
+				:is-collapsed="isSidebarCollapsed"
+				class="m-2"
+				@click="isSidebarCollapsed = !isSidebarCollapsed"
+			>
+				<template #icon>
+					<span class="grid h-5 w-6 flex-shrink-0 place-items-center">
+						<ArrowLeftFromLine
+							class="h-4 w-4 text-gray-700 duration-300 ease-in-out"
+							:class="{
+								'[transform:rotateY(180deg)]': isSidebarCollapsed,
+							}"
+						/>
+					</span>
+				</template>
+			</SidebarLink>
+		</div>
+	</Transition>
 </template>
 
 <script setup lang="ts">
@@ -131,3 +131,15 @@ const sidebarLinks = computed(() => {
 	return [mailboxItems[0], starredItem, ...mailboxItems.slice(1)].filter(Boolean)
 })
 </script>
+
+<style scoped>
+.v-enter-from,
+.v-leave-to {
+	@apply -translate-x-full opacity-0;
+}
+
+.v-enter-to,
+.v-leave-from {
+	@apply translate-x-0 opacity-100;
+}
+</style>

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -1,7 +1,7 @@
 <template>
 	<button
 		class="flex items-center space-x-2 rounded-full border px-2 py-1.5"
-		:class="{ 'cursor-pointer hover:border-gray-400': true }"
+		:class="{ 'cursor-pointer hover:border-gray-400': blobID }"
 		@click="openAttachment"
 	>
 		<Loader

--- a/frontend/src/components/MailDetailsPopover.vue
+++ b/frontend/src/components/MailDetailsPopover.vue
@@ -7,7 +7,7 @@
 			/>
 		</template>
 		<template #body-main>
-			<div class="grid max-w-lg grid-cols-5 gap-2 p-3 text-sm">
+			<div class="grid max-h-96 max-w-md grid-cols-5 gap-2 overflow-y-auto p-3 text-sm">
 				<span class="text-ink-gray-5 col-span-1">{{ __('From:') }}</span>
 				<span class="col-span-4">
 					<span class="font-semibold">

--- a/frontend/src/components/MailDetailsPopover.vue
+++ b/frontend/src/components/MailDetailsPopover.vue
@@ -1,11 +1,14 @@
 <template>
 	<Popover>
 		<template #target="{ togglePopover }">
-			<ChevronDown class="h-3 w-3 cursor-pointer" @click="togglePopover()" />
+			<ChevronDown
+				class="text-ink-gray-6 hover:bg-surface-gray-2 h-3 w-3 cursor-pointer rounded-sm"
+				@click.stop="togglePopover()"
+			/>
 		</template>
 		<template #body-main>
 			<div class="grid max-w-lg grid-cols-5 gap-2 p-3 text-sm">
-				<span class="col-span-1 text-gray-500">{{ __('From:') }}</span>
+				<span class="text-ink-gray-5 col-span-1">{{ __('From:') }}</span>
 				<span class="col-span-4">
 					<span class="font-semibold">
 						{{ mail.from_name || mail.from_email }}

--- a/frontend/src/components/MailListItem.vue
+++ b/frontend/src/components/MailListItem.vue
@@ -24,7 +24,7 @@
 				class="bg-surface-gray-3 flex h-10 min-h-10 w-10 min-w-10 rounded-full"
 				@click.stop="isSelected = false"
 			>
-				<Check class="text-ink-gray-5 m-auto" />
+				<Check class="text-ink-gray-5 m-auto h-5 w-5" />
 			</div>
 			<Avatar
 				v-else

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -246,7 +246,7 @@ import type { ComposeMailData, Mail } from '@/types'
 
 const { mailbox, threadID } = defineProps<{ mailbox: string; threadID?: string }>()
 
-const emit = defineEmits(['reloadMails', 'markAsUnread', 'moveThread', 'deleteThread'])
+const emit = defineEmits(['reloadMails', 'setSeen', 'moveThread', 'deleteThread'])
 
 const { isMobile } = useScreenSize()
 const dayjs = inject('$dayjs')
@@ -283,6 +283,9 @@ const mailThread = createResource({
 				...mail,
 				collapsed: !!mail.seen,
 			})),
+	onSuccess: (data: Mail[]) => {
+		if (data.some((mail) => !mail.seen)) emit('setSeen', true)
+	},
 	onError: () => router.push({ name: 'Mailbox', params: { mailbox } }),
 })
 
@@ -387,7 +390,7 @@ const threadActions = computed((): MailAction[] =>
 		},
 		{
 			label: __('Mark as Unread'),
-			onClick: () => emit('markAsUnread'),
+			onClick: () => emit('setSeen', false),
 			icon: MailIcon,
 		},
 	].filter((action) => action.condition !== false),

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -4,7 +4,7 @@
 			<Button
 				icon="chevron-left"
 				variant="ghost"
-				class="mr-2"
+				class="mr-2 shrink-0"
 				@click="router.push({ name: 'Mailbox', params: { mailbox } })"
 			/>
 			<span
@@ -15,7 +15,7 @@
 				}"
 			/>
 			<template v-else>
-				<h2 v-if="!isMobile" class="font-semibold leading-5">
+				<h2 v-if="!isMobile" class="mr-2 truncate font-semibold leading-5">
 					{{ mailThread?.data?.[0].subject || __('[No subject]') }}
 				</h2>
 				<div class="ml-auto shrink-0 space-x-2">
@@ -58,8 +58,7 @@
 					:key="mail.name"
 					:class="{
 						'border-b p-3.5 sm:rounded-md sm:border': mailThread.data.length > 1,
-						'cursor-pointer':
-							mail !== mailThread.data[mailThread.data.length - 1] && mail.collapsed,
+						'cursor-pointer': isCollapsed(mail),
 					}"
 					@click="mail.collapsed = false"
 				>
@@ -76,8 +75,8 @@
 							:image="mail.user_image"
 							size="xl"
 						/>
-						<div class="flex flex-1 justify-between text-xs">
-							<div class="flex flex-col space-y-1">
+						<div class="flex flex-1 justify-between truncate text-sm">
+							<div class="mr-3 flex flex-col space-y-1 truncate">
 								<div class="flex items-center space-x-1.5">
 									<span class="text-base font-semibold">
 										{{ mail.from_name || mail.from_email }}
@@ -86,26 +85,11 @@
 										{{ `<${mail.from_email}>` }}
 									</span>
 									<MailDetailsPopover
-										v-if="
-											!mail.draft &&
-											(!mail.collapsed ||
-												mail ===
-													mailThread.data[mailThread.data.length - 1])
-										"
+										v-if="!(mail.draft || isCollapsed(mail))"
 										:mail="mail"
 									/>
 								</div>
-								<div class="flex items-center space-x-2">
-									<span v-if="mail.recipients.To?.length">
-										{{ __('To: ') + getRecipients(mail.recipients.To) }}
-									</span>
-									<span v-if="mail.recipients.CC?.length">
-										{{ __('Cc: ') + getRecipients(mail.recipients.CC) }}
-									</span>
-									<span v-if="mail.recipients.BCC?.length">
-										{{ __('Bcc: ') + getRecipients(mail.recipients.BCC) }}
-									</span>
-								</div>
+								<div class="truncate">{{ getAllRecipients(mail) }}</div>
 							</div>
 							<div class="flex items-center space-x-1 self-start">
 								<MailDate :datetime="mail.received_at" />
@@ -115,7 +99,7 @@
 								>
 									<Button
 										variant="ghost"
-										@click="
+										@click.stop="
 											starMails.submit({
 												names: [mail.name],
 												flagged: false,
@@ -131,12 +115,12 @@
 								</Tooltip>
 								<Tooltip
 									v-for="action in mailActions(mail).filter(
-										(d) => d.condition !== false,
+										(d) => d.condition !== false && !isCollapsed(mail),
 									)"
 									:key="action.label"
 									:text="action.label"
 								>
-									<Button variant="ghost" @click="action.onClick">
+									<Button variant="ghost" @click.stop="action.onClick">
 										<template #icon>
 											<component
 												:is="action.icon"
@@ -145,11 +129,12 @@
 										</template>
 									</Button>
 								</Tooltip>
-								<Tooltip :text="__('More')">
+								<Tooltip v-if="!isCollapsed(mail)" :text="__('More')">
 									<Dropdown
 										:options="
 											moreActions(mail).filter((d) => d.condition !== false)
 										"
+										@click.stop
 									>
 										<Button variant="ghost">
 											<template #icon>
@@ -162,20 +147,11 @@
 						</div>
 					</div>
 
-					<div
-						v-show="
-							mail.collapsed && mail !== mailThread.data[mailThread.data.length - 1]
-						"
-						class="truncate"
-					>
+					<div v-show="isCollapsed(mail)" class="truncate">
 						{{ mail.preview }}
 					</div>
 
-					<div
-						v-show="
-							!mail.collapsed || mail === mailThread.data[mailThread.data.length - 1]
-						"
-					>
+					<div v-show="!isCollapsed(mail)">
 						<template v-if="mail.html_body">
 							<div
 								v-if="!iframeReady[mail.name]"
@@ -475,6 +451,20 @@ const moreActions = (mail: Mail): MailAction[] => [
 		condition: () => mailbox === 'trash',
 	},
 ]
+
+const isCollapsed = (mail: Mail) =>
+	mail.collapsed && mail !== mailThread.data[mailThread.data.length - 1]
+
+const getAllRecipients = (mail: Mail) => {
+	let recipients = ''
+	if (mail.recipients.To?.length)
+		recipients += __('To: ') + getRecipients(mail.recipients.To) + ' '
+	if (mail.recipients.Cc?.length)
+		recipients += __('Cc: ') + getRecipients(mail.recipients.Cc) + ' '
+	if (mail.recipients.Bcc?.length)
+		recipients += __('Bcc: ') + getRecipients(mail.recipients.Bcc) + ' '
+	return recipients
+}
 
 const moveMail = createResource({
 	url: 'mail.api.mail.set_mails_mailbox',

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -52,15 +52,25 @@
 
 			<MailThreadPlaceholder v-if="mailThread.loading" />
 
-			<div v-else class="space-y-4 p-3 sm:px-5 sm:py-6">
+			<div v-else class="space-y-4 sm:px-5 sm:py-6">
 				<div
 					v-for="mail in mailThread.data"
 					:key="mail.name"
 					:class="{
-						'border-b sm:rounded-md sm:border sm:p-3.5': mailThread.data.length > 1,
+						'border-b p-3.5 sm:rounded-md sm:border': mailThread.data.length > 1,
+						'cursor-pointer':
+							mail !== mailThread.data[mailThread.data.length - 1] && mail.collapsed,
 					}"
+					@click="mail.collapsed = false"
 				>
-					<div class="flex space-x-3 pb-6">
+					<div
+						class="flex space-x-3"
+						:class="{
+							'cursor-pointer': mail !== mailThread.data[mailThread.data.length - 1],
+							'pb-6': mail.preview,
+						}"
+						@click.stop="mail.collapsed = !mail.collapsed"
+					>
 						<Avatar
 							:label="mail.from_name || mail.from_email"
 							:image="mail.user_image"
@@ -75,7 +85,15 @@
 									<span v-if="mail.from_name && !isMobile" class="text-gray-600">
 										{{ `<${mail.from_email}>` }}
 									</span>
-									<MailDetailsPopover v-if="!mail.draft" :mail="mail" />
+									<MailDetailsPopover
+										v-if="
+											!mail.draft &&
+											(!mail.collapsed ||
+												mail ===
+													mailThread.data[mailThread.data.length - 1])
+										"
+										:mail="mail"
+									/>
 								</div>
 								<div class="flex items-center space-x-2">
 									<span v-if="mail.recipients.To?.length">
@@ -144,38 +162,56 @@
 						</div>
 					</div>
 
-					<template v-if="mail.html_body">
-						<div v-if="!iframeReady[mail.name]" class="animate-pulse space-y-2 py-4">
+					<div
+						v-show="
+							mail.collapsed && mail !== mailThread.data[mailThread.data.length - 1]
+						"
+						class="truncate"
+					>
+						{{ mail.preview }}
+					</div>
+
+					<div
+						v-show="
+							!mail.collapsed || mail === mailThread.data[mailThread.data.length - 1]
+						"
+					>
+						<template v-if="mail.html_body">
 							<div
-								v-for="i in 5"
-								:key="i"
-								class="bg-surface-gray-3 h-2"
-								:style="{ width: `${Math.floor(Math.random() * 40) + 60}%` }"
+								v-if="!iframeReady[mail.name]"
+								class="animate-pulse space-y-2 py-4"
+							>
+								<div
+									v-for="i in 5"
+									:key="i"
+									class="bg-surface-gray-3 h-2"
+									:style="{ width: `${Math.floor(Math.random() * 40) + 60}%` }"
+								/>
+							</div>
+							<IframeResizer
+								v-show="iframeReady[mail.name]"
+								class="w-full"
+								license="GPLv3"
+								:scrolling="true"
+								:srcdoc="getSrc(mail.html_body)"
+								@on-ready="iframeReady[mail.name] = true"
+							/>
+						</template>
+
+						<pre v-else-if="mail.text_body" class="text-wrap pt-4 text-sm leading-5">{{
+							mail.text_body
+						}}</pre>
+
+						<div v-if="mail.attachments?.length" class="mt-8 flex flex-wrap space-x-2">
+							<AttachmentCapsule
+								v-for="attachment in mail.attachments"
+								:key="attachment.name"
+								:file-name="attachment.filename"
+								:blob-i-d="attachment.blob_id"
+								:type="attachment.type"
+								class="mb-2"
 							/>
 						</div>
-						<IframeResizer
-							v-show="iframeReady[mail.name]"
-							class="w-full"
-							license="GPLv3"
-							:scrolling="true"
-							:srcdoc="getSrc(mail.html_body)"
-							@on-ready="iframeReady[mail.name] = true"
-						/>
-					</template>
-
-					<pre v-else-if="mail.text_body" class="text-wrap pt-4 text-sm leading-5">{{
-						mail.text_body
-					}}</pre>
-
-					<div v-if="mail.attachments?.length" class="mt-8 flex flex-wrap space-x-2">
-						<AttachmentCapsule
-							v-for="attachment in mail.attachments"
-							:key="attachment.name"
-							:file-name="attachment.filename"
-							:blob-i-d="attachment.blob_id"
-							:type="attachment.type"
-							class="mb-2"
-						/>
 					</div>
 				</div>
 			</div>
@@ -261,9 +297,16 @@ const mailThread = createResource({
 	auto: !!threadID,
 	makeParams: () => ({ thread_id: threadID }),
 	transform: (data: Mail[]) =>
-		data.filter((mail) =>
-			mailbox === 'trash' ? mail.mailbox_role === 'trash' : mail.mailbox_role !== 'trash',
-		),
+		data
+			.filter((mail) =>
+				mailbox === 'trash'
+					? mail.mailbox_role === 'trash'
+					: mail.mailbox_role !== 'trash',
+			)
+			.map((mail) => ({
+				...mail,
+				collapsed: !!mail.seen,
+			})),
 	onError: () => router.push({ name: 'Mailbox', params: { mailbox } }),
 })
 
@@ -290,7 +333,7 @@ const getSrc = (content: string) => {
 			<style>
 				body {
 					font-family: InterVar, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-					font-size: 13px;
+					font-size: 14px;
 					line-height: 1.25rem;
 				}
 				blockquote {

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -15,7 +15,7 @@
 				}"
 			/>
 			<template v-else>
-				<h2 class="leading-5">
+				<h2 v-if="!isMobile" class="font-semibold leading-5">
 					{{ mailThread?.data?.[0].subject || __('[No subject]') }}
 				</h2>
 				<div class="ml-auto shrink-0 space-x-2">
@@ -44,16 +44,23 @@
 			</template>
 		</div>
 		<div class="flex-1 overflow-y-auto">
+			<div v-if="isMobile && !mailThread.loading" class="border-b px-3 py-3.5">
+				<h2 class="font-semibold leading-5">
+					{{ mailThread?.data?.[0].subject || __('[No subject]') }}
+				</h2>
+			</div>
+
 			<MailThreadPlaceholder v-if="mailThread.loading" />
 
-			<div v-else class="space-y-4 px-2.5 py-3 sm:px-5 sm:py-6">
+			<div v-else class="space-y-4 p-3 sm:px-5 sm:py-6">
 				<div
 					v-for="mail in mailThread.data"
 					:key="mail.name"
-					class="p-3"
-					:class="{ 'rounded-md border': mailThread.data.length > 1 }"
+					:class="{
+						'border-b sm:rounded-md sm:border sm:p-3.5': mailThread.data.length > 1,
+					}"
 				>
-					<div class="flex space-x-3 border-b pb-2">
+					<div class="flex space-x-3 pb-6">
 						<Avatar
 							:label="mail.from_name || mail.from_email"
 							:image="mail.user_image"

--- a/frontend/src/components/Modals/SearchModal.vue
+++ b/frontend/src/components/Modals/SearchModal.vue
@@ -18,13 +18,13 @@
 					class="flex rounded p-2 hover:cursor-pointer hover:bg-gray-50"
 					@click="openMail(result.mailbox_role, result.thread_id)"
 				>
-					<div class="space-y-1">
-						<p class="text-base font-semibold">
+					<div class="mr-2 space-y-1 truncate">
+						<p class="truncate text-base font-semibold">
 							{{ result.subject || __('[No subject]') }}
 						</p>
-						<p class="text-sm">{{ getInterlocutors(result) }}</p>
+						<p class="truncate text-sm">{{ getInterlocutors(result) }}</p>
 					</div>
-					<p class="text-ink-gray-4 ml-auto text-xs">
+					<p class="text-ink-gray-4 ml-auto shrink-0 text-xs">
 						{{ getFormattedDate(result.received_at) }}
 					</p>
 				</div>

--- a/frontend/src/components/SendMail.vue
+++ b/frontend/src/components/SendMail.vue
@@ -40,17 +40,17 @@
 								<Button
 									:label="__('Cc')"
 									variant="ghost"
-									:class="[
-										cc ? '!bg-gray-300 hover:bg-gray-200' : '!text-gray-500',
-									]"
+									:class="
+										cc ? '!bg-gray-300 hover:bg-gray-200' : '!text-gray-500'
+									"
 									@click="toggleCC()"
 								/>
 								<Button
 									:label="__('Bcc')"
 									variant="ghost"
-									:class="[
-										bcc ? '!bg-gray-300 hover:bg-gray-200' : '!text-gray-500',
-									]"
+									:class="
+										bcc ? '!bg-gray-300 hover:bg-gray-200' : '!text-gray-500'
+									"
 									@click="toggleBCC()"
 								/>
 							</div>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -138,7 +138,12 @@
 							:mail
 							:user-layout
 							:class="{ 'bg-gray-50': mail.thread_id == threadID }"
-							@click="openThread(mail)"
+							@click="
+								router.push({
+									name: 'Mail',
+									params: { mailbox, threadID: mail.thread_id },
+								})
+							"
 							@select-thread="
 								(isManuallySelected) =>
 									selectThread(mail.thread_id, isManuallySelected)
@@ -184,7 +189,7 @@
 					:mailbox
 					:thread-i-d
 					@reload-mails="reloadMails"
-					@mark-as-unread="setSeen.submit({ thread_ids: [threadID], seen: false })"
+					@set-seen="(seen: boolean) => setSeen.submit({ thread_ids: [threadID], seen })"
 					@move-thread="
 						(move_to_mailbox: string) =>
 							moveThreads.submit({ thread_ids: [threadID], move_to_mailbox })
@@ -455,11 +460,6 @@ const setSeen = createResource({
 			router.push({ name: 'Mailbox', params: { mailbox } })
 	},
 })
-
-const openThread = (mail: Thread) => {
-	router.push({ name: 'Mail', params: { mailbox, threadID: mail.thread_id } })
-	if (!mail.seen) setSeen.submit({ thread_ids: [mail.thread_id], seen: true })
-}
 
 const moveThreads = createResource({
 	url: 'mail.api.mail.set_threads_mailbox',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -63,6 +63,7 @@ export interface Mail {
 	}
 	reply_to: string[]
 	attachments: Attachment[]
+	collapsed?: boolean
 }
 
 export interface ComposeMailData {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -54,6 +54,7 @@ export interface Mail {
 	received_at: string
 	draft: 0 | 1
 	flagged: 0 | 1
+	seen: 0 | 1
 	mailbox_role: string
 	recipients: {
 		To: Recipient[]

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -97,7 +97,7 @@ interface Recipient {
 
 export const getRecipients = (recipients: Recipient[], showEmail = false) =>
 	recipients
-		.map(({ display_name, email }) =>
+		?.map(({ display_name, email }) =>
 			showEmail && display_name ? `${display_name} <${email}>` : display_name || email,
 		)
 		.join(', ')

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,7 +64,8 @@ export default defineConfig({
 				short_name: 'Frappe Mail',
 				start_url: '/mail',
 				description: 'Modern email client powered by Frappe',
-				theme_color: '#FFF',
+				theme_color: '#ffffff',
+				background_color: '#ffffff',
 				icons: [
 					{
 						src: '/assets/mail/frontend/manifest/manifest-icon-192.maskable.png',

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -11,6 +11,7 @@ from mail.jmap import get_mailboxes_for_account
 from mail.mail.doctype.email_message.email_message import EmailMessage, enqueue_fetch_changes
 from mail.mail.doctype.email_message.search import EmailSearch
 from mail.mail.doctype.mail_queue.mail_queue import MailQueue
+from mail.utils import convert_html_to_text
 from mail.utils.rate_limiter import dynamic_rate_limit
 from mail.utils.user import has_role
 from mail.utils.validation import validate_permission_for_account
@@ -120,6 +121,7 @@ def get_thread_rows(thread_id: str) -> list[dict]:
 			EM.text_body,
 			EM.received_at,
 			EM.draft,
+			EM.seen,
 			EM.flagged,
 			EM.mailbox_role,
 			EMR.type,
@@ -148,8 +150,10 @@ def group_thread_mail_recipients(rows: list[dict]) -> tuple[dict, set]:
 				"subject": row["subject"],
 				"html_body": row["html_body"],
 				"text_body": row["text_body"],
+				"preview": convert_html_to_text(row["html_body"] or row["text_body"] or ""),
 				"received_at": row["received_at"],
 				"draft": row["draft"],
+				"seen": row["seen"],
 				"flagged": row["flagged"],
 				"mailbox_role": row["mailbox_role"],
 				"recipients": defaultdict(list),


### PR DESCRIPTION
Add transition for sidebar on PWA:

https://github.com/user-attachments/assets/ab59b677-e7ee-49c1-87e1-68c9bd057c65

Make mails collapsible and collapse seen mails by default:

https://github.com/user-attachments/assets/2ce60555-447e-4c45-bd09-08d9385b191b

Update layout to accommodate subject and truncate recipients:

<img width="302" height="674" alt="image" src="https://github.com/user-attachments/assets/90d4fa97-dc1b-4d48-9d57-7eb23f2e5985" />

Set seen on loading mail thread instead of click on mail list item so that mails are marked as seen even if they are opened in some other way (via search, etc.)

