### PR TITLE
refactor: move Vacation Response to new tab

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -54,5 +54,6 @@ declare module 'vue' {
     SettingsModal: typeof import('./src/components/Modals/SettingsModal.vue')['default']
     SidebarLink: typeof import('./src/components/SidebarLink.vue')['default']
     UserDropdown: typeof import('./src/components/UserDropdown.vue')['default']
+    VacationResponseSettings: typeof import('./src/components/Settings/VacationResponseSettings.vue')['default']
   }
 }

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -148,9 +148,7 @@
 						</div>
 					</div>
 
-					<div v-show="isCollapsed(mail)" class="truncate">
-						{{ mail.preview }}
-					</div>
+					<div v-show="isCollapsed(mail)" class="truncate">{{ mail.preview }}</div>
 
 					<div v-show="!isCollapsed(mail)">
 						<template v-if="mail.html_body">

--- a/frontend/src/components/Modals/SettingsModal.vue
+++ b/frontend/src/components/Modals/SettingsModal.vue
@@ -2,7 +2,7 @@
 	<Dialog v-model="show" :options="{ title: __('Settings'), size: '4xl' }">
 		<template #body>
 			<div class="flex" :style="{ height: 'calc(100vh - 9rem)' }">
-				<div class="flex w-48 shrink-0 flex-col border-r bg-gray-50 p-4 py-3">
+				<div class="flex w-52 shrink-0 flex-col border-r bg-gray-50 p-4 py-3">
 					<h1 class="px-2 text-xl leading-6">{{ __('Settings') }}</h1>
 					<div class="mt-3 space-y-1">
 						<button
@@ -34,12 +34,13 @@
 </template>
 <script setup lang="ts">
 import { markRaw, ref } from 'vue'
-import { Code, Mailbox, User } from 'lucide-vue-next'
+import { Code, Mailbox, TreePalm, User } from 'lucide-vue-next'
 import { Button, Dialog } from 'frappe-ui'
 
 import AccountSettings from '@/components/Settings/AccountSettings.vue'
 import AdvancedSettings from '@/components/Settings/AdvancedSettings.vue'
 import ProfileSettings from '@/components/Settings/ProfileSettings.vue'
+import VacationResponseSettings from '@/components/Settings/VacationResponseSettings.vue'
 
 const show = defineModel<boolean>()
 
@@ -53,6 +54,11 @@ const tabs = [
 		label: __('Account'),
 		icon: Mailbox,
 		component: markRaw(AccountSettings),
+	},
+	{
+		label: __('Vacation Response'),
+		icon: TreePalm,
+		component: markRaw(VacationResponseSettings),
 	},
 	{
 		label: __('Advanced'),

--- a/frontend/src/components/Settings/AccountSettings.vue
+++ b/frontend/src/components/Settings/AccountSettings.vue
@@ -49,43 +49,6 @@
 			variant="outline"
 		/>
 
-		<h1>{{ __('Vacation Response') }}</h1>
-		<Switch
-			v-model="account.doc.vacation_response_enabled"
-			:label="__('Enabled')"
-			:description="__('Auto-reply to incoming mails while you’re away.')"
-		/>
-		<template v-if="account.doc.vacation_response_enabled">
-			<FormControl
-				v-model="account.doc.vacation_from_date"
-				type="datetime-local"
-				:label="__('From Date')"
-				variant="outline"
-			/>
-			<FormControl
-				v-model="account.doc.vacation_to_date"
-				type="datetime-local"
-				:label="__('To Date')"
-				variant="outline"
-			/>
-			<FormControl
-				v-model="account.doc.vacation_response_subject"
-				:label="__('Subject')"
-				placeholder="Out of Office"
-				variant="outline"
-			/>
-			<div class="space-y-1.5">
-				<label class="text-ink-gray-5 block text-xs">{{ __('Message') }}</label>
-				<TextEditor
-					editor-class="prose-sm min-h-[8rem] border rounded-b-lg border-t-0 p-2 max-w-none"
-					placeholder="Type something..."
-					:fixed-menu="textEditorButtons"
-					:content="account.doc.vacation_response_html_body"
-					@change="(val) => (account.doc.vacation_response_html_body = val)"
-				/>
-			</div>
-		</template>
-
 		<h1>{{ __('Recovery') }}</h1>
 		<FormControl
 			v-model="account.doc.backup_email"
@@ -107,16 +70,9 @@
 
 <script setup lang="ts">
 import { inject, ref } from 'vue'
-import {
-	Button,
-	ErrorMessage,
-	FormControl,
-	Switch,
-	TextEditor,
-	createDocumentResource,
-} from 'frappe-ui'
+import { Button, ErrorMessage, FormControl, Switch, createDocumentResource } from 'frappe-ui'
 
-import { raiseToast, textEditorButtons } from '@/utils'
+import { raiseToast } from '@/utils'
 import AutocompleteControl from '@/components/Controls/AutocompleteControl.vue'
 
 import type { MailAccount } from '@/types/doctypes'
@@ -126,13 +82,11 @@ const user = inject('$user')
 const account = createDocumentResource({
 	doctype: 'Mail Account',
 	name: user.data?.name,
-	transform(data: MailAccount) {
+	transform: (data: MailAccount) => {
 		const keys = [
-			'enabled',
 			'create_mail_contact',
 			'destroy_email_after_submission',
 			'destroy_newsletter_after_submission',
-			'vacation_response_enabled',
 		] as const
 		for (const key of keys) data[key] = !!data[key]
 	},

--- a/frontend/src/components/Settings/AdvancedSettings.vue
+++ b/frontend/src/components/Settings/AdvancedSettings.vue
@@ -5,6 +5,7 @@
 		{{ __(`You don't have an API key yet. Generate one to access the API.`) }}
 	</p>
 	<Button
+		class="min-h-7"
 		:label="__(user.data?.api_key ? 'Regenerate Secret' : 'Generate Keys')"
 		@click="generateKeys.submit()"
 	/>

--- a/frontend/src/components/Settings/ProfileSettings.vue
+++ b/frontend/src/components/Settings/ProfileSettings.vue
@@ -19,6 +19,7 @@
 	<ErrorMessage :message="setName.error" />
 	<Button
 		:label="__('Save Changes')"
+		class="min-h-7"
 		variant="solid"
 		:disabled="
 			!firstName ||
@@ -27,7 +28,7 @@
 		:loading="setName.isLoading"
 		@click="setName.submit"
 	/>
-	<Button :label="__('Change Password')" @click="showChangePassword = true" />
+	<Button class="min-h-7" :label="__('Change Password')" @click="showChangePassword = true" />
 
 	<EditPhotoModal v-model="showEditPhoto" />
 	<ChangePasswordModal v-model="showChangePassword" />

--- a/frontend/src/components/Settings/VacationResponseSettings.vue
+++ b/frontend/src/components/Settings/VacationResponseSettings.vue
@@ -38,23 +38,16 @@
 			:label="__('Save Changes')"
 			variant="solid"
 			:disabled="JSON.stringify(account.doc) === JSON.stringify(account.originalDoc)"
-			:loading="setVacationResponse.loading || account.get.loading"
+			:loading="account.setVacationResponse.loading || account.get.loading"
 			class="min-h-7"
-			@click="setVacationResponse.submit"
+			@click="account.setVacationResponse.submit"
 		/>
 	</template>
 </template>
 
 <script setup lang="ts">
 import { inject } from 'vue'
-import {
-	Button,
-	FormControl,
-	Switch,
-	TextEditor,
-	createDocumentResource,
-	createResource,
-} from 'frappe-ui'
+import { Button, FormControl, Switch, TextEditor, createDocumentResource } from 'frappe-ui'
 
 import { raiseToast, textEditorButtons } from '@/utils'
 
@@ -71,21 +64,22 @@ const account = createDocumentResource({
 		data['vacation_from_date'] = dayjs(data['vacation_from_date']).format('YYYY-MM-DDTHH:mm')
 		data['vacation_to_date'] = dayjs(data['vacation_to_date']).format('YYYY-MM-DDTHH:mm')
 	},
-})
-
-const setVacationResponse = createResource({
-	url: 'mail.api.mail.set_vacation_response',
-	makeParams: () => ({
-		enabled: account.doc.vacation_response_enabled,
-		from_date: account.doc.vacation_from_date,
-		to_date: account.doc.vacation_to_date,
-		subject: account.doc.vacation_response_subject,
-		html_body: account.doc.vacation_response_html_body,
-	}),
-	onSuccess: () => {
-		account.reload()
-		raiseToast(__('Vacation response settings saved successfully'))
+	whitelistedMethods: {
+		setVacationResponse: {
+			method: 'set_vacation_response',
+			makeParams: () => ({
+				enabled: account.doc.vacation_response_enabled,
+				from_date: account.doc.vacation_from_date,
+				to_date: account.doc.vacation_to_date,
+				subject: account.doc.vacation_response_subject,
+				html_body: account.doc.vacation_response_html_body,
+			}),
+			onSuccess: () => {
+				account.reload()
+				raiseToast(__('Vacation response settings saved successfully'))
+			},
+			onError: (error) => raiseToast(error.messages[0], 'error'),
+		},
 	},
-	onError: (error) => raiseToast(error.messages[0], 'error'),
 })
 </script>

--- a/frontend/src/components/Settings/VacationResponseSettings.vue
+++ b/frontend/src/components/Settings/VacationResponseSettings.vue
@@ -1,0 +1,91 @@
+<template>
+	<template v-if="account.doc">
+		<h1>{{ __('Vacation Response') }}</h1>
+		<Switch
+			v-model="account.doc.vacation_response_enabled"
+			:label="__('Enabled')"
+			:description="__('Auto-reply to incoming mails while you’re away.')"
+		/>
+		<FormControl
+			v-model="account.doc.vacation_from_date"
+			type="datetime-local"
+			:label="__('From Date')"
+			variant="outline"
+		/>
+		<FormControl
+			v-model="account.doc.vacation_to_date"
+			type="datetime-local"
+			:label="__('To Date')"
+			variant="outline"
+		/>
+		<FormControl
+			v-model="account.doc.vacation_response_subject"
+			:label="__('Subject')"
+			placeholder="Out of Office"
+			variant="outline"
+		/>
+		<div class="space-y-1.5">
+			<label class="text-ink-gray-5 block text-xs">{{ __('Message') }}</label>
+			<TextEditor
+				editor-class="prose-sm min-h-[8rem] border rounded-b-lg border-t-0 p-2 max-w-none"
+				placeholder="Type something..."
+				:fixed-menu="textEditorButtons"
+				:content="account.doc.vacation_response_html_body"
+				@change="(val: string) => (account.doc.vacation_response_html_body = val)"
+			/>
+		</div>
+		<Button
+			:label="__('Save Changes')"
+			variant="solid"
+			:disabled="JSON.stringify(account.doc) === JSON.stringify(account.originalDoc)"
+			:loading="setVacationResponse.loading || account.get.loading"
+			class="min-h-7"
+			@click="setVacationResponse.submit"
+		/>
+	</template>
+</template>
+
+<script setup lang="ts">
+import { inject } from 'vue'
+import {
+	Button,
+	FormControl,
+	Switch,
+	TextEditor,
+	createDocumentResource,
+	createResource,
+} from 'frappe-ui'
+
+import { raiseToast, textEditorButtons } from '@/utils'
+
+import type { MailAccount } from '@/types/doctypes'
+
+const user = inject('$user')
+const dayjs = inject('$dayjs')
+
+const account = createDocumentResource({
+	doctype: 'Mail Account',
+	name: user.data.name,
+	transform: (data: MailAccount) => {
+		data['vacation_response_enabled'] = !!data['vacation_response_enabled']
+		data['vacation_from_date'] = dayjs(data['vacation_from_date']).format('YYYY-MM-DDTHH:mm')
+		data['vacation_to_date'] = dayjs(data['vacation_to_date']).format('YYYY-MM-DDTHH:mm')
+	},
+})
+
+const setVacationResponse = createResource({
+	url: 'mail.api.mail.set_vacation_response',
+	makeParams: () => ({
+		enabled: account.doc.vacation_response_enabled,
+		from_date: account.doc.vacation_from_date,
+		to_date: account.doc.vacation_to_date,
+		subject: account.doc.vacation_response_subject,
+		html_body: account.doc.vacation_response_html_body,
+	}),
+	onSuccess: () => {
+		account.reload()
+		raiseToast(__('Vacation response settings saved successfully'))
+	},
+	onError: (error) => raiseToast(error.messages[0], 'error'),
+})
+</script>

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -50,9 +50,7 @@ export const sessionStore = defineStore('mail-session', () => {
 		url: 'mail.api.get_branding',
 		cache: 'brand',
 		auto: true,
-		onSuccess(data) {
-			document.querySelector("link[rel='icon']").href = data.favicon
-		},
+		onSuccess: (data) => (document.querySelector("link[rel='icon']").href = data.favicon),
 	})
 
 	return { user, isLoggedIn, login, logout, branding }

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -89,22 +89,6 @@ def get_mailboxes() -> list[dict]:
 
 
 @frappe.whitelist()
-def set_vacation_response(
-	enabled: bool | int,
-	from_date: str | None = None,
-	to_date: str | None = None,
-	subject: str | None = None,
-	html_body: str | None = None,
-) -> None:
-	"""Updates vacation response details for the given mail account."""
-
-	doc = frappe.get_doc("Mail Account", frappe.session.user)
-	doc.set_vacation_response(
-		enabled, from_date, to_date, subject, convert_html_to_text(html_body), html_body
-	)
-
-
-@frappe.whitelist()
 def get_mail_thread(thread_id: str) -> list[dict]:
 	"""Returns mail thread for the given id."""
 

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -89,6 +89,22 @@ def get_mailboxes() -> list[dict]:
 
 
 @frappe.whitelist()
+def set_vacation_response(
+	enabled: bool | int,
+	from_date: str | None = None,
+	to_date: str | None = None,
+	subject: str | None = None,
+	html_body: str | None = None,
+) -> None:
+	"""Updates vacation response details for the given mail account."""
+
+	doc = frappe.get_doc("Mail Account", frappe.session.user)
+	doc.set_vacation_response(
+		enabled, from_date, to_date, subject, convert_html_to_text(html_body), html_body
+	)
+
+
+@frappe.whitelist()
 def get_mail_thread(thread_id: str) -> list[dict]:
 	"""Returns mail thread for the given id."""
 


### PR DESCRIPTION
- Update UI in accordance with https://github.com/frappe/mail/pull/230
- Move Vacation Response to a new tab

<img width="1920" height="998" alt="image" src="https://github.com/user-attachments/assets/8d4735af-3280-48e3-a8ba-385fa5f53813" />
