### PR TITLE
feat(JMAP): `MT-Priority - Mixer`

### DIFF
--- a/mail/mail/doctype/mail_queue/mail_queue.json
+++ b/mail/mail/doctype/mail_queue/mail_queue.json
@@ -12,11 +12,10 @@
   "column_break_vzib",
   "subject",
   "section_break_agmx",
-  "priority",
-  "section_break_kk2t",
   "save_as_draft",
   "destroy_after_submission",
-  "column_break_htqb",
+  "column_break_lnat",
+  "priority",
   "delivery_mode",
   "section_break_nug2",
   "failed_count",
@@ -317,10 +316,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "column_break_htqb",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0",
    "depends_on": "eval: !doc.save_as_draft",
    "description": "If enabled, the message will be deleted after successful submission.",
@@ -379,6 +374,7 @@
    "description": "<pre><b>Immediate</b> \u2014 send right after insert (after_insert).\n<b>Enqueue</b> \u2014 enqueue a job (using frappe.enqueue).\n<b>Batch</b> \u2014 wait to be picked up by a scheduled background job.\n</pre>",
    "fieldname": "delivery_mode",
    "fieldtype": "Select",
+   "in_standard_filter": 1,
    "label": "Delivery Mode",
    "no_copy": 1,
    "options": "Immediate\nEnqueue\nBatch",
@@ -525,27 +521,26 @@
    "set_only_once": 1
   },
   {
-   "default": "Normal",
    "fieldname": "priority",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Priority",
    "no_copy": 1,
-   "options": "Low\nNormal\nHigh",
-   "reqd": 1,
+   "options": "\nLow\nNormal\nHigh",
+   "read_only": 1,
    "search_index": 1,
    "set_only_once": 1
   },
   {
-   "fieldname": "section_break_kk2t",
-   "fieldtype": "Section Break"
+   "fieldname": "column_break_lnat",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-18 11:45:01.025319",
+ "modified": "2025-07-18 12:42:03.811805",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Queue",

--- a/mail/mail/doctype/mail_queue/mail_queue.json
+++ b/mail/mail/doctype/mail_queue/mail_queue.json
@@ -12,6 +12,8 @@
   "column_break_vzib",
   "subject",
   "section_break_agmx",
+  "priority",
+  "section_break_kk2t",
   "save_as_draft",
   "destroy_after_submission",
   "column_break_htqb",
@@ -521,12 +523,29 @@
    "label": "Newsletter",
    "no_copy": 1,
    "set_only_once": 1
+  },
+  {
+   "default": "Normal",
+   "fieldname": "priority",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Priority",
+   "no_copy": 1,
+   "options": "Low\nNormal\nHigh",
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "section_break_kk2t",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-17 12:57:58.810632",
+ "modified": "2025-07-18 11:45:01.025319",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Queue",

--- a/mail/mail/doctype/mail_queue/mail_queue.json
+++ b/mail/mail/doctype/mail_queue/mail_queue.json
@@ -528,7 +528,6 @@
    "label": "Priority",
    "no_copy": 1,
    "options": "\nLow\nNormal\nHigh",
-   "read_only": 1,
    "search_index": 1,
    "set_only_once": 1
   },
@@ -540,7 +539,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-18 12:42:03.811805",
+ "modified": "2025-07-18 12:57:35.361455",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Queue",

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -228,6 +228,7 @@ class MailQueue(Document):
 
 	def validate(self) -> None:
 		if self.is_new():
+			self.validate_priority()
 			self.validate_status()
 			self.validate_account()
 			self.validate_raw_message()
@@ -250,6 +251,16 @@ class MailQueue(Document):
 			self._process()
 		elif self.delivery_mode == "Enqueue":
 			frappe.enqueue_doc(self.doctype, self.name, "_process", queue="short", enqueue_after_commit=True)
+
+	def validate_priority(self) -> None:
+		"""Validates the priority."""
+
+		if self.newsletter:
+			self.priority = "Low"
+		elif self.received_after <= 5:
+			self.priority = "High"
+		else:
+			self.priority = "Normal"
 
 	def validate_status(self) -> None:
 		"""Validates the status."""

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -124,7 +124,7 @@ class MailQueue(Document):
 			"Normal": "0",
 			"High": "4",
 		}
-		return mt_priority_map[self.priority]
+		return mt_priority_map.get(self.priority, "0")
 
 	@property
 	def to(self) -> list[dict[str, str | None]]:
@@ -254,6 +254,9 @@ class MailQueue(Document):
 
 	def validate_priority(self) -> None:
 		"""Validates the priority."""
+
+		if self.priority:
+			return
 
 		if self.newsletter:
 			self.priority = "Low"

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -14,7 +14,7 @@ from frappe.core.doctype.file.file import File
 from frappe.core.doctype.file.file import has_permission as has_file_permission
 from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.model.document import Document
-from frappe.query_builder import Order
+from frappe.query_builder import Case, Order
 from frappe.utils import (
 	add_to_date,
 	cint,
@@ -910,6 +910,13 @@ def enqueue_process_pending_emails(batch_process_size: int = 1_000, max_batch_si
 	"""Enqueue process pending emails."""
 
 	MQ = frappe.qb.DocType("Mail Queue")
+
+	priority_order = Case()
+	priority_order.when(MQ.priority == "High", 1)
+	priority_order.when(MQ.priority == "Normal", 2)
+	priority_order.when(MQ.priority == "Low", 3)
+	priority_order.else_(4)
+
 	mails = (
 		frappe.qb.from_(MQ)
 		.select(MQ.name)
@@ -917,13 +924,13 @@ def enqueue_process_pending_emails(batch_process_size: int = 1_000, max_batch_si
 			(MQ.status == "Pending")
 			| (
 				(MQ.failed_count > 0)
-				& (MQ.failed_count < 3)
+				# & (MQ.failed_count < 3)
 				& (MQ.next_retry_after <= now_datetime())
 				& (MQ.status.isin(["Failed", "Failed to Draft", "Failed to Submit"]))
 			)
 			| ((MQ.status == "Queued") & (MQ.queued_at <= get_datetime(add_to_date(now(), minutes=-30))))
 		)
-		.orderby(MQ.creation, MQ.failed_count, order=Order.asc)
+		.orderby(priority_order, MQ.creation, MQ.failed_count, order=Order.asc)
 		.limit(max_batch_size)
 	).run(pluck="name")
 

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -116,6 +116,17 @@ class MailQueue(Document):
 		return doc
 
 	@property
+	def _priority(self) -> str:
+		"""Returns the MT-Priority value based on the priority field."""
+
+		mt_priority_map = {
+			"Low": "-4",
+			"Normal": "0",
+			"High": "4",
+		}
+		return mt_priority_map[self.priority]
+
+	@property
 	def to(self) -> list[dict[str, str | None]]:
 		"""Returns the recipients in the To field."""
 
@@ -651,6 +662,7 @@ class MailQueue(Document):
 										"parameters": {
 											"RET": "FULL",
 											"ENVID": self.name,
+											"MT-PRIORITY": self._priority,
 										},
 									},
 									"rcptTo": [


### PR DESCRIPTION
Provide an MT-Priority ([RFC 6710](https://www.rfc-editor.org/rfc/rfc6710.html)) - Mixer ([RFC 2156](https://www.rfc-editor.org/rfc/rfc2156)) value while submitting an email via JMAP.

**Note:** MT Priority should be enabled with Policy as `mixer` on Stalwart > SMTP > Inbound > Extensions.