### PR TITLE
fix: use lock while fetching email changes

### DIFF
--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -31,10 +31,12 @@ from mail.utils import convert_html_to_text, enqueue_job, user_context
 from mail.utils.cache import get_account_for_user
 from mail.utils.dt import parse_iso_datetime
 from mail.utils.email_parser import EmailParser
+from mail.utils.lock import acquire_lock, release_lock
 from mail.utils.user import get_account_email_addresses, is_account_owner, is_system_manager
 from mail.utils.validation import validate_permission_for_account
 
 BLOB_CACHE_TTL = 3600
+FETCH_LOCK_TIMEOUT = 300
 
 
 class EmailMessage(Document):
@@ -1181,18 +1183,31 @@ def fetch_changes(account: str, email_state: str | None = None) -> None:
 		)
 
 
+def locked_fetch_changes(account: str, email_state: str | None, lock_id: str) -> None:
+	"""Fetch changes for the specified account with a lock to prevent concurrent execution."""
+
+	try:
+		fetch_changes(account, email_state)
+	finally:
+		release_lock(f"fetch_changes:{account}", lock_id)
+
+
 def enqueue_fetch_changes(account: str, email_state: str | None = None) -> None:
 	"""Enqueue the fetch_changes job for the specified account."""
 
+	lockname = f"fetch_changes:{account}"
+	identifier = acquire_lock(lockname, acquire_timeout=0, lock_timeout=FETCH_LOCK_TIMEOUT)
+
+	if not identifier:
+		return
+
 	with user_context("Administrator"):
-		job_id = f"fetch_changes:{account}"
 		enqueue_job(
-			fetch_changes,
+			locked_fetch_changes,
 			account=account,
 			email_state=email_state,
+			lock_id=identifier,
 			queue="short",
-			job_id=job_id,
-			deduplicate=True,
 			enqueue_after_commit=True,
 		)
 

--- a/mail/utils/lock.py
+++ b/mail/utils/lock.py
@@ -1,0 +1,62 @@
+import time
+
+import frappe
+from frappe import _
+from redis.exceptions import WatchError
+from uuid_utils import uuid7
+
+
+def acquire_lock(lockname: str, acquire_timeout: int, lock_timeout: int) -> str | None:
+	"""
+	Acquire a distributed lock using Redis.
+	Returns a unique identifier for the lock if acquired, else None.
+
+	:param lockname: Unique lock name
+	:param acquire_timeout: How long to wait for lock (0 = no wait)
+	:param lock_timeout: TTL for lock in seconds
+	"""
+
+	if lock_timeout <= 0:
+		frappe.throw(_("Lock timeout must be greater than 0 seconds."))
+
+	cache = frappe.cache()
+	identifier = str(uuid7())
+	lock_key = f"lock:{lockname}"
+
+	if acquire_timeout == 0:
+		return identifier if cache.set(lock_key, identifier, ex=lock_timeout, nx=True) else None
+
+	end = time.time() + acquire_timeout
+	while time.time() < end:
+		if cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
+			return identifier
+		time.sleep(0.001)
+
+	return None
+
+
+def release_lock(lockname: str, identifier: str) -> bool:
+	"""
+	Release the lock only if it is held by the caller.
+	"""
+
+	cache = frappe.cache()
+	lock_key = f"lock:{lockname}"
+	pipe = cache.pipeline(True)
+
+	while True:
+		try:
+			pipe.watch(lock_key)
+			value = pipe.get(lock_key)
+			if value and value.decode() == identifier:
+				pipe.multi()
+				pipe.delete(lock_key)
+				pipe.execute()
+				return True
+
+			pipe.unwatch()
+			break
+		except WatchError:
+			continue
+
+	return False

--- a/mail/utils/lock.py
+++ b/mail/utils/lock.py
@@ -20,13 +20,18 @@ def acquire_lock(lockname: str, acquire_timeout: int, lock_timeout: int) -> str 
 		frappe.throw(_("Lock timeout must be greater than 0 seconds."))
 
 	identifier = str(uuid7())
-	lock_key = f"lock:{lockname}"
+	lock_key = frappe.cache.make_key(f"lock:{lockname}")
 
 	if acquire_timeout == 0:
-		return identifier if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True) else None
+		# nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
+		if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
+			return identifier
+		else:
+			return None
 
 	end = time.time() + acquire_timeout
 	while time.time() < end:
+		# nosemgrep: frappe-semgrep-rules.rules.frappe-cache-breaks-multitenancy
 		if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
 			return identifier
 		time.sleep(0.001)
@@ -39,7 +44,7 @@ def release_lock(lockname: str, identifier: str) -> bool:
 	Release the lock only if it is held by the caller.
 	"""
 
-	lock_key = f"lock:{lockname}"
+	lock_key = frappe.cache.make_key(f"lock:{lockname}")
 	pipe = frappe.cache.pipeline(True)
 
 	while True:

--- a/mail/utils/lock.py
+++ b/mail/utils/lock.py
@@ -19,16 +19,15 @@ def acquire_lock(lockname: str, acquire_timeout: int, lock_timeout: int) -> str 
 	if lock_timeout <= 0:
 		frappe.throw(_("Lock timeout must be greater than 0 seconds."))
 
-	cache = frappe.cache()
 	identifier = str(uuid7())
 	lock_key = f"lock:{lockname}"
 
 	if acquire_timeout == 0:
-		return identifier if cache.set(lock_key, identifier, ex=lock_timeout, nx=True) else None
+		return identifier if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True) else None
 
 	end = time.time() + acquire_timeout
 	while time.time() < end:
-		if cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
+		if frappe.cache.set(lock_key, identifier, ex=lock_timeout, nx=True):
 			return identifier
 		time.sleep(0.001)
 
@@ -40,9 +39,8 @@ def release_lock(lockname: str, identifier: str) -> bool:
 	Release the lock only if it is held by the caller.
 	"""
 
-	cache = frappe.cache()
 	lock_key = f"lock:{lockname}"
-	pipe = cache.pipeline(True)
+	pipe = frappe.cache.pipeline(True)
 
 	while True:
 		try:


### PR DESCRIPTION
```
Traceback with variables (most recent call last):
  File "apps/mail/mail/api/jmap.py", line 36, in push_notification
    enqueue_fetch_changes(account, state)
      account = 'notifications@frappecloud.com'
      request_data = {'@type': 'StateChange', 'changed': {'it': {'Thread': 'sv7ura', 'Mailbox': 'sv7ura', 'Email': 'sv7ura'}}}
      changes = [{'Thread': 'sv7ura', 'Mailbox': 'sv7ura', 'Email': 'sv7ura'}]
      change = {'Thread': 'sv7ura', 'Mailbox': 'sv7ura', 'Email': 'sv7ura'}
      key = ********
      state = 'sv7ura'
  File "apps/mail/mail/mail/doctype/email_message/email_message.py", line 1189, in enqueue_fetch_changes
    enqueue_job(
      account = 'notifications@frappecloud.com'
      email_state = 'sv7ura'
      job_id = 'fetch_changes:notifications@frappecloud.com'
  File "apps/mail/mail/utils/__init__.py", line 185, in enqueue_job
    frappe.enqueue(method, job_id=job_id, deduplicate=deduplicate, **kwargs)
      method = <function fetch_changes at 0x7f4b3c156c00>
      job_id = 'fetch_changes:notifications@frappecloud.com'
      deduplicate = True
      kwargs = {'account': 'notifications@frappecloud.com', 'email_state': 'sv7ura', 'queue': 'short', 'enqueue_after_commit': True}
  File "apps/frappe/frappe/utils/background_jobs.py", line 128, in enqueue
    job.delete()
      method = <function fetch_changes at 0x7f4b3c156c00>
      queue = 'short'
      timeout = None
      event = None
      is_async = True
      job_name = None
      now = False
      enqueue_after_commit = True
      on_success = None
      on_failure = None
      at_front = False
      job_id = 'fetch_changes:notifications@frappecloud.com'
      deduplicate = True
      at_front_when_starved = False
      kwargs = {'account': 'notifications@frappecloud.com', 'email_state': 'sv7ura'}
      job = <Job frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com: frappe.utils.background_jobs.execute_job(event=None, is_async=True, job_name='mail.mail.doctype.email_message.email_message.fetch_changes', kwargs={'account': 'notifications@frappecloud.com', 'email_state': 'svoura'}, method=<function fetch_changes at 0x7f4b3cfd4e00>, site='frappemail.frappe.cloud', user='Administrator')>
  File "env/lib/python3.11/site-packages/rq/job.py", line 1319, in delete
    self._remove_from_registries(pipeline=pipeline, remove_from_queue=remove_from_queue)
      self = <Job frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com: frappe.utils.background_jobs.execute_job(event=None, is_async=True, job_name='mail.mail.doctype.email_message.email_message.fetch_changes', kwargs={'account': 'notifications@frappecloud.com', 'email_state': 'svoura'}, method=<function fetch_changes at 0x7f4b3cfd4e00>, site='frappemail.frappe.cloud', user='Administrator')>
      pipeline = None
      remove_from_queue = True
      delete_dependents = False
      connection = <redis.client.Redis(<redis.connection.ConnectionPool(<redis.connection.Connection(host=localhost,port=11000,db=0)>)>)>
  File "env/lib/python3.11/site-packages/rq/job.py", line 1261, in _remove_from_registries
    if self.is_finished:
      self = <Job frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com: frappe.utils.background_jobs.execute_job(event=None, is_async=True, job_name='mail.mail.doctype.email_message.email_message.fetch_changes', kwargs={'account': 'notifications@frappecloud.com', 'email_state': 'svoura'}, method=<function fetch_changes at 0x7f4b3cfd4e00>, site='frappemail.frappe.cloud', user='Administrator')>
      pipeline = None
      remove_from_queue = True
      BaseRegistry = rq.registry.BaseRegistry
      Queue = rq.queue.Queue
      q = <Queue home-frappe-frappe-bench:short>
  File "env/lib/python3.11/site-packages/rq/job.py", line 442, in is_finished
    return self.get_status() == JobStatus.FINISHED
      self = <Job frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com: frappe.utils.background_jobs.execute_job(event=None, is_async=True, job_name='mail.mail.doctype.email_message.email_message.fetch_changes', kwargs={'account': 'notifications@frappecloud.com', 'email_state': 'svoura'}, method=<function fetch_changes at 0x7f4b3cfd4e00>, site='frappemail.frappe.cloud', user='Administrator')>
  File "env/lib/python3.11/site-packages/rq/job.py", line 410, in get_status
    raise InvalidJobOperation(f'Failed to retrieve status for job: {self.id}')
      self = <Job frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com: frappe.utils.background_jobs.execute_job(event=None, is_async=True, job_name='mail.mail.doctype.email_message.email_message.fetch_changes', kwargs={'account': 'notifications@frappecloud.com', 'email_state': 'svoura'}, method=<function fetch_changes at 0x7f4b3cfd4e00>, site='frappemail.frappe.cloud', user='Administrator')>
      refresh = True
      status = None
rq.exceptions.InvalidJobOperation: Failed to retrieve status for job: frappemail.frappe.cloud||fetch_changes|notifications@frappecloud.com
```