### PR TITLE
feat: Mailbox Management

### DIFF
--- a/frontend/src/types/doctypes.ts
+++ b/frontend/src/types/doctypes.ts
@@ -420,8 +420,6 @@ export interface EmailMessage extends DocType {
 	text_body?: string
 	/** Draft: Check */
 	draft: 0 | 1
-	/** Mailbox Role: Data */
-	mailbox_role?: string
 	/** Flagged: Check */
 	flagged: 0 | 1
 	/** Answered: Check */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -55,7 +55,6 @@ export interface Mail {
 	draft: 0 | 1
 	flagged: 0 | 1
 	seen: 0 | 1
-	mailbox_role: string
 	recipients: {
 		To: Recipient[]
 		Cc: Recipient[]

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -7,11 +7,12 @@ from frappe import _
 from frappe.query_builder.functions import Count
 from frappe.utils import format_datetime, random_string
 
-from mail.jmap import get_mailboxes_for_account
+from mail.jmap import get_mailbox_id_by_role, get_mailboxes_for_account
 from mail.mail.doctype.email_message.email_message import EmailMessage, enqueue_fetch_changes
 from mail.mail.doctype.email_message.search import EmailSearch
 from mail.mail.doctype.mail_queue.mail_queue import MailQueue
 from mail.utils import convert_html_to_text
+from mail.utils.cache import get_account_for_user
 from mail.utils.rate_limiter import dynamic_rate_limit
 from mail.utils.user import has_role
 from mail.utils.validation import validate_permission_for_account
@@ -42,22 +43,25 @@ def get_mails_from_mailbox(mailbox: str, limit: int, filter_by: str | None = Non
 
 
 @frappe.whitelist()
-def get_mailbox_thread_count(mailbox: str) -> int:
+def get_mailbox_thread_count(mailbox_id: str) -> int:
 	"""Returns no. of mails for the given mailbox."""
 
 	EM = frappe.qb.DocType("Email Message")
-
+	account = get_account_for_user(frappe.session.user)
 	distinct_threads = (
 		frappe.qb.from_(EM)
 		.select(EM.thread_id)
 		.distinct()
-		.where((EM.account == frappe.session.user) & (EM.destroyed == 0))
+		.where((EM.account == account) & (EM.destroyed == 0))
 	)
 
-	if mailbox == "starred":
-		distinct_threads = distinct_threads.where((EM.flagged == 1) & (EM.mailbox_role != "trash"))
+	if mailbox_id == "starred":
+		distinct_threads = distinct_threads.where(EM.flagged == 1)
+
+		if trash_mailbox_id := get_mailbox_id_by_role(account, "trash"):
+			distinct_threads = distinct_threads.where(EM.mailbox_id != trash_mailbox_id)
 	else:
-		distinct_threads = distinct_threads.where(EM.mailbox_role == mailbox)
+		distinct_threads = distinct_threads.where(EM.mailbox_id == mailbox_id)
 
 	count = (frappe.qb.from_(distinct_threads).select(Count("*").as_("count"))).run()
 
@@ -75,11 +79,11 @@ def get_mailboxes() -> list[dict]:
 	EmailMessage = frappe.qb.DocType("Email Message")
 	unseen_counts = (
 		frappe.qb.from_(EmailMessage)
-		.select(EmailMessage.mailbox_role, Count("*").as_("count"))
+		.select(EmailMessage.mailbox_id, Count("*").as_("count"))
 		.where((EmailMessage.account == user) & (EmailMessage.destroyed == 0) & (EmailMessage.seen == 0))
-		.groupby(EmailMessage.mailbox_role)
+		.groupby(EmailMessage.mailbox_id)
 	).run(as_dict=True)
-	unseen_map = {item["mailbox_role"]: item["count"] for item in unseen_counts}
+	unseen_map = {item["mailbox_id"]: item["count"] for item in unseen_counts}
 
 	mailboxes = get_mailboxes_for_account(user)
 	for mailbox in mailboxes:
@@ -123,7 +127,7 @@ def get_thread_rows(thread_id: str) -> list[dict]:
 			EM.draft,
 			EM.seen,
 			EM.flagged,
-			EM.mailbox_role,
+			EM.mailbox_id,
 			EMR.type,
 			EMR.email,
 			EMR.display_name,
@@ -155,7 +159,7 @@ def group_thread_mail_recipients(rows: list[dict]) -> tuple[dict, set]:
 				"draft": row["draft"],
 				"seen": row["seen"],
 				"flagged": row["flagged"],
-				"mailbox_role": row["mailbox_role"],
+				"mailbox_id": row["mailbox_id"],
 				"recipients": defaultdict(list),
 				"reply_to": [],
 			}
@@ -456,13 +460,13 @@ def set_mails_mailbox(mail_ids: list[str], mailbox: str) -> None:
 
 
 @frappe.whitelist()
-def empty_mailbox(mailbox: str) -> None:
+def empty_mailbox(mailbox_id: str) -> None:
 	"""Empties selected mailbox for current user."""
 
 	user = frappe.session.user
 	messages = frappe.get_all(
 		"Email Message",
-		{"account": user, "mailbox_role": ["in", mailbox], "destroyed": 0},
+		{"account": user, "mailbox_id": ["in", mailbox_id], "destroyed": 0},
 		pluck="name",
 	)
 	EmailMessage.destroy_emails(user, messages)

--- a/mail/backend.py
+++ b/mail/backend.py
@@ -223,7 +223,6 @@ class MailBackendAccountManager(MailBackendManagerBase):
 			secrets=[secret],
 			emails=[email],
 			roles=["user"],
-			disabledPermissions=["jmap-mailbox-set"],
 		).__dict__
 		self.create_request(
 			method="POST",

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -181,6 +181,7 @@ has_permission = {
 	"Mail Domain Request": "mail.mail.doctype.mail_domain_request.mail_domain_request.has_permission",
 	"Mail Domain": "mail.mail.doctype.mail_domain.mail_domain.has_permission",
 	"Mail Account": "mail.mail.doctype.mail_account.mail_account.has_permission",
+	"Mailbox": "mail.mail.doctype.mailbox.mailbox.has_permission",
 	"Mailing List": "mail.mail.doctype.mailing_list.mailing_list.has_permission",
 	"Mailing List Member": "mail.mail.doctype.mailing_list_member.mailing_list_member.has_permission",
 	"Mailing List External Member": "mail.mail.doctype.mailing_list_external_member.mailing_list_external_member.has_permission",

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -328,6 +328,32 @@ class JMAPClient:
 		)
 		return response["methodResponses"][0][1]
 
+	def mailbox_destroy(self, mailbox_ids: list[str], remove_emails: bool = False) -> dict:
+		"""Destroys the mailboxes with the given IDs."""
+
+		result = {"destroyed": [], "notDestroyed": {}}
+		for ids_batch in create_batch(mailbox_ids, self.max_objects_in_set):
+			response = self._make_request(
+				using=["urn:ietf:params:jmap:mail"],
+				method_calls=[
+					[
+						"Mailbox/set",
+						{
+							"accountId": self.account_id,
+							"destroy": ids_batch,
+							"onDestroyRemoveEmails": remove_emails,
+						},
+						"0",
+					]
+				],
+			)
+
+			result["destroyed"].extend(response["methodResponses"][0][1].get("destroyed", []))
+			if not_destroyed := response["methodResponses"][0][1].get("notDestroyed", {}):
+				result["notDestroyed"].update(not_destroyed)
+
+		return result
+
 	def email_query(self, filter: dict, position: int = 0, limit: int = 50) -> dict:
 		"""Query emails based on the provided filter."""
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -175,8 +175,9 @@ class JMAPClient:
 			return [
 				{
 					"id": mailbox["id"],
+					"name": mailbox["name"],
 					"role": mailbox["role"],
-					"name": mailbox["_name"],
+					"_name": mailbox["_name"],
 					"_parent": mailbox["_parent"],
 					"parent_id": mailbox["parent_id"],
 					"subscribed": mailbox["subscribed"],
@@ -233,7 +234,7 @@ class JMAPClient:
 
 		for mailbox in self.mailboxes:
 			if id and mailbox["id"] == id:
-				return mailbox["name"]
+				return mailbox["_name"]
 
 		if raise_exception:
 			frappe.throw(

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -267,7 +267,7 @@ class JMAPClient:
 		role: str | None = None,
 		parent: str | None = None,
 		sort_order: int = 0,
-		is_subscribed: bool = True,
+		subscribed: bool = True,
 	) -> dict:
 		"""Creates a mailbox with the given parameters."""
 
@@ -284,7 +284,7 @@ class JMAPClient:
 								"role": role or None,
 								"parentId": parent or None,
 								"sortOrder": sort_order or 0,
-								"isSubscribed": is_subscribed or False,
+								"isSubscribed": subscribed or False,
 							}
 						},
 					},
@@ -301,7 +301,7 @@ class JMAPClient:
 		role: str | None = None,
 		parent: str | None = None,
 		sort_order: int = 0,
-		is_subscribed: bool = True,
+		subscribed: bool = True,
 	) -> dict:
 		"""Updates the mailbox with the given parameters."""
 
@@ -318,7 +318,7 @@ class JMAPClient:
 								"role": role or None,
 								"parentId": parent or None,
 								"sortOrder": sort_order or 0,
-								"isSubscribed": is_subscribed or False,
+								"isSubscribed": subscribed or False,
 							}
 						},
 					},

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -260,6 +260,40 @@ class JMAPClient:
 
 		return response["methodResponses"][0][1]["list"]
 
+	def mailbox_create(
+		self,
+		unique_id: str,
+		name: str,
+		role: str | None = None,
+		parent: str | None = None,
+		sort_order: int = 0,
+		is_subscribed: bool = True,
+	) -> dict:
+		"""Creates a mailbox with the given parameters."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"Mailbox/set",
+					{
+						"accountId": self.account_id,
+						"create": {
+							unique_id: {
+								"name": name,
+								"role": role or None,
+								"parentId": parent or None,
+								"sortOrder": sort_order or 0,
+								"isSubscribed": is_subscribed or False,
+							}
+						},
+					},
+					"0",
+				]
+			],
+		)
+		return response["methodResponses"][0][1]
+
 	def email_query(self, filter: dict, position: int = 0, limit: int = 50) -> dict:
 		"""Query emails based on the provided filter."""
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -241,6 +241,25 @@ class JMAPClient:
 			if (id and mailbox.get("id") == id) or (role and mailbox_role.lower() == role.lower()):
 				return mailbox["name"]
 
+	def mailbox_get(self, mailbox_ids: list[str] | None = None) -> dict:
+		"""Returns the mailboxes for the provided mailbox IDs."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"Mailbox/get",
+					{
+						"accountId": self.account_id,
+						"ids": mailbox_ids,
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]["list"]
+
 	def email_query(self, filter: dict, position: int = 0, limit: int = 50) -> dict:
 		"""Query emails based on the provided filter."""
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -171,14 +171,7 @@ class JMAPClient:
 		"""Returns the mailboxes for the logged-in user."""
 
 		def generator() -> dict[list[dict]]:
-			mailboxes = {}
-			for account_id in [self.account_id]:
-				response = self._make_request(
-					["urn:ietf:params:jmap:mail"], [["Mailbox/get", {"accountId": account_id}, "0"]]
-				)
-				mailboxes[account_id] = response["methodResponses"][0][1]["list"]
-
-			return mailboxes
+			return {self.account_id: self.mailbox_get()}
 
 		return frappe.cache.hget("jmap:mailboxes", self.__session.auth[0], generator)
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -167,11 +167,23 @@ class JMAPClient:
 		return self.capabilities["urn:ietf:params:jmap:core"].get("maxConcurrentUpload", 4)
 
 	@property
-	def mailboxes(self) -> dict[list[dict]]:
+	def mailboxes(self) -> list[dict]:
 		"""Returns the mailboxes for the logged-in user."""
 
-		def generator() -> dict[list[dict]]:
-			return {self.account_id: self.mailbox_get()}
+		def generator() -> list[dict]:
+			mailboxes = frappe.db.get_all("Mailbox", {"account": self.__session.auth[0]})
+			return [
+				{
+					"id": mailbox["id"],
+					"role": mailbox["role"],
+					"name": mailbox["_name"],
+					"_parent": mailbox["_parent"],
+					"parent_id": mailbox["parent_id"],
+					"subscribed": mailbox["subscribed"],
+					"_sort_order": mailbox["_sort_order"],
+				}
+				for mailbox in mailboxes
+			]
 
 		return frappe.cache.hget("jmap:mailboxes", self.__session.auth[0], generator)
 
@@ -187,51 +199,26 @@ class JMAPClient:
 
 		return frappe.cache.hget("jmap:identities", self.__session.auth[0], generator)
 
-	def get_mailboxes(self) -> list[dict]:
-		"""Returns the mailboxes for the logged-in user."""
+	def get_mailbox_id_by_role(self, role: str) -> str | None:
+		"""Returns the mailbox ID for the given role."""
 
-		mailboxes = []
-		for mailbox in self.mailboxes[self.account_id]:
-			mailboxes.append(
-				{
-					"id": mailbox["id"],
-					"name": mailbox["name"],
-					"role": mailbox["role"],
-				}
-			)
-
-		if mailboxes:
-			role_order = ["inbox", "sent", "drafts", "junk", "trash"]
-			role_priority = {role: i for i, role in enumerate(role_order)}
-
-			return sorted(mailboxes, key=lambda m: (role_priority.get(m["role"], len(role_order))))
-
-		return mailboxes
-
-	def get_mailbox_id(self, role: str | None = None, name: str | None = None) -> str | None:
-		"""Returns the mailbox ID for the given role or name."""
-
-		for mailbox in self.mailboxes[self.account_id]:
+		for mailbox in self.mailboxes:
 			mailbox_role = mailbox.get("role") or ""
-			mailbox_name = mailbox.get("name") or ""
-			if (role and mailbox_role.lower() == role.lower()) or (
-				name and mailbox_name.lower() == name.lower()
-			):
+			if role and mailbox_role.lower() == role.lower():
 				return mailbox["id"]
 
-	def get_mailbox_role(self, id: str) -> str | None:
+	def get_mailbox_role_by_id(self, id: str) -> str | None:
 		"""Returns the mailbox role for the given ID."""
 
-		for mailbox in self.mailboxes[self.account_id]:
-			if mailbox.get("id") == id:
+		for mailbox in self.mailboxes:
+			if mailbox["id"] == id:
 				return mailbox["role"]
 
-	def get_mailbox_name(self, id: str | None = None, role: str | None = None) -> str | None:
-		"""Returns the mailbox name for the given ID or role."""
+	def get_mailbox_name_by_id(self, id: str) -> str | None:
+		"""Returns the mailbox name for the given ID."""
 
-		for mailbox in self.mailboxes[self.account_id]:
-			mailbox_role = mailbox.get("role") or ""
-			if (id and mailbox.get("id") == id) or (role and mailbox_role.lower() == role.lower()):
+		for mailbox in self.mailboxes:
+			if id and mailbox["id"] == id:
 				return mailbox["name"]
 
 	def mailbox_get(self, mailbox_ids: list[str] | None = None) -> list[dict]:
@@ -530,8 +517,8 @@ class JMAPClient:
 		"""Update emails mailbox."""
 
 		update_data = {}
-		junk_mailbox_id = self.get_mailbox_id(role="junk")
-		trash_mailbox_id = self.get_mailbox_id(role="trash")
+		junk_mailbox_id = self.get_mailbox_id_by_role(role="junk")
+		trash_mailbox_id = self.get_mailbox_id_by_role(role="trash")
 
 		for email in emails_to_move:
 			email_id, from_mailbox_id = email
@@ -837,7 +824,7 @@ def get_mailboxes(account: str) -> list[dict]:
 	"""Returns the mailboxes for the given account."""
 
 	client = get_jmap_client(account)
-	return client.get_mailboxes()
+	return client.mailboxes
 
 
 def get_identities(account: str) -> list[dict]:
@@ -847,25 +834,25 @@ def get_identities(account: str) -> list[dict]:
 	return client.identities
 
 
-def get_mailbox_id(account: str, role: str | None = None, name: str | None = None) -> str | None:
-	"""Returns the mailbox ID for the given role or name."""
+def get_mailbox_id_by_role(account: str, role: str) -> str | None:
+	"""Returns the mailbox ID for the given role."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_id(role, name)
+	return client.get_mailbox_id_by_role(role)
 
 
-def get_mailbox_role(account: str, id: str) -> str | None:
+def get_mailbox_role_by_id(account: str, id: str) -> str | None:
 	"""Returns the mailbox role for the given ID."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_role(id)
+	return client.get_mailbox_role_by_id(id)
 
 
-def get_mailbox_name(account: str, id: str | None = None, role: str | None = None) -> str | None:
-	"""Returns the mailbox name for the given ID or role."""
+def get_mailbox_name_by_id(account: str, id: str) -> str | None:
+	"""Returns the mailbox name for the given ID."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_name(id, role)
+	return client.get_mailbox_name_by_id(id)
 
 
 @frappe.whitelist()
@@ -877,19 +864,19 @@ def get_mailboxes_for_account(account: str) -> list[dict]:
 
 
 @frappe.whitelist()
-def get_mailbox_id_for_account(account: str, role: str | None = None, name: str | None = None) -> str | None:
-	"""Returns the mailbox ID for the given role or name."""
+def get_mailbox_id_for_account(account: str, role: str) -> str | None:
+	"""Returns the mailbox ID for the given role."""
 
 	validate_permission_for_account(account)
-	return get_mailbox_id(account, role, name)
+	return get_mailbox_id_by_role(account, role)
 
 
 @frappe.whitelist()
-def get_mailbox_name_for_account(account: str, id: str | None = None, role: str | None = None) -> str | None:
-	"""Returns the mailbox name for the given ID or role."""
+def get_mailbox_name_for_account(account: str, id: str) -> str | None:
+	"""Returns the mailbox name for the given ID."""
 
 	validate_permission_for_account(account)
-	return get_mailbox_name(account, id, role)
+	return get_mailbox_name_by_id(account, id)
 
 
 def raise_for_status(response: requests.Response) -> None:

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -241,7 +241,7 @@ class JMAPClient:
 			if (id and mailbox.get("id") == id) or (role and mailbox_role.lower() == role.lower()):
 				return mailbox["name"]
 
-	def mailbox_get(self, mailbox_ids: list[str] | None = None) -> dict:
+	def mailbox_get(self, mailbox_ids: list[str] | None = None) -> list[dict]:
 		"""Returns the mailboxes for the provided mailbox IDs."""
 
 		response = self._make_request(

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -294,6 +294,40 @@ class JMAPClient:
 		)
 		return response["methodResponses"][0][1]
 
+	def mailbox_set(
+		self,
+		mailbox_id: str,
+		name: str,
+		role: str | None = None,
+		parent: str | None = None,
+		sort_order: int = 0,
+		is_subscribed: bool = True,
+	) -> dict:
+		"""Updates the mailbox with the given parameters."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:mail"],
+			method_calls=[
+				[
+					"Mailbox/set",
+					{
+						"accountId": self.account_id,
+						"update": {
+							mailbox_id: {
+								"name": name,
+								"role": role or None,
+								"parentId": parent or None,
+								"sortOrder": sort_order or 0,
+								"isSubscribed": is_subscribed or False,
+							}
+						},
+					},
+					"0",
+				]
+			],
+		)
+		return response["methodResponses"][0][1]
+
 	def email_query(self, filter: dict, position: int = 0, limit: int = 50) -> dict:
 		"""Query emails based on the provided filter."""
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -199,7 +199,7 @@ class JMAPClient:
 
 		return frappe.cache.hget("jmap:identities", self.__session.auth[0], generator)
 
-	def get_mailbox_id_by_role(self, role: str) -> str | None:
+	def get_mailbox_id_by_role(self, role: str, raise_exception: bool = False) -> str | None:
 		"""Returns the mailbox ID for the given role."""
 
 		for mailbox in self.mailboxes:
@@ -207,19 +207,40 @@ class JMAPClient:
 			if role and mailbox_role.lower() == role.lower():
 				return mailbox["id"]
 
-	def get_mailbox_role_by_id(self, id: str) -> str | None:
+		if raise_exception:
+			frappe.throw(
+				_("Mailbox with role {0} not found for account {1}.").format(
+					frappe.bold(role), frappe.bold(self.__session.auth[0])
+				)
+			)
+
+	def get_mailbox_role_by_id(self, id: str, raise_exception: bool = False) -> str | None:
 		"""Returns the mailbox role for the given ID."""
 
 		for mailbox in self.mailboxes:
 			if mailbox["id"] == id:
 				return mailbox["role"]
 
-	def get_mailbox_name_by_id(self, id: str) -> str | None:
+		if raise_exception:
+			frappe.throw(
+				_("Mailbox with ID {0} not found for account {1}.").format(
+					frappe.bold(id), frappe.bold(self.__session.auth[0])
+				)
+			)
+
+	def get_mailbox_name_by_id(self, id: str, raise_exception: bool = False) -> str | None:
 		"""Returns the mailbox name for the given ID."""
 
 		for mailbox in self.mailboxes:
 			if id and mailbox["id"] == id:
 				return mailbox["name"]
+
+		if raise_exception:
+			frappe.throw(
+				_("Mailbox with ID {0} not found for account {1}.").format(
+					frappe.bold(id), frappe.bold(self.__session.auth[0])
+				)
+			)
 
 	def mailbox_get(self, mailbox_ids: list[str] | None = None) -> list[dict]:
 		"""Returns the mailboxes for the provided mailbox IDs."""
@@ -834,25 +855,25 @@ def get_identities(account: str) -> list[dict]:
 	return client.identities
 
 
-def get_mailbox_id_by_role(account: str, role: str) -> str | None:
+def get_mailbox_id_by_role(account: str, role: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox ID for the given role."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_id_by_role(role)
+	return client.get_mailbox_id_by_role(role, raise_exception=raise_exception)
 
 
-def get_mailbox_role_by_id(account: str, id: str) -> str | None:
+def get_mailbox_role_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox role for the given ID."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_role_by_id(id)
+	return client.get_mailbox_role_by_id(id, raise_exception=raise_exception)
 
 
-def get_mailbox_name_by_id(account: str, id: str) -> str | None:
+def get_mailbox_name_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox name for the given ID."""
 
 	client = get_jmap_client(account)
-	return client.get_mailbox_name_by_id(id)
+	return client.get_mailbox_name_by_id(id, raise_exception=raise_exception)
 
 
 @frappe.whitelist()
@@ -864,19 +885,19 @@ def get_mailboxes_for_account(account: str) -> list[dict]:
 
 
 @frappe.whitelist()
-def get_mailbox_id_for_account(account: str, role: str) -> str | None:
+def get_mailbox_id_for_account(account: str, role: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox ID for the given role."""
 
 	validate_permission_for_account(account)
-	return get_mailbox_id_by_role(account, role)
+	return get_mailbox_id_by_role(account, role, raise_exception=raise_exception)
 
 
 @frappe.whitelist()
-def get_mailbox_name_for_account(account: str, id: str) -> str | None:
+def get_mailbox_name_for_account(account: str, id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox name for the given ID."""
 
 	validate_permission_for_account(account)
-	return get_mailbox_name_by_id(account, id)
+	return get_mailbox_name_by_id(account, id, raise_exception=raise_exception)
 
 
 def raise_for_status(response: requests.Response) -> None:

--- a/mail/mail/doctype/email_message/email_message.js
+++ b/mail/mail/doctype/email_message/email_message.js
@@ -114,23 +114,31 @@ frappe.ui.form.on('Email Message', {
 	},
 
 	add_move_buttons(frm) {
-		const add_move_button = (label, target) => {
-			frm.add_custom_button(
-				__(label),
-				() => frm.events.move_to_mailbox(frm, target),
-				__('Move'),
-			)
-		}
+		frappe.call({
+			method: 'mail.jmap.get_mailboxes_for_account',
+			args: {
+				account: frm.doc.account,
+			},
+			freeze: true,
+			freeze_message: __('Loading Mailboxes...'),
+			callback: (r) => {
+				if (!r.exc) {
+					const mailboxes = r.message || []
+					if (mailboxes.length == 0) return
 
-		const current_role = frm.doc.mailbox_role
+					const current_mailbox = mailboxes.find((m) => m.id === frm.doc.mailbox_id)
+					mailboxes.forEach((mailbox) => {
+						if (mailbox.id == current_mailbox.id || mailbox.role === 'drafts') return
 
-		if (current_role !== 'trash') add_move_button('Move to Trash', 'trash')
-		if (current_role !== 'junk' && current_role !== 'sent')
-			add_move_button('Move to Junk', 'junk')
-		if (['trash', 'junk'].includes(current_role)) {
-			add_move_button('Move to Inbox', 'inbox')
-			add_move_button('Move to Sent', 'sent')
-		}
+						frm.add_custom_button(
+							__('Move to ' + mailbox._name),
+							() => frm.events.move_to_mailbox(frm, mailbox.id),
+							__('Move'),
+						)
+					})
+				}
+			},
+		})
 	},
 
 	add_draft_submit_buttons(frm) {
@@ -186,14 +194,14 @@ frappe.ui.form.on('Email Message', {
 		})
 	},
 
-	move_to_mailbox(frm, mailbox_role) {
+	move_to_mailbox(frm, mailbox_id) {
 		frappe.call({
 			doc: frm.doc,
 			method: 'move_to_mailbox',
 			freeze: true,
 			freeze_message: __('Moving to Mailbox...'),
 			args: {
-				mailbox_role: mailbox_role,
+				mailbox_id: mailbox_id,
 			},
 			callback: (r) => {
 				if (!r.exc) {

--- a/mail/mail/doctype/email_message/email_message.json
+++ b/mail/mail/doctype/email_message/email_message.json
@@ -35,7 +35,6 @@
   "sender_name",
   "sender_email",
   "in_reply_to",
-  "mailbox_role",
   "mailbox_id",
   "thread_id",
   "keywords_section",
@@ -514,15 +513,6 @@
    "search_index": 1
   },
   {
-   "fieldname": "mailbox_role",
-   "fieldtype": "Data",
-   "label": "Mailbox Role",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
-  },
-  {
    "default": "0",
    "depends_on": "eval: !doc.__islocal",
    "fieldname": "flagged",
@@ -568,7 +558,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-17 12:59:27.169419",
+ "modified": "2025-08-05 10:10:00.447666",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Email Message",

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -18,7 +18,7 @@ from frappe.utils import add_to_date, cint, escape_html, get_datetime, now, time
 from pypika import Case
 from uuid_utils import uuid7
 
-from mail.jmap import get_jmap_client, get_mailbox_id, get_mailbox_name, get_mailbox_role
+from mail.jmap import get_jmap_client, get_mailbox_id_by_role, get_mailbox_name_by_id, get_mailbox_role_by_id
 from mail.mail.doctype.email_message.search import EmailSearch
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import (
 	create_jmap_sync_state,
@@ -214,7 +214,7 @@ class EmailMessage(Document):
 		if not emails_to_move:
 			return
 
-		target_mailbox_id = mailbox_id or get_mailbox_id(account, role=mailbox_role)
+		target_mailbox_id = mailbox_id or get_mailbox_id_by_role(account, role=mailbox_role)
 
 		if not target_mailbox_id:
 			frappe.throw(_("Mailbox not found."))
@@ -222,8 +222,8 @@ class EmailMessage(Document):
 		try:
 			client = get_jmap_client(account)
 			client.email_set_mailbox(list(emails_to_move), target_mailbox_id)
-			target_mailbox_role = mailbox_role or get_mailbox_role(account, target_mailbox_id)
-			target_mailbox_name = get_mailbox_name(account, target_mailbox_id)
+			target_mailbox_role = mailbox_role or get_mailbox_role_by_id(account, target_mailbox_id)
+			target_mailbox_name = get_mailbox_name_by_id(account, target_mailbox_id)
 
 			# This database update could potentially cause a deadlock.
 			frappe.db.set_value(
@@ -395,8 +395,8 @@ class EmailMessage(Document):
 		email_message._id = email_data["id"]
 		email_message.account = account
 		email_message.mailbox_id = list(email_data["mailboxIds"].keys())[0]
-		email_message.mailbox_role = get_mailbox_role(account, email_message.mailbox_id)
-		email_message.folder = get_mailbox_name(account, email_message.mailbox_id)
+		email_message.mailbox_role = get_mailbox_role_by_id(account, email_message.mailbox_id)
+		email_message.folder = get_mailbox_name_by_id(account, email_message.mailbox_id)
 		email_message.subject = email_data["subject"]
 		email_message.sent_at = parse_iso_datetime(email_data["sentAt"])
 		email_message.received_at = parse_iso_datetime(email_data["receivedAt"])
@@ -481,8 +481,8 @@ class EmailMessage(Document):
 		_id = email_data["id"]
 
 		mailbox_id = list(email_data["mailboxIds"].keys())[0]
-		mailbox_role = get_mailbox_role(account, mailbox_id)
-		folder = get_mailbox_name(account, mailbox_id)
+		mailbox_role = get_mailbox_role_by_id(account, mailbox_id)
+		folder = get_mailbox_name_by_id(account, mailbox_id)
 
 		_keywords = json.dumps(email_data["keywords"])
 		draft = cint(email_data["keywords"].get("$draft", False))

--- a/mail/mail/doctype/email_message/email_message.py
+++ b/mail/mail/doctype/email_message/email_message.py
@@ -18,7 +18,7 @@ from frappe.utils import add_to_date, cint, escape_html, get_datetime, now, time
 from pypika import Case
 from uuid_utils import uuid7
 
-from mail.jmap import get_jmap_client, get_mailbox_id_by_role, get_mailbox_name_by_id, get_mailbox_role_by_id
+from mail.jmap import get_jmap_client, get_mailbox_id_by_role, get_mailbox_name_by_id
 from mail.mail.doctype.email_message.search import EmailSearch
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import (
 	create_jmap_sync_state,
@@ -70,7 +70,10 @@ class EmailMessage(Document):
 			subquery = subquery.where(EM.seen == 0)
 
 		if is_flagged:
-			subquery = subquery.where((EM.flagged == 1) & (EM.mailbox_role != "trash"))
+			subquery = subquery.where(EM.flagged == 1)
+
+			if trash_mailbox_id := get_mailbox_id_by_role(account, "trash"):
+				subquery = subquery.where(EM.mailbox_id != trash_mailbox_id)
 
 		if is_has_attachment:
 			subquery = subquery.where(EM.has_attachment == 1)
@@ -86,7 +89,7 @@ class EmailMessage(Document):
 				EM.from_name,
 				EM.from_email,
 				EM.subject,
-				EM.mailbox_role,
+				EM.mailbox_id,
 				Case().when(EM.html_body.isnotnull(), EM.html_body).else_(EM.text_body).as_("preview"),
 				EM.has_attachment,
 				EM.received_at,
@@ -195,16 +198,11 @@ class EmailMessage(Document):
 		return messages
 
 	@staticmethod
-	def move_emails_to_mailbox(
-		account: str,
-		message_ids: list[str],
-		mailbox_id: str | None = None,
-		mailbox_role: str | None = None,
-	) -> None:
+	def move_emails_to_mailbox(account: str, message_ids: list[str], mailbox_id: str) -> None:
 		"""Move emails to a specified mailbox."""
 
-		if not account or not message_ids or not (mailbox_id or mailbox_role):
-			frappe.throw(_("Account, message IDs, and mailbox ID/role/name are required."))
+		if not account or not message_ids or not mailbox_id:
+			frappe.throw(_("Account, message IDs, and mailbox ID are required."))
 
 		validate_permission_for_account(account)
 
@@ -214,24 +212,17 @@ class EmailMessage(Document):
 		if not emails_to_move:
 			return
 
-		target_mailbox_id = mailbox_id or get_mailbox_id_by_role(account, role=mailbox_role)
-
-		if not target_mailbox_id:
-			frappe.throw(_("Mailbox not found."))
-
 		try:
 			client = get_jmap_client(account)
-			client.email_set_mailbox(list(emails_to_move), target_mailbox_id)
-			target_mailbox_role = mailbox_role or get_mailbox_role_by_id(account, target_mailbox_id)
-			target_mailbox_name = get_mailbox_name_by_id(account, target_mailbox_id)
+			client.email_set_mailbox(list(emails_to_move), mailbox_id)
+			target_mailbox_name = get_mailbox_name_by_id(account, mailbox_id)
 
 			# This database update could potentially cause a deadlock.
 			frappe.db.set_value(
 				"Email Message",
 				filters,
 				{
-					"mailbox_id": target_mailbox_id,
-					"mailbox_role": target_mailbox_role,
+					"mailbox_id": mailbox_id,
 					"folder": target_mailbox_name,
 				},
 			)
@@ -382,7 +373,7 @@ class EmailMessage(Document):
 
 		if notify:
 			frappe.publish_realtime(
-				"mail_created_or_updated", email_message.mailbox_role, user=email_message.account
+				"mail_created_or_updated", email_message.mailbox_id, user=email_message.account
 			)
 
 	@staticmethod
@@ -395,7 +386,6 @@ class EmailMessage(Document):
 		email_message._id = email_data["id"]
 		email_message.account = account
 		email_message.mailbox_id = list(email_data["mailboxIds"].keys())[0]
-		email_message.mailbox_role = get_mailbox_role_by_id(account, email_message.mailbox_id)
 		email_message.folder = get_mailbox_name_by_id(account, email_message.mailbox_id)
 		email_message.subject = email_data["subject"]
 		email_message.sent_at = parse_iso_datetime(email_data["sentAt"])
@@ -481,7 +471,6 @@ class EmailMessage(Document):
 		_id = email_data["id"]
 
 		mailbox_id = list(email_data["mailboxIds"].keys())[0]
-		mailbox_role = get_mailbox_role_by_id(account, mailbox_id)
 		folder = get_mailbox_name_by_id(account, mailbox_id)
 
 		_keywords = json.dumps(email_data["keywords"])
@@ -497,7 +486,6 @@ class EmailMessage(Document):
 			filters,
 			{
 				"mailbox_id": mailbox_id,
-				"mailbox_role": mailbox_role,
 				"folder": folder,
 				"_keywords": _keywords,
 				"draft": draft,
@@ -772,12 +760,12 @@ class EmailMessage(Document):
 		EmailMessage.destroy_emails(self.account, [self.name])
 
 	@frappe.whitelist()
-	def move_to_mailbox(self, mailbox_id: str | None = None, mailbox_role: str | None = None) -> None:
+	def move_to_mailbox(self, mailbox_id: str) -> None:
 		"""Move the email message to a specified folder."""
 
 		self.validate_draft()
 		self.validate_destroyed()
-		EmailMessage.move_emails_to_mailbox(self.account, [self.name], mailbox_id, mailbox_role)
+		EmailMessage.move_emails_to_mailbox(self.account, [self.name], mailbox_id)
 		self.reload()
 
 	@frappe.whitelist()
@@ -1160,9 +1148,9 @@ def fetch_changes(account: str, email_state: str | None = None) -> None:
 			for d in frappe.get_all(
 				"Email Message",
 				filters={"account": account, "_id": ["in", updated_ids], "destroyed": 0},
-				fields=["name", "mailbox_role"],
+				fields=["name", "mailbox_id"],
 			):
-				search.set_value(d.name, "mailbox_role", d.mailbox_role)
+				search.set_value(d.name, "mailbox_id", d.mailbox_id)
 
 		if destroyed_ids := result["destroyed"]:
 			filters = {"account": account, "_id": ["in", destroyed_ids], "destroyed": 0}

--- a/mail/mail/doctype/email_message/search.py
+++ b/mail/mail/doctype/email_message/search.py
@@ -66,7 +66,7 @@ class EmailSearch:
 				"from_name",
 				"from_email",
 				"thread_id",
-				"mailbox_role",
+				"mailbox_id",
 				"received_at",
 			],
 		)
@@ -104,7 +104,7 @@ class EmailSearch:
 			"from_email": cstr(doc.from_email),
 			"recipients": cstr(doc.recipients),
 			"thread_id": cstr(doc.thread_id),
-			"mailbox_role": cstr(doc.mailbox_role),
+			"mailbox_id": cstr(doc.mailbox_id),
 			"received_at": cstr(doc.received_at),
 		}
 		self.ft.add_document(key, replace=True, **mapping)

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -592,8 +592,8 @@ class MailQueue(Document):
 
 		try:
 			client = get_jmap_client(self.account)
-			draft_mailbox_id = get_mailbox_id_by_role(self.account, role="drafts")
-			sent_mailbox_id = get_mailbox_id_by_role(self.account, role="sent")
+			draft_mailbox_id = get_mailbox_id_by_role(self.account, role="drafts", raise_exception=True)
+			sent_mailbox_id = get_mailbox_id_by_role(self.account, role="sent", raise_exception=True)
 
 			using = ["urn:ietf:params:jmap:mail"]
 			method_calls = []

--- a/mail/mail/doctype/mail_queue/mail_queue.py
+++ b/mail/mail/doctype/mail_queue/mail_queue.py
@@ -28,7 +28,7 @@ from frappe.utils import (
 )
 from uuid_utils import uuid7
 
-from mail.jmap import get_identities, get_jmap_client, get_mailbox_id
+from mail.jmap import get_identities, get_jmap_client, get_mailbox_id_by_role
 from mail.utils.cache import get_account_for_email, get_account_for_user
 from mail.utils.dt import convert_to_utc, parsedate_to_datetime
 from mail.utils.user import get_account_email_addresses, is_account_owner, is_system_manager
@@ -592,8 +592,8 @@ class MailQueue(Document):
 
 		try:
 			client = get_jmap_client(self.account)
-			draft_mailbox_id = get_mailbox_id(self.account, role="drafts")
-			sent_mailbox_id = get_mailbox_id(self.account, role="sent")
+			draft_mailbox_id = get_mailbox_id_by_role(self.account, role="drafts")
+			sent_mailbox_id = get_mailbox_id_by_role(self.account, role="sent")
 
 			using = ["urn:ietf:params:jmap:mail"]
 			method_calls = []

--- a/mail/mail/doctype/mailbox/mailbox.js
+++ b/mail/mail/doctype/mailbox/mailbox.js
@@ -1,8 +1,17 @@
 // Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Mailbox", {
-// 	refresh(frm) {
+frappe.ui.form.on('Mailbox', {
+	refresh(frm) {
+		frm.trigger('set_queries')
+	},
 
-// 	},
-// });
+	set_queries(frm) {
+		frm.set_query('_parent', () => ({
+			query: 'mail.utils.query.get_account_mailboxes',
+			filters: {
+				account: frm.doc.account,
+			},
+		}))
+	},
+})

--- a/mail/mail/doctype/mailbox/mailbox.js
+++ b/mail/mail/doctype/mailbox/mailbox.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Mailbox", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -13,6 +13,7 @@
   "_name",
   "role",
   "sort_order",
+  "_sort_order",
   "column_break_0da9",
   "_parent",
   "parent_id",
@@ -66,6 +67,7 @@
    "fieldtype": "Int",
    "in_list_view": 1,
    "label": "Sort Order",
+   "no_copy": 1,
    "non_negative": 1
   },
   {
@@ -159,13 +161,22 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Subscribed"
+  },
+  {
+   "fieldname": "_sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order",
+   "no_copy": 1,
+   "non_negative": 1,
+   "read_only": 1,
+   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 16:57:36.461211",
+ "modified": "2025-08-04 17:25:23.516057",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -10,8 +10,8 @@
   "is_subscribed",
   "section_break_cbgf",
   "id",
-  "role",
   "_name",
+  "role",
   "sort_order",
   "column_break_0da9",
   "_parent",
@@ -42,7 +42,8 @@
    "fieldname": "_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Name"
+   "label": "Name",
+   "reqd": 1
   },
   {
    "fieldname": "parent_id",
@@ -60,10 +61,12 @@
    "options": "\nall\narchive\ndrafts\nflagged\nimportant\ninbox\njunk\nsent\nsubscribed\ntrash"
   },
   {
+   "default": "0",
    "fieldname": "sort_order",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Sort Order"
+   "label": "Sort Order",
+   "non_negative": 1
   },
   {
    "fieldname": "total_emails",
@@ -162,7 +165,7 @@
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 11:17:12.671934",
+ "modified": "2025-08-04 14:05:49.384545",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -6,18 +6,24 @@
  "field_order": [
   "section_break_nuoa",
   "account",
+  "column_break_5a4x",
+  "is_subscribed",
+  "section_break_cbgf",
   "id",
+  "role",
   "_name",
+  "sort_order",
+  "column_break_0da9",
   "parent1",
   "parent_id",
-  "role",
-  "sort_order",
+  "section_break_9nkx",
   "total_emails",
   "unread_emails",
+  "column_break_cg5h",
   "total_threads",
   "unread_threads",
-  "my_rights",
-  "is_subscribed"
+  "section_break_uvft",
+  "rights"
  ],
  "fields": [
   {
@@ -41,7 +47,10 @@
   {
    "fieldname": "parent_id",
    "fieldtype": "Data",
-   "label": "Parent ID"
+   "label": "Parent ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "parent1",
@@ -59,57 +68,100 @@
   {
    "fieldname": "sort_order",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Sort Order"
   },
   {
    "fieldname": "total_emails",
    "fieldtype": "Int",
-   "label": "Total Emails"
-  },
-  {
-   "fieldname": "unread_emails",
-   "fieldtype": "Int",
-   "label": "Unread Emails"
-  },
-  {
-   "fieldname": "total_threads",
-   "fieldtype": "Int",
-   "label": "Total Threads"
-  },
-  {
-   "fieldname": "unread_threads",
-   "fieldtype": "Int",
-   "label": "Unread Threads"
-  },
-  {
-   "fieldname": "my_rights",
-   "fieldtype": "JSON",
-   "label": "My Rights",
+   "in_list_view": 1,
+   "label": "Total Emails",
    "no_copy": 1,
    "read_only": 1,
    "set_only_once": 1
   },
   {
-   "default": "0",
+   "fieldname": "unread_emails",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Unread Emails",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "total_threads",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Total Threads",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "unread_threads",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Unread Threads",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "default": "1",
    "fieldname": "is_subscribed",
    "fieldtype": "Check",
-   "label": "Is Subscribed"
+   "in_list_view": 1,
+   "label": "Subscribed"
   },
   {
    "fieldname": "account",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Account",
+   "no_copy": 1,
    "options": "Mail Account",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "section_break_uvft",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_9nkx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_cg5h",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_5a4x",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_cbgf",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_0da9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "rights",
+   "fieldtype": "JSON",
+   "label": "Rights",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 09:46:11.512908",
+ "modified": "2025-08-04 10:54:57.970095",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -7,7 +7,7 @@
   "section_break_nuoa",
   "account",
   "column_break_5a4x",
-  "is_subscribed",
+  "subscribed",
   "section_break_cbgf",
   "id",
   "_name",
@@ -58,7 +58,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Role",
-   "options": "\nall\narchive\ndrafts\nflagged\nimportant\ninbox\njunk\nsent\nsubscribed\ntrash"
+   "options": "\narchive\ndrafts\nimportant\ninbox\njunk\nsent\ntrash"
   },
   {
    "default": "0",
@@ -103,13 +103,6 @@
    "no_copy": 1,
    "read_only": 1,
    "set_only_once": 1
-  },
-  {
-   "default": "1",
-   "fieldname": "is_subscribed",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Subscribed"
   },
   {
    "fieldname": "account",
@@ -159,13 +152,20 @@
    "in_list_view": 1,
    "label": "Parent",
    "options": "Mailbox"
+  },
+  {
+   "default": "1",
+   "fieldname": "subscribed",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Subscribed"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 14:05:49.384545",
+ "modified": "2025-08-04 15:54:24.427160",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -5,6 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_nuoa",
+  "account",
   "id",
   "_name",
   "parent1",
@@ -26,7 +27,6 @@
   {
    "fieldname": "id",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "ID",
    "no_copy": 1,
    "read_only": 1,
@@ -35,6 +35,7 @@
   {
    "fieldname": "_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Name"
   },
   {
@@ -45,11 +46,13 @@
   {
    "fieldname": "parent1",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Parent"
   },
   {
    "fieldname": "role",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Role",
    "options": "\nall\narchive\ndrafts\nflagged\nimportant\ninbox\njunk\nsent\nsubscribed\ntrash"
   },
@@ -91,13 +94,22 @@
    "fieldname": "is_subscribed",
    "fieldtype": "Check",
    "label": "Is Subscribed"
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account",
+   "options": "Mail Account",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 09:10:55.951328",
+ "modified": "2025-08-04 09:46:11.512908",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -14,7 +14,7 @@
   "_name",
   "sort_order",
   "column_break_0da9",
-  "parent1",
+  "_parent",
   "parent_id",
   "section_break_9nkx",
   "total_emails",
@@ -51,12 +51,6 @@
    "no_copy": 1,
    "read_only": 1,
    "set_only_once": 1
-  },
-  {
-   "fieldname": "parent1",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Parent"
   },
   {
    "fieldname": "role",
@@ -155,13 +149,20 @@
    "no_copy": 1,
    "read_only": 1,
    "set_only_once": 1
+  },
+  {
+   "fieldname": "_parent",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Parent",
+   "options": "Mailbox"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 10:54:57.970095",
+ "modified": "2025-08-04 11:17:12.671934",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -165,7 +165,7 @@
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2025-08-04 15:54:24.427160",
+ "modified": "2025-08-04 16:57:36.461211",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox",
@@ -181,6 +181,13 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Mail User",
    "write": 1
   }
  ],

--- a/mail/mail/doctype/mailbox/mailbox.json
+++ b/mail/mail/doctype/mailbox/mailbox.json
@@ -1,0 +1,123 @@
+{
+ "actions": [],
+ "creation": "2025-08-01 10:56:53.714444",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_nuoa",
+  "id",
+  "_name",
+  "parent1",
+  "parent_id",
+  "role",
+  "sort_order",
+  "total_emails",
+  "unread_emails",
+  "total_threads",
+  "unread_threads",
+  "my_rights",
+  "is_subscribed"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_nuoa",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "_name",
+   "fieldtype": "Data",
+   "label": "Name"
+  },
+  {
+   "fieldname": "parent_id",
+   "fieldtype": "Data",
+   "label": "Parent ID"
+  },
+  {
+   "fieldname": "parent1",
+   "fieldtype": "Data",
+   "label": "Parent"
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Select",
+   "label": "Role",
+   "options": "\nall\narchive\ndrafts\nflagged\nimportant\ninbox\njunk\nsent\nsubscribed\ntrash"
+  },
+  {
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order"
+  },
+  {
+   "fieldname": "total_emails",
+   "fieldtype": "Int",
+   "label": "Total Emails"
+  },
+  {
+   "fieldname": "unread_emails",
+   "fieldtype": "Int",
+   "label": "Unread Emails"
+  },
+  {
+   "fieldname": "total_threads",
+   "fieldtype": "Int",
+   "label": "Total Threads"
+  },
+  {
+   "fieldname": "unread_threads",
+   "fieldtype": "Int",
+   "label": "Unread Threads"
+  },
+  {
+   "fieldname": "my_rights",
+   "fieldtype": "JSON",
+   "label": "My Rights",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subscribed",
+   "fieldtype": "Check",
+   "label": "Is Subscribed"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_virtual": 1,
+ "links": [],
+ "modified": "2025-08-04 09:10:55.951328",
+ "modified_by": "Administrator",
+ "module": "Mail",
+ "name": "Mailbox",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -12,10 +12,13 @@ from uuid_utils import uuid7
 from mail.jmap import get_jmap_client
 from mail.utils import extract_filter_values
 from mail.utils.cache import get_account_for_user
+from mail.utils.user import has_role, is_system_manager
+from mail.utils.validation import validate_permission_for_account
 
 
 class Mailbox(Document):
 	def db_insert(self, *args, **kwargs) -> None:
+		validate_permission_for_account(self.account)
 		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
 		self.id = add_mailbox(
 			self.account, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
@@ -24,10 +27,12 @@ class Mailbox(Document):
 
 	def load_from_db(self) -> "Mailbox":
 		account, id = self.name.split("|")
+		validate_permission_for_account(account)
 		mailbox = get_mailbox(account, id)
 		return super(Document, self).__init__(mailbox)
 
 	def db_update(self) -> None:
+		validate_permission_for_account(self.account)
 		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
 		update_mailbox(
 			self.account, self.id, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
@@ -36,6 +41,7 @@ class Mailbox(Document):
 
 	def delete(self) -> None:
 		account, id = self.name.split("|")
+		validate_permission_for_account(account)
 		delete_mailbox(account, id)
 
 	@staticmethod
@@ -52,6 +58,7 @@ class Mailbox(Document):
 			frappe.msgprint(_("Please select a account to view mailboxes."), alert=True)
 			return []
 
+		validate_permission_for_account(account)
 		mailboxes = fetch_mailboxes(account, limit=page_length)
 
 		if not mailboxes:
@@ -174,3 +181,18 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"creation": today(),
 		"modified": today(),
 	}
+
+
+def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Mailbox":
+		return False
+
+	user = user or frappe.session.user
+
+	if is_system_manager(user):
+		return True
+
+	if has_role(user, "Mail User"):
+		return doc.account == get_account_for_user(user)
+
+	return False

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -6,7 +6,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, now
+from frappe.utils import cint, today
 from uuid_utils import uuid7
 
 from mail.jmap import get_jmap_client
@@ -28,7 +28,10 @@ class Mailbox(Document):
 		return super(Document, self).__init__(mailbox)
 
 	def db_update(self) -> None:
-		raise NotImplementedError
+		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
+		update_mailbox(
+			self.account, self.id, self._name, self.role, parent, self.sort_order, bool(self.is_subscribed)
+		)
 
 	def delete(self) -> None:
 		raise NotImplementedError
@@ -60,7 +63,7 @@ class Mailbox(Document):
 
 	@staticmethod
 	def get_stats(**kwargs) -> dict:
-		pass
+		return {}
 
 
 def add_mailbox(
@@ -99,6 +102,27 @@ def get_mailbox(account: str, id: str) -> dict:
 	)
 
 
+def update_mailbox(
+	account: str,
+	id: str,
+	name: str,
+	role: str | None = None,
+	parent: str | None = None,
+	sort_order: int = 0,
+	is_subscribed: bool = True,
+) -> None:
+	"""Updates an existing mailbox with the given parameters."""
+
+	client = get_jmap_client(account)
+	response = client.mailbox_set(id, name, role, parent, sort_order, is_subscribed)
+
+	if not response.get("updated"):
+		if response.get("notUpdated"):
+			frappe.throw(_("Mailbox update failed: {0}").format(response["notUpdated"][id]["description"]))
+		else:
+			frappe.throw(_("Mailbox update failed: {0}").format(response["description"]))
+
+
 def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 	"""Returns a list of mailboxes for the given account."""
 
@@ -132,6 +156,6 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"total_threads": cint(mailbox["totalThreads"]),
 		"unread_threads": cint(mailbox["unreadThreads"]),
 		"rights": rights,
-		"creation": now(),
-		"modified": now(),
+		"creation": today(),
+		"modified": today(),
 	}

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -18,7 +18,7 @@ class Mailbox(Document):
 	def db_insert(self, *args, **kwargs) -> None:
 		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
 		self.id = add_mailbox(
-			self.account, self._name, self.role, parent, self.sort_order, bool(self.is_subscribed)
+			self.account, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
 		)
 		self.name = f"{self.account}|{self.id}"
 
@@ -30,8 +30,9 @@ class Mailbox(Document):
 	def db_update(self) -> None:
 		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
 		update_mailbox(
-			self.account, self.id, self._name, self.role, parent, self.sort_order, bool(self.is_subscribed)
+			self.account, self.id, self._name, self.role, parent, self.sort_order, bool(self.subscribed)
 		)
+		self.reload()
 
 	def delete(self) -> None:
 		raise NotImplementedError
@@ -72,13 +73,13 @@ def add_mailbox(
 	role: str | None = None,
 	parent: str | None = None,
 	sort_order: int = 0,
-	is_subscribed: bool = True,
+	subscribed: bool = True,
 ) -> str:
 	"""Adds a mailbox for the given account with the specified parameters."""
 
 	unique_id = str(uuid7())
 	client = get_jmap_client(account)
-	response = client.mailbox_create(unique_id, name, role, parent, sort_order, is_subscribed)
+	response = client.mailbox_create(unique_id, name, role, parent, sort_order, subscribed)
 
 	if response.get("created"):
 		return response["created"][unique_id]["id"]
@@ -109,12 +110,15 @@ def update_mailbox(
 	role: str | None = None,
 	parent: str | None = None,
 	sort_order: int = 0,
-	is_subscribed: bool = True,
+	subscribed: bool = True,
 ) -> None:
 	"""Updates an existing mailbox with the given parameters."""
 
+	if parent and id == parent:
+		frappe.throw(_("Mailbox cannot be a parent of itself."))
+
 	client = get_jmap_client(account)
-	response = client.mailbox_set(id, name, role, parent, sort_order, is_subscribed)
+	response = client.mailbox_set(id, name, role, parent, sort_order, subscribed)
 
 	if not response.get("updated"):
 		if response.get("notUpdated"):
@@ -150,7 +154,7 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"parent_id": mailbox["parentId"],
 		"role": mailbox["role"],
 		"sort_order": cint(mailbox["sortOrder"]),
-		"is_subscribed": bool(mailbox["isSubscribed"]),
+		"subscribed": bool(mailbox["isSubscribed"]),
 		"total_emails": cint(mailbox["totalEmails"]),
 		"unread_emails": cint(mailbox["unreadEmails"]),
 		"total_threads": cint(mailbox["totalThreads"]),

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -68,11 +68,25 @@ class Mailbox(Document):
 
 	@staticmethod
 	def get_count(filters=None, **kwargs) -> int:
-		return len(Mailbox.get_list(filters, **kwargs))
+		filters = filters or []
+		account_values = extract_filter_values(filters, [{"account": "="}])
+		account = (
+			account_values[0]
+			if account_values and account_values[0]
+			else get_account_for_user(frappe.session.user)
+		)
+
+		return frappe.cache.get_value(get_total_cache_key(account)) if account else 0
 
 	@staticmethod
 	def get_stats(**kwargs) -> dict:
 		return {}
+
+
+def get_total_cache_key(account: str) -> str:
+	"""Returns a cache key for total mailbox count for the given account."""
+
+	return f"{account}:mailboxes:total"
 
 
 def add_mailbox(
@@ -148,9 +162,9 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 
 	client = get_jmap_client(account)
 	mailboxes = client.mailbox_get()
-
 	formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
 	sorted_mailboxes = sorted(formatted_mailboxes, key=lambda m: m.get("_sort_order", 0))
+	frappe.cache.set_value(get_total_cache_key(account), len(mailboxes), expires_in_sec=600)
 
 	start = (page - 1) * limit
 	end = start + limit

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -6,7 +6,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint
+from frappe.utils import cint, now
 
 from mail.jmap import get_jmap_client
 from mail.utils import extract_filter_values
@@ -86,8 +86,8 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 def format_mailbox(account: str, mailbox: dict) -> dict:
 	"""Formats mailbox data for display."""
 
-	if parent := mailbox["parentId"]:
-		parent = f"{account}|{parent}"
+	if _parent := mailbox["parentId"]:
+		_parent = f"{account}|{_parent}"
 	if rights := mailbox.get("myRights"):
 		rights = json.dumps(rights, indent=4, sort_keys=True)
 
@@ -96,7 +96,7 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"account": account,
 		"id": mailbox["id"],
 		"_name": mailbox["name"],
-		"parent": parent,
+		"_parent": _parent,
 		"parent_id": mailbox["parentId"],
 		"role": mailbox["role"],
 		"sort_order": cint(mailbox["sortOrder"]),
@@ -106,4 +106,6 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"total_threads": cint(mailbox["totalThreads"]),
 		"unread_threads": cint(mailbox["unreadThreads"]),
 		"rights": rights,
+		"creation": now(),
+		"modified": now(),
 	}

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -149,15 +149,19 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 	client = get_jmap_client(account)
 	mailboxes = client.mailbox_get()
 
+	formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
+	sorted_mailboxes = sorted(formatted_mailboxes, key=lambda m: m.get("_sort_order", 0))
+
 	start = (page - 1) * limit
 	end = start + limit
 
-	return [format_mailbox(account, mailbox) for mailbox in mailboxes[start:end]]
+	return sorted_mailboxes[start:end]
 
 
 def format_mailbox(account: str, mailbox: dict) -> dict:
 	"""Formats mailbox data for display."""
 
+	sort_order = cint(mailbox["sortOrder"])
 	if _parent := mailbox["parentId"]:
 		_parent = f"{account}|{_parent}"
 	if rights := mailbox.get("myRights"):
@@ -171,7 +175,8 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"_parent": _parent,
 		"parent_id": mailbox["parentId"],
 		"role": mailbox["role"],
-		"sort_order": cint(mailbox["sortOrder"]),
+		"sort_order": sort_order,
+		"_sort_order": sort_order or get_sort_order(mailbox["role"]),
 		"subscribed": bool(mailbox["isSubscribed"]),
 		"total_emails": cint(mailbox["totalEmails"]),
 		"unread_emails": cint(mailbox["unreadEmails"]),
@@ -181,6 +186,17 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"creation": today(),
 		"modified": today(),
 	}
+
+
+def get_sort_order(role: str | None = None) -> int:
+	"""Returns the sort order for the mailbox based on its role."""
+
+	sort_order = ["inbox", "sent", "drafts", "junk", "trash"]
+
+	if not role or role not in sort_order:
+		return 0
+
+	return sort_order.index(role) + 1
 
 
 def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint, now
+from uuid_utils import uuid7
 
 from mail.jmap import get_jmap_client
 from mail.utils import extract_filter_values
@@ -14,14 +15,16 @@ from mail.utils.cache import get_account_for_user
 
 
 class Mailbox(Document):
-	def autoname(self) -> None:
+	def db_insert(self, *args, **kwargs) -> None:
+		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
+		self.id = add_mailbox(
+			self.account, self._name, self.role, parent, self.sort_order, bool(self.is_subscribed)
+		)
 		self.name = f"{self.account}|{self.id}"
 
-	def db_insert(self, *args, **kwargs) -> None:
-		raise NotImplementedError
-
 	def load_from_db(self) -> "Mailbox":
-		mailbox = get_mailbox(self.name)
+		account, id = self.name.split("|")
+		mailbox = get_mailbox(account, id)
 		return super(Document, self).__init__(mailbox)
 
 	def db_update(self) -> None:
@@ -60,10 +63,33 @@ class Mailbox(Document):
 		pass
 
 
-def get_mailbox(name: str) -> dict:
+def add_mailbox(
+	account: str,
+	name: str,
+	role: str | None = None,
+	parent: str | None = None,
+	sort_order: int = 0,
+	is_subscribed: bool = True,
+) -> str:
+	"""Adds a mailbox for the given account with the specified parameters."""
+
+	unique_id = str(uuid7())
+	client = get_jmap_client(account)
+	response = client.mailbox_create(unique_id, name, role, parent, sort_order, is_subscribed)
+
+	if response.get("created"):
+		return response["created"][unique_id]["id"]
+	elif response.get("notCreated"):
+		frappe.throw(
+			_("Mailbox creation failed: {0}").format(response["notCreated"][unique_id]["description"])
+		)
+	else:
+		frappe.throw(_("Mailbox creation failed: {0}").format(response["description"]))
+
+
+def get_mailbox(account: str, id: str) -> dict:
 	"""Returns mailbox details for the given name in the format 'account|id'."""
 
-	account, id = name.split("|")
 	client = get_jmap_client(account)
 	if mailboxes := client.mailbox_get([id]):
 		return format_mailbox(account, mailboxes[0])

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -103,12 +103,13 @@ def add_mailbox(
 	client = get_jmap_client(account)
 	response = client.mailbox_create(unique_id, name, role, parent, sort_order, subscribed)
 
+	title = _("Mailbox Creation Error")
 	if response.get("created"):
 		return response["created"][unique_id]["id"]
 	elif response.get("notCreated"):
-		frappe.throw(_(response["notCreated"][unique_id]["description"]))
+		frappe.throw(_(response["notCreated"][unique_id]["description"]), title=title)
 	else:
-		frappe.throw(_(response["description"]))
+		frappe.throw(_(response["description"]), title=title)
 
 
 def get_mailbox(account: str, id: str) -> dict:
@@ -119,7 +120,8 @@ def get_mailbox(account: str, id: str) -> dict:
 		return format_mailbox(account, mailboxes[0])
 
 	frappe.throw(
-		_("Mailbox with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account))
+		_("Mailbox with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account)),
+		title=_("Mailbox Not Found"),
 	)
 
 
@@ -134,17 +136,18 @@ def update_mailbox(
 ) -> None:
 	"""Updates an existing mailbox with the given parameters."""
 
+	title = _("Mailbox Update Error")
 	if parent and id == parent:
-		frappe.throw(_("Mailbox cannot be a parent of itself."))
+		frappe.throw(_("Mailbox cannot be a parent of itself."), title=title)
 
 	client = get_jmap_client(account)
 	response = client.mailbox_set(id, name, role, parent, sort_order, subscribed)
 
 	if not response.get("updated"):
 		if response.get("notUpdated"):
-			frappe.throw(_(response["notUpdated"][id]["description"]))
+			frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
 		else:
-			frappe.throw(_(response["description"]))
+			frappe.throw(_(response["description"]), title=title)
 
 
 def delete_mailbox(account: str, id: str) -> None:
@@ -154,7 +157,7 @@ def delete_mailbox(account: str, id: str) -> None:
 	response = client.mailbox_destroy([id], remove_emails=True)
 
 	if response.get("notDestroyed"):
-		frappe.throw(_(response["notDestroyed"][id]["description"]))
+		frappe.throw(_(response["notDestroyed"][id]["description"]), title=_("Mailbox Deletion Error"))
 
 
 def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
@@ -163,7 +166,10 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 	client = get_jmap_client(account)
 	mailboxes = client.mailbox_get()
 	formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
-	sorted_mailboxes = sorted(formatted_mailboxes, key=lambda m: m.get("_sort_order", 0))
+	sorted_mailboxes = sorted(
+		formatted_mailboxes,
+		key=lambda m: (m.get("_sort_order") == 0, m.get("_sort_order", float("inf")), m.get("_name")),
+	)
 	frappe.cache.set_value(get_total_cache_key(account), len(mailboxes), expires_in_sec=600)
 
 	start = (page - 1) * limit

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Mailbox(Document):
+	def db_insert(self, *args, **kwargs):
+		raise NotImplementedError
+
+	def load_from_db(self):
+		raise NotImplementedError
+
+	def db_update(self):
+		raise NotImplementedError
+
+	def delete(self):
+		raise NotImplementedError
+
+	@staticmethod
+	def get_list(filters=None, page_length=20, **kwargs):
+		pass
+
+	@staticmethod
+	def get_count(filters=None, **kwargs):
+		pass
+
+	@staticmethod
+	def get_stats(**kwargs):
+		pass

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -21,7 +21,8 @@ class Mailbox(Document):
 		raise NotImplementedError
 
 	def load_from_db(self) -> "Mailbox":
-		raise NotImplementedError
+		mailbox = get_mailbox(self.name)
+		return super(Document, self).__init__(mailbox)
 
 	def db_update(self) -> None:
 		raise NotImplementedError
@@ -59,6 +60,19 @@ class Mailbox(Document):
 		pass
 
 
+def get_mailbox(name: str) -> dict:
+	"""Returns mailbox details for the given name in the format 'account|id'."""
+
+	account, id = name.split("|")
+	client = get_jmap_client(account)
+	if mailboxes := client.mailbox_get([id]):
+		return format_mailbox(account, mailboxes[0])
+
+	frappe.throw(
+		_("Mailbox with ID {0} not found in account {1}.").format(frappe.bold(id), frappe.bold(account))
+	)
+
+
 def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 	"""Returns a list of mailboxes for the given account."""
 
@@ -74,8 +88,8 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 
 	if parent := mailbox["parentId"]:
 		parent = f"{account}|{parent}"
-	if my_rights := mailbox.get("myRights"):
-		my_rights = json.dumps(my_rights, indent=4, sort_keys=True)
+	if rights := mailbox.get("myRights"):
+		rights = json.dumps(rights, indent=4, sort_keys=True)
 
 	return {
 		"name": f"{account}|{mailbox['id']}",
@@ -91,5 +105,5 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 		"unread_emails": cint(mailbox["unreadEmails"]),
 		"total_threads": cint(mailbox["totalThreads"]),
 		"unread_threads": cint(mailbox["unreadThreads"]),
-		"my_rights": my_rights,
+		"rights": rights,
 	}

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -140,10 +140,12 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 	"""Returns a list of mailboxes for the given account."""
 
 	client = get_jmap_client(account)
-	if mailboxes := client.mailbox_get():
-		return [format_mailbox(account, mailbox) for mailbox in mailboxes]
+	mailboxes = client.mailbox_get()
 
-	return []
+	start = (page - 1) * limit
+	end = start + limit
+
+	return [format_mailbox(account, mailbox) for mailbox in mailboxes[start:end]]
 
 
 def format_mailbox(account: str, mailbox: dict) -> dict:

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -1,31 +1,95 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import json
+
+import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
+
+from mail.jmap import get_jmap_client
+from mail.utils import extract_filter_values
+from mail.utils.cache import get_account_for_user
 
 
 class Mailbox(Document):
-	def db_insert(self, *args, **kwargs):
+	def autoname(self) -> None:
+		self.name = f"{self.account}|{self.id}"
+
+	def db_insert(self, *args, **kwargs) -> None:
 		raise NotImplementedError
 
-	def load_from_db(self):
+	def load_from_db(self) -> "Mailbox":
 		raise NotImplementedError
 
-	def db_update(self):
+	def db_update(self) -> None:
 		raise NotImplementedError
 
-	def delete(self):
+	def delete(self) -> None:
 		raise NotImplementedError
 
 	@staticmethod
-	def get_list(filters=None, page_length=20, **kwargs):
-		pass
+	def get_list(filters=None, page_length=20, **kwargs) -> list:
+		filters = filters or []
+		account_values = extract_filter_values(filters, [{"account": "="}])
+		account = (
+			account_values[0]
+			if account_values and account_values[0]
+			else get_account_for_user(frappe.session.user)
+		)
+
+		if not account:
+			frappe.msgprint(_("Please select a account to view mailboxes."), alert=True)
+			return []
+
+		mailboxes = fetch_mailboxes(account, limit=page_length)
+
+		if not mailboxes:
+			frappe.msgprint(_("No mailboxes found."), alert=True)
+
+		return mailboxes
 
 	@staticmethod
-	def get_count(filters=None, **kwargs):
-		pass
+	def get_count(filters=None, **kwargs) -> int:
+		return len(Mailbox.get_list(filters, **kwargs))
 
 	@staticmethod
-	def get_stats(**kwargs):
+	def get_stats(**kwargs) -> dict:
 		pass
+
+
+def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
+	"""Returns a list of mailboxes for the given account."""
+
+	client = get_jmap_client(account)
+	if mailboxes := client.mailbox_get():
+		return [format_mailbox(account, mailbox) for mailbox in mailboxes]
+
+	return []
+
+
+def format_mailbox(account: str, mailbox: dict) -> dict:
+	"""Formats mailbox data for display."""
+
+	if parent := mailbox["parentId"]:
+		parent = f"{account}|{parent}"
+	if my_rights := mailbox.get("myRights"):
+		my_rights = json.dumps(my_rights, indent=4, sort_keys=True)
+
+	return {
+		"name": f"{account}|{mailbox['id']}",
+		"account": account,
+		"id": mailbox["id"],
+		"_name": mailbox["name"],
+		"parent": parent,
+		"parent_id": mailbox["parentId"],
+		"role": mailbox["role"],
+		"sort_order": cint(mailbox["sortOrder"]),
+		"is_subscribed": bool(mailbox["isSubscribed"]),
+		"total_emails": cint(mailbox["totalEmails"]),
+		"unread_emails": cint(mailbox["unreadEmails"]),
+		"total_threads": cint(mailbox["totalThreads"]),
+		"unread_threads": cint(mailbox["unreadThreads"]),
+		"my_rights": my_rights,
+	}

--- a/mail/mail/doctype/mailbox/mailbox.py
+++ b/mail/mail/doctype/mailbox/mailbox.py
@@ -35,7 +35,8 @@ class Mailbox(Document):
 		self.reload()
 
 	def delete(self) -> None:
-		raise NotImplementedError
+		account, id = self.name.split("|")
+		delete_mailbox(account, id)
 
 	@staticmethod
 	def get_list(filters=None, page_length=20, **kwargs) -> list:
@@ -84,11 +85,9 @@ def add_mailbox(
 	if response.get("created"):
 		return response["created"][unique_id]["id"]
 	elif response.get("notCreated"):
-		frappe.throw(
-			_("Mailbox creation failed: {0}").format(response["notCreated"][unique_id]["description"])
-		)
+		frappe.throw(_(response["notCreated"][unique_id]["description"]))
 	else:
-		frappe.throw(_("Mailbox creation failed: {0}").format(response["description"]))
+		frappe.throw(_(response["description"]))
 
 
 def get_mailbox(account: str, id: str) -> dict:
@@ -122,9 +121,19 @@ def update_mailbox(
 
 	if not response.get("updated"):
 		if response.get("notUpdated"):
-			frappe.throw(_("Mailbox update failed: {0}").format(response["notUpdated"][id]["description"]))
+			frappe.throw(_(response["notUpdated"][id]["description"]))
 		else:
-			frappe.throw(_("Mailbox update failed: {0}").format(response["description"]))
+			frappe.throw(_(response["description"]))
+
+
+def delete_mailbox(account: str, id: str) -> None:
+	"""Deletes a mailbox for the given account by its ID."""
+
+	client = get_jmap_client(account)
+	response = client.mailbox_destroy([id], remove_emails=True)
+
+	if response.get("notDestroyed"):
+		frappe.throw(_(response["notDestroyed"][id]["description"]))
 
 
 def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:

--- a/mail/mail/doctype/mailbox/test_mailbox.py
+++ b/mail/mail/doctype/mailbox/test_mailbox.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestMailbox(IntegrationTestCase):
+	"""
+	Integration tests for Mailbox.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/utils/query.py
+++ b/mail/utils/query.py
@@ -103,6 +103,9 @@ def get_account_mailboxes(
 	filters = filters or {}
 	account = filters.get("account") or get_account_for_user(frappe.session.user)
 
+	if not account:
+		return []
+
 	result = []
 	if mailboxes := fetch_mailboxes(account):
 		for mailbox in mailboxes:

--- a/mail/utils/query.py
+++ b/mail/utils/query.py
@@ -1,5 +1,8 @@
 import frappe
 
+from mail.mail.doctype.mailbox.mailbox import fetch_mailboxes
+from mail.utils.cache import get_account_for_user
+
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
@@ -83,3 +86,29 @@ def get_personal_signup_domains(
 			& (MAIL_TENANT.allow_personal_signup == 1)
 		)
 	).run(as_dict=False)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_account_mailboxes(
+	doctype: str | None = None,
+	txt: str | None = None,
+	searchfield: str | None = None,
+	start: int = 0,
+	page_len: int = 20,
+	filters: dict | None = None,
+) -> list:
+	"""Returns a list of mailboxes for the account."""
+
+	filters = filters or {}
+	account = filters.get("account") or get_account_for_user(frappe.session.user)
+
+	result = []
+	if mailboxes := fetch_mailboxes(account):
+		for mailbox in mailboxes:
+			if txt and txt.lower() not in mailbox["id"].lower():
+				continue
+
+			result.append([mailbox["name"]])
+
+	return result[start : start + page_len]


### PR DESCRIPTION
- [x] Mailbox Virtual DocType
- [x] List All Mailboxes
- [x] Pagination
- [x] Get Mailbox Details
- [x] Create Mailbox
- [x] Update Mailbox
- [x] Delete Mailbox
- [x] Sort mailboxes based on role (if sort_order = 0)
- [x] Remove `mailbox_role` field from Email Message
- [x] ~~Make Mailbox a Tree (?)~~
- [x] Remove dependency from `role`, use `id` instead
- [x] Mailbox Permissions for Mail User
- [x] Handle case when `drafts` or `sent` do not exist
- [x] Refactor `jmap.py`
- [x] ~~Patch~~ Script to allow `jmap-mailbox-set`

closes: https://github.com/frappe/mail/issues/208