### PR TITLE
feat: Add download functionality to AttachmentCapsule

### DIFF
--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -15,12 +15,15 @@
 			<span class="truncate text-sm">{{ fileName }}</span>
 		</button>
 		<button
-			v-if="blobID && !isLoading"
+			v-if="blobID"
 			class="text-ink-gray-4 hover:text-ink-gray-6 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100"
+			:class="{ 'pointer-events-none opacity-30': isDownloading }"
 			@click.stop="downloadAttachment"
 			:title="__('Download')"
+			:disabled="isDownloading"
 		>
-			<Download class="h-3.5 w-3.5" />
+			<Loader v-if="isDownloading" class="h-3.5 w-3.5 animate-spin" />
+			<Download v-else class="h-3.5 w-3.5" />
 		</button>
 	</div>
 </template>
@@ -37,6 +40,7 @@ const { fileName, blobID, type } = defineProps<{
 }>()
 
 const isLoading = ref(false)
+const isDownloading = ref(false)
 
 const openAttachment = async () => {
 	if (!blobID) return
@@ -47,9 +51,9 @@ const openAttachment = async () => {
 
 const downloadAttachment = async () => {
 	if (!blobID) return
-	isLoading.value = true
+	isDownloading.value = true
 	await fetchAttachmentForDownload.submit()
-	isLoading.value = false
+	isDownloading.value = false
 }
 
 const fetchAttachment = createResource({
@@ -85,6 +89,6 @@ const fetchAttachmentForDownload = createResource({
 		// Clean up the object URL
 		URL.revokeObjectURL(url)
 	},
-	onError: () => (isLoading.value = false),
+	onError: () => (isDownloading.value = false),
 })
 </script>

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -13,7 +13,7 @@
 		</button>
 		<button
 			v-if="blobID"
-			class="rounded p-1 text-ink-gray-4 transition-opacity hover:bg-gray-100 hover:text-ink-gray-6"
+			class="text-ink-gray-4 hover:text-ink-gray-6 rounded p-1 transition-opacity hover:bg-gray-100"
 			:class="{
 				'pointer-events-none opacity-30': isDownloading,
 				'opacity-0 group-hover:opacity-100': !isMobile,

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -33,6 +33,7 @@
 import { ref } from 'vue'
 import { Download, Loader, Paperclip } from 'lucide-vue-next'
 import { createResource } from 'frappe-ui'
+
 import { useScreenSize } from '@/utils/composables'
 
 const { fileName, blobID, type } = defineProps<{

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -3,10 +3,7 @@
 		class="group flex items-center space-x-2 rounded-full border px-2 py-1.5"
 		:class="{ 'hover:border-outline-gray-3 cursor-pointer': blobID }"
 	>
-		<button
-			class="flex min-w-0 flex-1 items-center space-x-2"
-			@click="openAttachment"
-		>
+		<button class="flex min-w-0 flex-1 items-center space-x-2" @click="openAttachment">
 			<Loader
 				v-if="isLoading"
 				class="text-ink-gray-4 h-3.5 min-h-3.5 w-3.5 min-w-3.5 animate-spin"

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -1,10 +1,10 @@
 <template>
 	<div
-		class="flex items-center space-x-2 rounded-full border px-2 py-1.5 group"
+		class="group flex items-center space-x-2 rounded-full border px-2 py-1.5"
 		:class="{ 'hover:border-outline-gray-3 cursor-pointer': blobID }"
 	>
 		<button
-			class="flex items-center space-x-2 flex-1 min-w-0"
+			class="flex min-w-0 flex-1 items-center space-x-2"
 			@click="openAttachment"
 		>
 			<Loader
@@ -16,7 +16,7 @@
 		</button>
 		<button
 			v-if="blobID"
-			class="text-ink-gray-4 hover:text-ink-gray-6 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100"
+			class="text-ink-gray-4 hover:text-ink-gray-6 rounded p-1 opacity-0 transition-opacity hover:bg-gray-100 group-hover:opacity-100"
 			:class="{ 'pointer-events-none opacity-30': isDownloading }"
 			@click.stop="downloadAttachment"
 			:title="__('Download')"
@@ -30,7 +30,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Loader, Paperclip, Download } from 'lucide-vue-next'
+import { Download, Loader, Paperclip } from 'lucide-vue-next'
 import { createResource } from 'frappe-ui'
 
 const { fileName, blobID, type } = defineProps<{

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -1,21 +1,33 @@
 <template>
-	<button
-		class="flex items-center space-x-2 rounded-full border px-2 py-1.5"
+	<div
+		class="flex items-center space-x-2 rounded-full border px-2 py-1.5 group"
 		:class="{ 'hover:border-outline-gray-3 cursor-pointer': blobID }"
-		@click="openAttachment"
 	>
-		<Loader
-			v-if="isLoading"
-			class="text-ink-gray-4 h-3.5 min-h-3.5 w-3.5 min-w-3.5 animate-spin"
-		/>
-		<Paperclip v-else class="text-ink-gray-4 h-3.5 min-h-3.5 w-3.5 min-w-3.5" />
-		<span class="truncate text-sm">{{ fileName }}</span>
-	</button>
+		<button
+			class="flex items-center space-x-2 flex-1 min-w-0"
+			@click="openAttachment"
+		>
+			<Loader
+				v-if="isLoading"
+				class="text-ink-gray-4 h-3.5 min-h-3.5 w-3.5 min-w-3.5 animate-spin"
+			/>
+			<Paperclip v-else class="text-ink-gray-4 h-3.5 min-h-3.5 w-3.5 min-w-3.5" />
+			<span class="truncate text-sm">{{ fileName }}</span>
+		</button>
+		<button
+			v-if="blobID && !isLoading"
+			class="text-ink-gray-4 hover:text-ink-gray-6 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100"
+			@click.stop="downloadAttachment"
+			:title="__('Download')"
+		>
+			<Download class="h-3.5 w-3.5" />
+		</button>
+	</div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Loader, Paperclip } from 'lucide-vue-next'
+import { Loader, Paperclip, Download } from 'lucide-vue-next'
 import { createResource } from 'frappe-ui'
 
 const { fileName, blobID, type } = defineProps<{
@@ -33,6 +45,13 @@ const openAttachment = async () => {
 	isLoading.value = false
 }
 
+const downloadAttachment = async () => {
+	if (!blobID) return
+	isLoading.value = true
+	await fetchAttachmentForDownload.submit()
+	isLoading.value = false
+}
+
 const fetchAttachment = createResource({
 	url: 'mail.api.mail.fetch_attachment',
 	makeParams: () => ({ blob_id: blobID }),
@@ -42,6 +61,29 @@ const fetchAttachment = createResource({
 		const blob = new Blob([byteArray], { type })
 		const url = URL.createObjectURL(blob)
 		window.open(url, '_blank')
+	},
+	onError: () => (isLoading.value = false),
+})
+
+const fetchAttachmentForDownload = createResource({
+	url: 'mail.api.mail.fetch_attachment',
+	makeParams: () => ({ blob_id: blobID }),
+	cache: ['attachment-download', blobID],
+	onSuccess: (data: number[]) => {
+		const byteArray = new Uint8Array(data)
+		const blob = new Blob([byteArray], { type })
+		const url = URL.createObjectURL(blob)
+
+		// Create a temporary link element for download
+		const link = document.createElement('a')
+		link.href = url
+		link.download = fileName || 'attachment'
+		document.body.appendChild(link)
+		link.click()
+		document.body.removeChild(link)
+
+		// Clean up the object URL
+		URL.revokeObjectURL(url)
 	},
 	onError: () => (isLoading.value = false),
 })

--- a/frontend/src/components/AttachmentCapsule.vue
+++ b/frontend/src/components/AttachmentCapsule.vue
@@ -13,8 +13,12 @@
 		</button>
 		<button
 			v-if="blobID"
-			class="text-ink-gray-4 hover:text-ink-gray-6 rounded p-1 opacity-0 transition-opacity hover:bg-gray-100 group-hover:opacity-100"
-			:class="{ 'pointer-events-none opacity-30': isDownloading }"
+			class="rounded p-1 text-ink-gray-4 transition-opacity hover:bg-gray-100 hover:text-ink-gray-6"
+			:class="{
+				'pointer-events-none opacity-30': isDownloading,
+				'opacity-0 group-hover:opacity-100': !isMobile,
+				'opacity-60': isMobile,
+			}"
 			@click.stop="downloadAttachment"
 			:title="__('Download')"
 			:disabled="isDownloading"
@@ -29,12 +33,15 @@
 import { ref } from 'vue'
 import { Download, Loader, Paperclip } from 'lucide-vue-next'
 import { createResource } from 'frappe-ui'
+import { useScreenSize } from '@/utils/composables'
 
 const { fileName, blobID, type } = defineProps<{
 	fileName: string
 	blobID?: string
 	type?: string
 }>()
+
+const { isMobile } = useScreenSize()
 
 const isLoading = ref(false)
 const isDownloading = ref(false)


### PR DESCRIPTION
Added a download feature for attachments since it was missing.
Thought about making an issue, but just sent a PR instead in case it helps.
If you want to do it differently, feel free to close this. No hard feelings :)
Cheers!


- Add download button that appears on hover within attachment capsule
- Implement downloadAttachment function with separate cache key
- Create temporary download link to trigger file download
- Preserve original filename when downloading
- Maintain existing click-to-view functionality alongside download option

[Frappe mail attachment download.webm](https://github.com/user-attachments/assets/ea4c8714-068c-4e61-b446-ace0cc850ead)
