### PR TITLE
chore: use app-password to access JMAP

### DIFF
--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -123,7 +123,6 @@ def create_account(request_key: str, first_name: str, last_name: str, password: 
 
 	if account_request.account:
 		account_request.create_account(first_name, last_name, password)
-
 	else:
 		create_user(account_request.email, first_name, last_name, password, ["Mail Admin"])
 

--- a/mail/backend.py
+++ b/mail/backend.py
@@ -134,7 +134,7 @@ class MailBackendManagerBase:
 class MailBackendDKIMManager(MailBackendManagerBase):
 	"""Class to manage DKIM keys on the Mail Backend."""
 
-	def create(self, domain_name: str, rsa_private_key: str) -> None:
+	def create(self, domain_name: str, rsa_private_key: str) -> "MailBackendRequest":
 		"""Creates a DKIM key on the backend."""
 
 		from mail.mail.doctype.mail_cluster.mail_cluster import reload_clusters_config
@@ -164,7 +164,7 @@ class MailBackendDKIMManager(MailBackendManagerBase):
 			on_end = reload_servers_config
 			on_end_kwargs = {"servers": [self.backend_name]}
 
-		self.create_request(
+		return self.create_request(
 			method="POST",
 			endpoint="/api/settings",
 			request_data=request_data,
@@ -172,7 +172,7 @@ class MailBackendDKIMManager(MailBackendManagerBase):
 			on_end_kwargs=on_end_kwargs,
 		)
 
-	def delete(self, domain_name: str) -> None:
+	def delete(self, domain_name: str) -> "MailBackendRequest":
 		"""Deletes a DKIM key from the backend."""
 
 		request_data = json.dumps(
@@ -183,7 +183,7 @@ class MailBackendDKIMManager(MailBackendManagerBase):
 				}
 			]
 		)
-		self.create_request(
+		return self.create_request(
 			method="POST",
 			endpoint="/api/settings",
 			request_data=request_data,
@@ -193,22 +193,24 @@ class MailBackendDKIMManager(MailBackendManagerBase):
 class MailBackendDomainManager(MailBackendManagerBase):
 	"""Class to manage domains on the Mail Backend."""
 
-	def create(self, domain_name: str) -> None:
+	def create(self, domain_name: str) -> "MailBackendRequest":
 		"""Creates a domain on the backend."""
 
 		principal = Principal(name=domain_name, type="domain").__dict__
-		self.create_request(method="POST", endpoint="/api/principal", request_data=json.dumps(principal))
+		return self.create_request(
+			method="POST", endpoint="/api/principal", request_data=json.dumps(principal), do_not_enqueue=True
+		)
 
-	def delete(self, domain_name: str) -> None:
+	def delete(self, domain_name: str) -> "MailBackendRequest":
 		"""Deletes a domain from the backend."""
 
-		self.create_request(method="DELETE", endpoint=f"/api/principal/{domain_name}")
+		return self.create_request(method="DELETE", endpoint=f"/api/principal/{domain_name}")
 
 
 class MailBackendAccountManager(MailBackendManagerBase):
 	"""Class to manage accounts on the Mail Backend."""
 
-	def create(self, email: str, display_name: str, quota: int, secret: str) -> None:
+	def create(self, email: str, display_name: str, quota: int, secret: str) -> "MailBackendRequest":
 		"""Creates an account on the backend."""
 
 		from mail.mail.doctype.jmap_push_subscription.jmap_push_subscription import (
@@ -224,15 +226,16 @@ class MailBackendAccountManager(MailBackendManagerBase):
 			emails=[email],
 			roles=["user"],
 		).__dict__
-		self.create_request(
+		return self.create_request(
 			method="POST",
 			endpoint="/api/principal",
 			request_data=json.dumps(principal),
 			on_end=create_jmap_push_subscriptions,
 			on_end_kwargs={"account": email},
+			do_not_enqueue=True,
 		)
 
-	def update(self, email: str, display_name: str, new_secret: str, old_secret: str) -> None:
+	def update(self, email: str, display_name: str, new_secret: str, old_secret: str) -> "MailBackendRequest":
 		"""Updates an account on the backend."""
 
 		request_data = [
@@ -260,9 +263,11 @@ class MailBackendAccountManager(MailBackendManagerBase):
 			)
 
 		request_data = json.dumps(request_data)
-		self.create_request(method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data)
+		return self.create_request(
+			method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data
+		)
 
-	def set_quota(self, email: str, quota: int) -> None:
+	def set_quota(self, email: str, quota: int) -> "MailBackendRequest":
 		"""Sets the quota for an account on the backend."""
 
 		request_data = json.dumps(
@@ -274,16 +279,18 @@ class MailBackendAccountManager(MailBackendManagerBase):
 				}
 			]
 		)
-		self.create_request(method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data)
+		return self.create_request(
+			method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data
+		)
 
-	def delete(self, email: str) -> None:
+	def delete(self, email: str) -> "MailBackendRequest":
 		"""Deletes an account from the backend."""
 
 		from mail.mail.doctype.jmap_push_subscription.jmap_push_subscription import (
 			delete_jmap_push_subscriptions,
 		)
 
-		self.create_request(
+		return self.create_request(
 			method="DELETE",
 			endpoint=f"/api/principal/{email}",
 			on_start=delete_jmap_push_subscriptions,
@@ -300,7 +307,7 @@ class MailBackendMailingListManager(MailBackendManagerBase):
 		display_name: str,
 		members: list[str] | None = None,
 		external_members: list[str] | None = None,
-	) -> None:
+	) -> "MailBackendRequest":
 		"""Creates a mailing list on the backend."""
 
 		principal = Principal(
@@ -311,9 +318,11 @@ class MailBackendMailingListManager(MailBackendManagerBase):
 			members=members or [],
 			externalMembers=external_members or [],
 		).__dict__
-		self.create_request(method="POST", endpoint="/api/principal", request_data=json.dumps(principal))
+		return self.create_request(
+			method="POST", endpoint="/api/principal", request_data=json.dumps(principal)
+		)
 
-	def update(self, email: str, display_name: str) -> None:
+	def update(self, email: str, display_name: str) -> "MailBackendRequest":
 		"""Updates a mailing list on the backend."""
 
 		request_data = json.dumps(
@@ -325,40 +334,42 @@ class MailBackendMailingListManager(MailBackendManagerBase):
 				}
 			]
 		)
-		self.create_request(method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data)
+		return self.create_request(
+			method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data
+		)
 
-	def delete(self, email: str) -> None:
+	def delete(self, email: str) -> "MailBackendRequest":
 		"""Deletes a mailing list from the backend."""
 
-		self.create_request(method="DELETE", endpoint=f"/api/principal/{email}")
+		return self.create_request(method="DELETE", endpoint=f"/api/principal/{email}")
 
-	def add_member(self, email: str, member: str, is_external: bool = False) -> None:
+	def add_member(self, email: str, member: str, is_external: bool = False) -> "MailBackendRequest":
 		"""Adds a mailing list member on the backend."""
 
 		endpoint = f"/api/principal/{email}"
 		field = "externalMembers" if is_external else "members"
 		request_data = json.dumps([{"action": "addItem", "field": field, "value": member}])
-		self.create_request(method="PATCH", endpoint=endpoint, request_data=request_data)
+		return self.create_request(method="PATCH", endpoint=endpoint, request_data=request_data)
 
-	def remove_member(self, email: str, member: str, is_external: bool = False) -> None:
+	def remove_member(self, email: str, member: str, is_external: bool = False) -> "MailBackendRequest":
 		"""Removes a mailing list member from the backend."""
 
 		endpoint = f"/api/principal/{email}"
 		field = "externalMembers" if is_external else "members"
 		request_data = json.dumps([{"action": "removeItem", "field": field, "value": member}])
-		self.create_request(method="PATCH", endpoint=endpoint, request_data=request_data)
+		return self.create_request(method="PATCH", endpoint=endpoint, request_data=request_data)
 
 
 class MailBackendAliasManager(MailBackendManagerBase):
 	"""Class to manage aliases on the Mail Backend."""
 
-	def create(self, email: str, alias: str) -> None:
+	def create(self, email: str, alias: str) -> "MailBackendRequest":
 		"""Creates an alias on the backend."""
 
 		from mail.mail.doctype.mail_account.mail_account import sync_jmap_identities
 
 		request_data = json.dumps([{"action": "addItem", "field": "emails", "value": alias}])
-		self.create_request(
+		return self.create_request(
 			method="PATCH",
 			endpoint=f"/api/principal/{email}",
 			request_data=request_data,
@@ -372,13 +383,13 @@ class MailBackendAliasManager(MailBackendManagerBase):
 		self.delete(old_email, alias)
 		self.create(new_email, alias)
 
-	def delete(self, email: str, alias: str) -> None:
+	def delete(self, email: str, alias: str) -> "MailBackendRequest":
 		"""Deletes an alias from the backend."""
 
 		from mail.mail.doctype.mail_account.mail_account import sync_jmap_identities
 
 		request_data = json.dumps([{"action": "removeItem", "field": "emails", "value": alias}])
-		self.create_request(
+		return self.create_request(
 			method="PATCH",
 			endpoint=f"/api/principal/{email}",
 			request_data=request_data,
@@ -392,7 +403,7 @@ class MailBackendIdentityManager(MailBackendManagerBase):
 		self,
 		account_id: str,
 		identities: dict[str, dict[str, Any]],
-	) -> None:
+	) -> "MailBackendRequest":
 		"""Synchronizes identities with the backend."""
 
 		payload = {
@@ -424,7 +435,7 @@ class MailBackendIdentityManager(MailBackendManagerBase):
 			],
 		}
 
-		self.create_request(method="POST", endpoint="/jmap", request_json=payload, do_not_enqueue=True)
+		return self.create_request(method="POST", endpoint="/jmap", request_json=payload, do_not_enqueue=True)
 
 
 def get_mail_backend_api(

--- a/mail/backend.py
+++ b/mail/backend.py
@@ -9,7 +9,7 @@ import requests
 from frappe import _
 
 from mail.mail.doctype.mail_backend_request.mail_backend_request import create_mail_backend_request
-from mail.utils import get_dkim_selector
+from mail.utils import get_dkim_selector, reformat_pbkdf2_hash
 
 if TYPE_CHECKING:
 	from mail.mail.doctype.mail_backend_request.mail_backend_request import MailBackendRequest
@@ -210,6 +210,13 @@ class MailBackendDomainManager(MailBackendManagerBase):
 class MailBackendAccountManager(MailBackendManagerBase):
 	"""Class to manage accounts on the Mail Backend."""
 
+	def get(self, email: str, do_not_enqueue: bool = True) -> "MailBackendRequest":
+		"""Returns the account details from the backend."""
+
+		return self.create_request(
+			method="GET", endpoint=f"/api/principal/{email}", do_not_enqueue=do_not_enqueue
+		)
+
 	def create(self, email: str, display_name: str, quota: int, secret: str) -> "MailBackendRequest":
 		"""Creates an account on the backend."""
 
@@ -222,7 +229,7 @@ class MailBackendAccountManager(MailBackendManagerBase):
 			type="individual",
 			description=display_name,
 			quota=quota,
-			secrets=[secret],
+			secrets=[reformat_pbkdf2_hash(secret)],
 			emails=[email],
 			roles=["user"],
 		).__dict__
@@ -247,24 +254,20 @@ class MailBackendAccountManager(MailBackendManagerBase):
 		]
 
 		if old_secret != new_secret:
-			request_data.extend(
-				[
-					{
-						"action": "addItem",
-						"field": "secrets",
-						"value": new_secret,
-					},
-					{
-						"action": "removeItem",
-						"field": "secrets",
-						"value": old_secret,
-					},
-				]
-			)
+			if account_details := self.get(email, do_not_enqueue=True):
+				secrets = json.loads(account_details.response_json or "{}").get("data", {}).get("secrets", [])
+
+				for secret in secrets:
+					if not secret.startswith("$app$"):
+						request_data.append({"action": "removeItem", "field": "secrets", "value": secret})
+
+				request_data.append(
+					{"action": "addItem", "field": "secrets", "value": reformat_pbkdf2_hash(new_secret)}
+				)
 
 		request_data = json.dumps(request_data)
 		return self.create_request(
-			method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data
+			method="PATCH", endpoint=f"/api/principal/{email}", request_data=request_data, do_not_enqueue=True
 		)
 
 	def set_quota(self, email: str, quota: int) -> "MailBackendRequest":

--- a/mail/events.py
+++ b/mail/events.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe.model.document import Document
+
+from mail.backend import MailBackendAccountManager
+from mail.utils.cache import get_cluster_for_tenant
+from mail.utils.user import get_account_for_user, get_user_hashed_password
+
+
+def update_account_password(doc: Document, method: str | None = None) -> None:
+	"""Update the account password hash when the user password is changed."""
+
+	account = get_account_for_user(doc.name)
+
+	if not account:
+		return
+
+	account_doc = frappe.get_doc("Mail Account", account)
+	current_hashed_password = get_user_hashed_password(account_doc.user)
+	if account_doc.secret_hash != current_hashed_password:
+		MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(account_doc.tenant)).update(
+			account_doc.email,
+			account_doc.display_name,
+			current_hashed_password,
+			old_secret=account_doc.secret_hash,
+		)

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -206,7 +206,13 @@ website_route_rules = [
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {}
+doc_events = {
+	"User": {
+		"on_update": [
+			"mail.events.update_account_password",
+		],
+	},
+}
 
 # Scheduled Tasks
 # ---------------

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -839,7 +839,7 @@ def get_jmap_client(account: str, server: str | None = None, cache: bool = True)
 
 			host = server_base_url
 
-		return JMAPClient(host, account_doc.email, account_doc.get_password())
+		return JMAPClient(host, account_doc.email, account_doc.get_password("app_password"))
 
 	if cache and not server:
 		return frappe.cache.hget("jmap:client", account, generator)

--- a/mail/mail/doctype/mail_account/mail_account.js
+++ b/mail/mail/doctype/mail_account/mail_account.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('Mail Account', {
 	},
 
 	refresh(frm) {
-		frm.trigger('add_show_password')
+		frm.trigger('add_show_app_password')
 		frm.trigger('add_actions')
 	},
 
@@ -28,11 +28,13 @@ frappe.ui.form.on('Mail Account', {
 		}))
 	},
 
-	add_show_password(frm) {
+	add_show_app_password(frm) {
 		if (frm.doc.__islocal) return
 
-		if (frm.doc.password) {
-			frm.add_custom_button(__('Show Password'), () => frm.trigger('get_account_password'))
+		if (frm.doc.app_password) {
+			frm.add_custom_button(__('Show App Password'), () =>
+				frm.trigger('get_account_app_password'),
+			)
 		}
 	},
 
@@ -58,18 +60,18 @@ frappe.ui.form.on('Mail Account', {
 		)
 
 		frm.add_custom_button(
-			__('Re-generate Password'),
-			() => frm.trigger('regenerate_password'),
+			__('Re-generate App Password'),
+			() => frm.trigger('regenerate_app_password'),
 			__('Actions'),
 		)
 	},
 
-	get_account_password(frm) {
+	get_account_app_password(frm) {
 		frappe.call({
 			doc: frm.doc,
-			method: 'get_account_password',
+			method: 'get_account_app_password',
 			freeze: true,
-			freeze_message: __('Getting Password...'),
+			freeze_message: __('Getting App Password...'),
 			callback: (r) => {
 				if (!r.exc) {
 					frappe.msgprint(r.message)
@@ -218,17 +220,41 @@ frappe.ui.form.on('Mail Account', {
 		dialog.show()
 	},
 
-	regenerate_password(frm) {
-		frappe.call({
-			doc: frm.doc,
-			method: 'regenerate_password',
-			freeze: true,
-			freeze_message: __('Regenerating Password...'),
-			callback: (r) => {
-				if (!r.exc) {
-					frm.refresh()
-				}
+	regenerate_app_password(frm) {
+		const dialog = new frappe.ui.Dialog({
+			title: __('Regenerate App Password'),
+			size: 'small',
+			fields: [
+				{
+					fieldname: 'account_password',
+					fieldtype: 'Password',
+					label: __('Account Password'),
+					description: __(
+						'Your main account password is required to regenerate the app password.',
+					),
+					reqd: 1,
+				},
+			],
+			primary_action_label: __('Regenerate'),
+			primary_action: (data) => {
+				frappe.call({
+					doc: frm.doc,
+					method: 'regenerate_app_password',
+					args: {
+						account_password: data.account_password,
+					},
+					freeze: true,
+					freeze_message: __('Regenerating App Password...'),
+					callback: (r) => {
+						if (!r.exc) {
+							frm.refresh()
+							dialog.hide()
+						}
+					},
+				})
 			},
 		})
+
+		dialog.show()
 	},
 })

--- a/mail/mail/doctype/mail_account/mail_account.json
+++ b/mail/mail/doctype/mail_account/mail_account.json
@@ -15,11 +15,13 @@
   "user",
   "email",
   "normalized_email",
-  "password",
-  "secret",
   "default_outgoing_email",
   "backup_email",
-  "section_break_wzwp",
+  "authentication_section",
+  "app_password",
+  "column_break_oxwx",
+  "secret_hash",
+  "quota_section",
   "_disk_quota",
   "disk_quota",
   "_used_quota",
@@ -128,22 +130,6 @@
   {
    "fieldname": "column_break_yyco",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "password",
-   "fieldtype": "Password",
-   "hidden": 1,
-   "label": "Password",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "secret",
-   "fieldtype": "Small Text",
-   "hidden": 1,
-   "label": "Secret",
-   "no_copy": 1,
-   "read_only": 1
   },
   {
    "fieldname": "default_outgoing_email",
@@ -297,10 +283,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "section_break_wzwp",
-   "fieldtype": "Section Break"
-  },
-  {
    "fieldname": "column_break_rrsz",
    "fieldtype": "Column Break"
   },
@@ -345,6 +327,40 @@
    "no_copy": 1,
    "options": "File Size",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval: !doc.__islocal",
+   "fieldname": "app_password",
+   "fieldtype": "Password",
+   "label": "App Password",
+   "mandatory_depends_on": "eval: !doc.__islocal",
+   "no_copy": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: false",
+   "fieldname": "authentication_section",
+   "fieldtype": "Section Break",
+   "label": "Authentication"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: true",
+   "fieldname": "quota_section",
+   "fieldtype": "Section Break",
+   "label": "Quota"
+  },
+  {
+   "fieldname": "column_break_oxwx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "secret_hash",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Secret Hash",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -386,7 +402,7 @@
    "link_fieldname": "account"
   }
  ],
- "modified": "2025-08-19 15:58:31.062290",
+ "modified": "2025-09-08 21:42:49.180617",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Account",

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -2,8 +2,6 @@
 # For license information, please see license.txt
 
 import base64
-import random
-import string
 from datetime import datetime, timezone
 from email.utils import parseaddr
 from functools import cached_property
@@ -19,7 +17,13 @@ from frappe.utils.data import convert_utc_to_system_timezone, get_datetime
 from mail.backend import MailBackendAccountManager, MailBackendIdentityManager, get_mail_backend_api
 from mail.jmap import get_jmap_client, invalidate_jmap_cache, invalidate_jmap_client_cache, raise_for_status
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import create_jmap_sync_state
-from mail.utils import convert_html_to_text, generate_uuid_style_hash, hash_password, normalize_email
+from mail.utils import (
+	convert_html_to_text,
+	generate_random_phrase,
+	generate_uuid_style_hash,
+	hash_password,
+	normalize_email,
+)
 from mail.utils.cache import (
 	get_aliases_for_user,
 	get_cluster_for_tenant,
@@ -442,9 +446,7 @@ class MailAccount(Document):
 		if not account_password:
 			frappe.throw(_("Account password is required to generate app password."))
 
-		self.app_password = " ".join(
-			["".join(random.choices(string.ascii_lowercase, k=l)) for l in (5, 4, 4, 4, 3)]
-		)
+		self.app_password = generate_random_phrase()
 		base_url = frappe.db.get_value("Mail Cluster", get_cluster_for_tenant(self.tenant), "base_url")
 
 		try:

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -19,13 +19,7 @@ from frappe.utils.data import convert_utc_to_system_timezone, get_datetime
 from mail.backend import MailBackendAccountManager, MailBackendIdentityManager, get_mail_backend_api
 from mail.jmap import get_jmap_client, invalidate_jmap_cache, invalidate_jmap_client_cache, raise_for_status
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import create_jmap_sync_state
-from mail.utils import (
-	convert_html_to_text,
-	generate_uuid_style_hash,
-	hash_password,
-	normalize_email,
-	reformat_pbkdf2_hash,
-)
+from mail.utils import convert_html_to_text, generate_uuid_style_hash, hash_password, normalize_email
 from mail.utils.cache import (
 	get_aliases_for_user,
 	get_cluster_for_tenant,
@@ -190,7 +184,7 @@ class MailAccount(Document):
 					self.email,
 					self.display_name,
 					cint(quota * (1024**3)),
-					reformat_pbkdf2_hash(self.secret_hash),
+					self.secret_hash,
 				)
 				if request.status != "Completed":
 					frappe.throw(
@@ -201,8 +195,8 @@ class MailAccount(Document):
 				MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).update(
 					self.email,
 					self.display_name,
-					reformat_pbkdf2_hash(self.secret_hash),
-					reformat_pbkdf2_hash(self.get_doc_before_save().secret_hash),
+					self.secret_hash,
+					self.get_doc_before_save().secret_hash,
 				)
 
 				if self.has_value_changed("secret_hash"):

--- a/mail/mail/doctype/mail_account/mail_account.py
+++ b/mail/mail/doctype/mail_account/mail_account.py
@@ -1,24 +1,30 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-from datetime import datetime
+import base64
+import random
+import string
+from datetime import datetime, timezone
 from email.utils import parseaddr
 from functools import cached_property
+from urllib.parse import urljoin
 
 import frappe
+import requests
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, now, random_string, validate_email_address
+from frappe.utils import cint, now, validate_email_address
 from frappe.utils.data import convert_utc_to_system_timezone, get_datetime
 
 from mail.backend import MailBackendAccountManager, MailBackendIdentityManager, get_mail_backend_api
-from mail.jmap import get_jmap_client, invalidate_jmap_cache
+from mail.jmap import get_jmap_client, invalidate_jmap_cache, invalidate_jmap_client_cache, raise_for_status
 from mail.mail.doctype.jmap_sync_state.jmap_sync_state import create_jmap_sync_state
 from mail.utils import (
 	convert_html_to_text,
 	generate_uuid_style_hash,
 	hash_password,
 	normalize_email,
+	reformat_pbkdf2_hash,
 )
 from mail.utils.cache import (
 	get_aliases_for_user,
@@ -27,7 +33,7 @@ from mail.utils.cache import (
 	get_tenant_for_user,
 )
 from mail.utils.dt import convert_to_utc
-from mail.utils.user import has_role, is_system_manager, is_tenant_admin
+from mail.utils.user import get_user_hashed_password, has_role, is_system_manager, is_tenant_admin
 from mail.utils.validation import (
 	is_email_assigned,
 	is_subaddressed_email,
@@ -162,7 +168,8 @@ class MailAccount(Document):
 		self.validate_tenant_max_accounts()
 		self.validate_email()
 		self.set_normalized_email()
-		self.validate_password()
+		self.validate_app_password()
+		self.validate_secret_hash()
 		self.validate_default_outgoing_email()
 		self.validate_display_name()
 		self.validate_reply_to()
@@ -177,15 +184,28 @@ class MailAccount(Document):
 		if self.enabled:
 			if self.has_value_changed("enabled") or self.has_value_changed("email"):
 				quota = cint(frappe.db.get_value("Mail Domain", self.domain_name, "default_disk_quota")) or 10
-				MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).create(
-					self.email, self.display_name, cint(quota * (1024**3)), self.secret
+				request = MailBackendAccountManager(
+					"Mail Cluster", get_cluster_for_tenant(self.tenant)
+				).create(
+					self.email,
+					self.display_name,
+					cint(quota * (1024**3)),
+					reformat_pbkdf2_hash(self.secret_hash),
 				)
-			elif self.has_value_changed("display_name") or self.has_value_changed("secret"):
+				if request.status != "Completed":
+					frappe.throw(
+						_("Failed to create account {0} on the mail server.").format(frappe.bold(self.email)),
+						title=_("Account Creation Failed"),
+					)
+			elif self.has_value_changed("display_name") or self.has_value_changed("secret_hash"):
 				MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).update(
-					self.email, self.display_name, self.secret, self.get_doc_before_save().secret
+					self.email,
+					self.display_name,
+					reformat_pbkdf2_hash(self.secret_hash),
+					reformat_pbkdf2_hash(self.get_doc_before_save().secret_hash),
 				)
 
-				if self.has_value_changed("secret"):
+				if self.has_value_changed("secret_hash"):
 					invalidate_jmap_cache(self.name)
 		elif self.has_value_changed("enabled"):
 			MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).delete(self.email)
@@ -270,18 +290,22 @@ class MailAccount(Document):
 		if not self.normalized_email:
 			self.normalized_email = normalize_email(self.email)
 
-	def validate_password(self) -> None:
-		"""Generates secret if password is changed"""
+	def validate_app_password(self) -> None:
+		"""Validates the app password."""
 
-		if not self.password:
-			self._generate_password()
+		if self.is_new() or self.app_password:
+			return
 
-		if not self.is_new():
-			if previous_doc := self.get_doc_before_save():
-				if previous_doc.get_password("password") == self.get_password("password"):
-					return
+		frappe.throw(_("App Password is mandatory."))
 
-		self.generate_secret()
+	def validate_secret_hash(self) -> None:
+		"""Validates the secret hash."""
+
+		if not self.secret_hash:
+			self.secret_hash = get_user_hashed_password(self.user)
+
+			if not self.secret_hash:
+				frappe.throw(_("Could not fetch password for user {0}.").format(frappe.bold(self.user)))
 
 	def validate_default_outgoing_email(self) -> None:
 		"""Validates the default outgoing email."""
@@ -327,18 +351,12 @@ class MailAccount(Document):
 		frappe.cache.hdel(f"user|{self.user}", ["account", "default_outgoing_email"])
 		frappe.cache.hdel(f"email|{self.email}", "account")
 
-	def generate_secret(self) -> None:
-		"""Generates secret from password"""
-
-		password = self.get_password("password")
-		self.secret = hash_password(password)
-
 	@frappe.whitelist()
-	def get_account_password(self) -> str:
-		"""Returns the password for the Mail Account."""
+	def get_account_app_password(self) -> str:
+		"""Returns the app password for the Mail Account."""
 
 		validate_permission_for_account(self.name)
-		return self.get_password("password")
+		return self.get_password("app_password")
 
 	@frappe.whitelist()
 	def sync_jmap_identities(self) -> None:
@@ -416,19 +434,50 @@ class MailAccount(Document):
 			frappe.throw(_("Failed to set vacation response."))
 
 	@frappe.whitelist()
-	def regenerate_password(self) -> None:
-		"""Regenerates the password for the Mail Account."""
+	def regenerate_app_password(self, account_password: str) -> None:
+		"""Regenerates the app password for the Mail Account."""
 
 		validate_permission_for_account(self.name)
-		self._generate_password()
-		self.save()
+		self._generate_app_password(account_password, save=True)
 
-		frappe.msgprint(_("Password has been regenerated."), alert=True, indicator="green")
+		frappe.msgprint(_("App Password has been regenerated."), alert=True, indicator="green")
 
-	def _generate_password(self) -> None:
-		"""Generates a random password for the Mail Account."""
+	def _generate_app_password(self, account_password: str, save: bool = True) -> None:
+		"""Generates a app password for the Mail Account."""
 
-		self.password = random_string(length=20)
+		if not account_password:
+			frappe.throw(_("Account password is required to generate app password."))
+
+		self.app_password = " ".join(
+			["".join(random.choices(string.ascii_lowercase, k=l)) for l in (5, 4, 4, 4, 3)]
+		)
+		base_url = frappe.db.get_value("Mail Cluster", get_cluster_for_tenant(self.tenant), "base_url")
+
+		try:
+			data = [
+				{
+					"type": "addAppPassword",
+					"name": base64.b64encode(
+						f"{frappe.local.site}${datetime.now(timezone.utc).isoformat(timespec='milliseconds')}".encode()
+					).decode(),
+					"password": hash_password(self.app_password),
+				}
+			]
+			response = requests.post(
+				urljoin(base_url, "api/account/auth"), json=data, auth=(self.email, account_password)
+			)
+			raise_for_status(response)
+
+			if save:
+				self.save()
+
+			invalidate_jmap_client_cache(self.name)
+		except Exception:
+			frappe.log_error(
+				title=_("Failed to generate app password"),
+				message=frappe.get_traceback(with_context=True),
+			)
+			frappe.throw(_("Failed to generate app password. Please check your account password."))
 
 	def _sync_jmap_identities(self) -> None:
 		"""Syncs JMAP identities for the Mail Account."""
@@ -542,14 +591,17 @@ def create_mail_account(
 	email: str,
 	backup_email: str,
 	first_name: str,
-	last_name: str | None = None,
-	password: str | None = None,
+	last_name: str,
+	password: str,
 	is_admin: bool = False,
 ) -> "MailAccount":
 	"""Creates a Mail Account"""
 
 	if frappe.db.exists("Mail Account", email):
 		frappe.throw(_("Mail Account {0} already exists.").format(frappe.bold(email)))
+
+	if not password:
+		frappe.throw(_("Password is required to create account."))
 
 	user = _create_user_for_mail_account(email, first_name, last_name, password, is_admin)
 	_add_user_to_tenant(tenant, user, is_admin)
@@ -558,6 +610,7 @@ def create_mail_account(
 	account.user = user
 	account.backup_email = backup_email
 	account.insert(ignore_permissions=True)
+	account._generate_app_password(account_password=password)
 
 	return account
 

--- a/mail/mail/doctype/mail_account_request/mail_account_request.js
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.js
@@ -106,6 +106,7 @@ frappe.ui.form.on('Mail Account Request', {
 					label: __('Last Name'),
 					fieldname: 'last_name',
 					fieldtype: 'Data',
+					reqd: 1,
 				},
 				{
 					label: __('Password'),

--- a/mail/mail/doctype/mail_account_request/mail_account_request.py
+++ b/mail/mail/doctype/mail_account_request/mail_account_request.py
@@ -196,9 +196,7 @@ class MailAccountRequest(Document):
 		frappe.msgprint(_("Verification email sent successfully."), indicator="green", alert=True)
 
 	@frappe.whitelist()
-	def force_verify_and_create_account(
-		self, first_name: str, last_name: str | None = None, password: str | None = None
-	) -> None:
+	def force_verify_and_create_account(self, first_name: str, last_name: str, password: str) -> None:
 		"""Force verify and create account for invited user."""
 
 		self.validate_expired()
@@ -216,9 +214,7 @@ class MailAccountRequest(Document):
 		self.db_set("is_verified", 1)
 		self.create_account(first_name, last_name, password)
 
-	def create_account(
-		self, first_name: str, last_name: str | None = None, password: str | None = None
-	) -> None:
+	def create_account(self, first_name: str, last_name: str, password: str) -> None:
 		"""Create mail account for the user."""
 
 		if not self.is_verified:

--- a/mail/mail/doctype/mail_domain/mail_domain.py
+++ b/mail/mail/doctype/mail_domain/mail_domain.py
@@ -38,7 +38,14 @@ class MailDomain(Document):
 		self.validate_is_verified()
 
 	def after_insert(self) -> None:
-		MailBackendDomainManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).create(self.domain_name)
+		request = MailBackendDomainManager("Mail Cluster", get_cluster_for_tenant(self.tenant)).create(
+			self.domain_name
+		)
+		if request.status != "Completed":
+			frappe.throw(
+				_("Failed to create domain {0} on the mail server.").format(frappe.bold(self.domain_name)),
+				title=_("Domain Creation Failed"),
+			)
 
 	def on_update(self) -> None:
 		self.clear_cache()

--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -2,3 +2,4 @@
 
 [post_model_sync]
 mail.patches.rename_fields_based_on_config_toml
+mail.patches.set_account_password

--- a/mail/patches/set_account_password.py
+++ b/mail/patches/set_account_password.py
@@ -1,0 +1,61 @@
+import json
+
+import frappe
+from frappe import _
+
+from mail.utils import reformat_pbkdf2_hash
+from mail.utils.cache import get_cluster_for_tenant
+from mail.utils.user import get_user_hashed_password
+
+
+def execute() -> None:
+	domains = frappe.db.get_all("Mail Domain", {"enabled": 1, "is_verified": 1})
+	accounts = frappe.db.get_all("Mail Account", pluck="name")
+
+	for account in accounts:
+		try:
+			doc = frappe.get_doc("Mail Account", account)
+			secret_hash = get_user_hashed_password(doc.user)
+			doc._db_set(secret_hash=secret_hash)
+
+			if not doc.enabled or doc.domain_name not in domains:
+				continue
+
+			if hasattr(doc, "password") and doc.password:
+				account_password = doc.get_password("password")
+				doc._generate_app_password(account_password)
+
+			get_req = frappe.new_doc("Mail Backend Request")
+			get_req.backend_type = "Mail Cluster"
+			get_req.backend_name = get_cluster_for_tenant(doc.tenant)
+			get_req.method = "GET"
+			get_req.endpoint = f"/api/principal/{account}"
+			frappe.flags.do_not_enqueue = True
+			get_req.save()
+
+			secrets = json.loads(get_req.response_json or "{}").get("data", {}).get("secrets", [])
+			request_data = [
+				{
+					"action": "addItem",
+					"field": "secrets",
+					"value": reformat_pbkdf2_hash(secret_hash),
+				}
+			]
+			for secret in secrets:
+				if not secret.startswith("$app$"):
+					request_data.append({"action": "removeItem", "field": "secrets", "value": secret})
+
+			patch_req = frappe.new_doc("Mail Backend Request")
+			patch_req.backend_type = "Mail Cluster"
+			patch_req.backend_name = get_cluster_for_tenant(doc.tenant)
+			patch_req.method = "PATCH"
+			patch_req.endpoint = f"/api/principal/{account}"
+			patch_req.request_data = json.dumps(request_data)
+			frappe.flags.do_not_enqueue = True
+			patch_req.save()
+
+		except Exception:
+			frappe.log_error(
+				_("Failed to set password for account {0}").format(account),
+				frappe.get_traceback(with_context=True),
+			)

--- a/mail/patches/set_account_password.py
+++ b/mail/patches/set_account_password.py
@@ -1,15 +1,13 @@
-import json
-
 import frappe
 from frappe import _
 
-from mail.utils import reformat_pbkdf2_hash
+from mail.backend import MailBackendAccountManager
 from mail.utils.cache import get_cluster_for_tenant
 from mail.utils.user import get_user_hashed_password
 
 
 def execute() -> None:
-	domains = frappe.db.get_all("Mail Domain", {"enabled": 1, "is_verified": 1})
+	domains = frappe.db.get_all("Mail Domain", {"enabled": 1, "is_verified": 1}, pluck="name")
 	accounts = frappe.db.get_all("Mail Account", pluck="name")
 
 	for account in accounts:
@@ -25,35 +23,9 @@ def execute() -> None:
 				account_password = doc.get_password("password")
 				doc._generate_app_password(account_password)
 
-			get_req = frappe.new_doc("Mail Backend Request")
-			get_req.backend_type = "Mail Cluster"
-			get_req.backend_name = get_cluster_for_tenant(doc.tenant)
-			get_req.method = "GET"
-			get_req.endpoint = f"/api/principal/{account}"
-			frappe.flags.do_not_enqueue = True
-			get_req.save()
-
-			secrets = json.loads(get_req.response_json or "{}").get("data", {}).get("secrets", [])
-			request_data = [
-				{
-					"action": "addItem",
-					"field": "secrets",
-					"value": reformat_pbkdf2_hash(secret_hash),
-				}
-			]
-			for secret in secrets:
-				if not secret.startswith("$app$"):
-					request_data.append({"action": "removeItem", "field": "secrets", "value": secret})
-
-			patch_req = frappe.new_doc("Mail Backend Request")
-			patch_req.backend_type = "Mail Cluster"
-			patch_req.backend_name = get_cluster_for_tenant(doc.tenant)
-			patch_req.method = "PATCH"
-			patch_req.endpoint = f"/api/principal/{account}"
-			patch_req.request_data = json.dumps(request_data)
-			frappe.flags.do_not_enqueue = True
-			patch_req.save()
-
+			MailBackendAccountManager("Mail Cluster", get_cluster_for_tenant(doc.tenant)).update(
+				doc.email, doc.display_name, secret_hash, old_secret=""
+			)
 		except Exception:
 			frappe.log_error(
 				_("Failed to set password for account {0}").format(account),

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -36,21 +36,25 @@ def verify_password(password: str, hashed_password: str) -> bool:
 
 
 def reformat_pbkdf2_hash(passlib_hash: str, dklen: int | None = None) -> str:
-	"""Normalize a PBKDF2 hash into a consistent format."""
+	"""Normalize a PBKDF2 hash from Passlib crypt-base64 format."""
 
-	prefix, iterations, salt_mod, hash_b64 = passlib_hash.strip("$").split("$")
+	crypt_b64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	std_b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	trans = str.maketrans(crypt_b64, std_b64)
+
+	prefix, iterations, salt_mod, hash_mod = passlib_hash.strip("$").split("$")
 	iterations = int(iterations)
-	salt_std = salt_mod.replace(".", "+").replace("-", "/")
-	salt_bytes = base64.b64decode(salt_std + "===")
-	salt_b64 = base64.b64encode(salt_bytes).decode().rstrip("=")
-	hash_bytes = base64.b64decode(hash_b64 + "===")
+
+	salt_bytes = base64.b64decode(salt_mod.translate(trans) + "===")
+	hash_bytes = base64.b64decode(hash_mod.translate(trans) + "===")
+
 	if dklen is None:
 		dklen = len(hash_bytes)
 
-	hash_clean = base64.b64encode(hash_bytes).decode().rstrip("=")
-	stalwart_hash = f"${prefix}$i={iterations},l={dklen}${salt_b64}${hash_clean}"
+	salt_b64 = base64.b64encode(salt_bytes).decode().rstrip("=")
+	hash_b64 = base64.b64encode(hash_bytes).decode().rstrip("=")
 
-	return stalwart_hash
+	return f"${prefix}$i={iterations},l={dklen}${salt_b64}${hash_b64}"
 
 
 @contextmanager

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -35,6 +35,24 @@ def verify_password(password: str, hashed_password: str) -> bool:
 	return bcrypt.checkpw(password.encode(), hashed_password.encode())
 
 
+def reformat_pbkdf2_hash(passlib_hash: str, dklen: int | None = None) -> str:
+	"""Normalize a PBKDF2 hash into a consistent format."""
+
+	prefix, iterations, salt_mod, hash_b64 = passlib_hash.strip("$").split("$")
+	iterations = int(iterations)
+	salt_std = salt_mod.replace(".", "+").replace("-", "/")
+	salt_bytes = base64.b64decode(salt_std + "===")
+	salt_b64 = base64.b64encode(salt_bytes).decode().rstrip("=")
+	hash_bytes = base64.b64decode(hash_b64 + "===")
+	if dklen is None:
+		dklen = len(hash_bytes)
+
+	hash_clean = base64.b64encode(hash_bytes).decode().rstrip("=")
+	stalwart_hash = f"${prefix}$i={iterations},l={dklen}${salt_b64}${hash_clean}"
+
+	return stalwart_hash
+
+
 @contextmanager
 def user_context(user: str) -> Generator[None, None, None]:
 	"""Context manager to temporarily switch the user context."""

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -2,6 +2,7 @@ import base64
 import gzip
 import hashlib
 import os
+import random
 import re
 import secrets
 import string
@@ -35,26 +36,36 @@ def verify_password(password: str, hashed_password: str) -> bool:
 	return bcrypt.checkpw(password.encode(), hashed_password.encode())
 
 
-def reformat_pbkdf2_hash(passlib_hash: str, dklen: int | None = None) -> str:
-	"""Normalize a PBKDF2 hash from Passlib crypt-base64 format."""
+def generate_random_phrase() -> str:
+	"""Generate a random passphrase consisting of 5 words."""
 
-	crypt_b64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	std_b64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-	trans = str.maketrans(crypt_b64, std_b64)
+	return " ".join(["".join(random.choices(string.ascii_lowercase, k=l)) for l in (5, 4, 4, 4, 3)])
+
+
+def reformat_pbkdf2_hash(passlib_hash: str, dklen: int | None = None) -> str:
+	"""Normalize a PBKDF2 hash into a consistent format."""
 
 	prefix, iterations, salt_mod, hash_mod = passlib_hash.strip("$").split("$")
 	iterations = int(iterations)
 
-	salt_bytes = base64.b64decode(salt_mod.translate(trans) + "===")
-	hash_bytes = base64.b64decode(hash_mod.translate(trans) + "===")
+	def b64decode_mod(s: str) -> bytes:
+		s = s.replace(".", "+").replace("-", "/")
+		pad_len = (-len(s)) % 4
+		return base64.b64decode(s + ("=" * pad_len))
 
+	def b64encode_std(b: bytes) -> str:
+		return base64.b64encode(b).decode().rstrip("=")
+
+	salt_bytes = b64decode_mod(salt_mod)
+	salt_b64 = b64encode_std(salt_bytes)
+
+	hash_bytes = b64decode_mod(hash_mod)
 	if dklen is None:
 		dklen = len(hash_bytes)
+	hash_clean = b64encode_std(hash_bytes)
 
-	salt_b64 = base64.b64encode(salt_bytes).decode().rstrip("=")
-	hash_b64 = base64.b64encode(hash_bytes).decode().rstrip("=")
-
-	return f"${prefix}$i={iterations},l={dklen}${salt_b64}${hash_b64}"
+	formatted_hash = f"${prefix}$i={iterations},l={dklen}${salt_b64}${hash_clean}"
+	return formatted_hash
 
 
 @contextmanager

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 import frappe
 from frappe import _
 from frappe.core.doctype.user.user import generate_keys
+from frappe.query_builder import Table
 from frappe.utils.caching import request_cache
 
 from mail.utils import user_context
@@ -108,6 +109,26 @@ def generate_user_keys(user: str) -> dict:
 			return generate_keys(user)
 
 	frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+
+def get_user_hashed_password(user: str) -> str | None:
+	"""Returns the hashed password for a given user."""
+
+	Auth = Table("__Auth")
+	result = (
+		frappe.qb.from_(Auth)
+		.select(Auth.password)
+		.where(
+			(Auth.doctype == "User")
+			& (Auth.name == user)
+			& (Auth.fieldname == "password")
+			& (Auth.encrypted == 0)
+		)
+		.limit(1)
+		.run()
+	)
+	if result:
+		return result[0][0]
 
 
 def get_caldav_settings(user: str) -> dict:


### PR DESCRIPTION
- On user creation:
  - [x] Create Mail Account, password should be the same as the User's password.
  - [x] Create an app password for the account using the User's password.
  - [x] Store app password (editable) in Mail Account to access JMAP.
  - [x] Regenerate App Password using the User's password.

- On user password change:
  - [x] Update the account password on the server.

- On app password change/remove:
  - [x] The user needs to set one for the Mail Account manually or can use "Re-generate App Password".

- [x] Patch for existing Mail Accounts.

close: https://github.com/frappe/mail/issues/265