### PR TITLE
feat: simulating relevance search

### DIFF
--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -12,7 +12,7 @@ from mail.mail.doctype.mail_message.mail_message import (
 	fetch_threads,
 	get_message_ids,
 	move_messages,
-	search_messages,
+	relevance_search_messages,
 	set_flagged_status,
 	set_seen_status,
 )
@@ -430,4 +430,4 @@ def search_mails(query) -> dict:
 	"""Returns search results for the given query."""
 
 	account = get_account_for_user(frappe.session.user)
-	return search_messages(account, {"text": query}, 0, 10)
+	return relevance_search_messages(account, text=query, limit=10)

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -399,6 +399,47 @@ class JMAPClient:
 
 		return {"ids": _ids[:limit], "total": total}
 
+	def relevance_search(self, text: str, limit: int = 50) -> dict:
+		"""Returns emails matching the given text in subject, to, cc, bcc, body or text."""
+
+		filters = [
+			{"subject": text},
+			{"to": text},
+			{"cc": text},
+			{"bcc": text},
+			{"body": text},
+			{"text": text},
+		]
+
+		method_calls = []
+		for i, filter in enumerate(filters):
+			method_calls.append(
+				[
+					"Email/query",
+					{
+						"accountId": self.account_id,
+						"filter": filter,
+						"position": 0,
+						"limit": limit,
+						"sort": [{"property": "receivedAt", "isAscending": False}],
+						"calculateTotal": True if i == len(filters) - 1 else False,
+					},
+					str(i),
+				]
+			)
+		response = self._make_request(using=["urn:ietf:params:jmap:mail"], method_calls=method_calls)
+
+		_ids = []
+		total = 0
+		for method_response in response["methodResponses"]:
+			_method, result, _call_id = method_response
+			total = result.get("total", total)
+			for _id in result.get("ids", []):
+				if _id not in _ids:
+					_ids.append(_id)
+
+		return {"ids": _ids[:limit], "total": total}
+
 	def thread_query(
 		self, filter: dict | None = None, position: int = 0, limit: int = 50, fetch_all: bool = False
 	) -> list[str] | dict[str, list]:

--- a/mail/mail/doctype/mail_message/mail_message.py
+++ b/mail/mail/doctype/mail_message/mail_message.py
@@ -661,6 +661,25 @@ def search_messages(account: str, filter: dict, position: int = 0, limit: int = 
 	return messages
 
 
+def relevance_search_messages(account: str, text: str, limit: int = 20) -> list[dict]:
+	"""Returns a list of messages based on relevance search for the provided text."""
+
+	validate_permission_for_account(account)
+
+	client = get_jmap_client(account)
+	result = client.relevance_search(text, limit)
+	_ids = result["ids"]
+
+	if not _ids:
+		return []
+
+	fetched_messages = get_messages(account, _ids=_ids, sort_asc=False)
+	msg_by_id = {msg["_id"]: msg for msg in fetched_messages}
+	messages = [msg_by_id[mid] for mid in _ids if mid in msg_by_id]
+
+	return messages[:limit]
+
+
 def get_messages(account: str, _ids: list[str], sort_asc: bool = False) -> list[dict]:
 	"""Returns a list of messages for the provided IDs."""
 


### PR DESCRIPTION
JMAP does not natively support relevance search or sort by relevance (unlike IMAP).

**Before:** Searches used a text (FTS) filter with results sorted by receivedAt descending.

<img width="1904" height="942" alt="image" src="https://github.com/user-attachments/assets/17b3156a-6295-4a42-901d-fa567295a00d" />

**After:** Searches simulate relevance by batching Email/query calls on subject, to, cc, bcc, body, and text, sorting each set by receivedAt descending and merging the top IDs based on the limit.

<img width="1904" height="942" alt="image" src="https://github.com/user-attachments/assets/9a46e9f4-0105-4448-9336-4423c526d4b5" />

**Note:** `relevance_search_messages()` might be slow as compared to `search_messages()` due to batch calls and FTS (text).

**search_messages**

New Search

```
21720 function calls (21680 primitive calls) in 0.922 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.922    0.922 {built-in method builtins.exec}
        1    0.000    0.000    0.922    0.922 <string>:1(<module>)
        1    0.000    0.000    0.922    0.922 mail_message.py:636(search_messages)
        1    0.000    0.000    0.922    0.922 mail_message.py:578(fetch_messages)
        4    0.000    0.000    0.909    0.227 sessions.py:500(request)
      6/4    0.000    0.000    0.905    0.226 sessions.py:673(send)
        6    0.000    0.000    0.810    0.135 adapters.py:613(send)
        6    0.000    0.000    0.805    0.134 connectionpool.py:592(urlopen)
        6    0.000    0.000    0.803    0.134 connectionpool.py:377(_make_request)
        6    0.000    0.000    0.520    0.087 connectionpool.py:1085(_validate_conn)
        4    0.000    0.000    0.520    0.130 connection.py:669(connect)
        2    0.000    0.000    0.513    0.257 jmap.py:63(_make_request)
        2    0.000    0.000    0.511    0.256 sessions.py:626(post)
        1    0.000    0.000    0.413    0.413 mail_message.py:683(get_messages)
        2    0.000    0.000    0.399    0.200 jmap.py:857(get_jmap_client)
        2    0.000    0.000    0.399    0.200 jmap.py:18(__init__)
        2    0.000    0.000    0.399    0.199 jmap.py:28(_discover_config)
```

Repeated Search

```
10191 function calls (10171 primitive calls) in 0.278 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.278    0.278 {built-in method builtins.exec}
        1    0.000    0.000    0.278    0.278 <string>:1(<module>)
        1    0.000    0.000    0.278    0.278 mail_message.py:636(search_messages)
        1    0.000    0.000    0.277    0.277 mail_message.py:578(fetch_messages)
        2    0.000    0.000    0.275    0.138 sessions.py:500(request)
      3/2    0.000    0.000    0.273    0.137 sessions.py:673(send)
        3    0.000    0.000    0.270    0.090 adapters.py:613(send)
        3    0.000    0.000    0.268    0.089 connectionpool.py:592(urlopen)
        3    0.000    0.000    0.268    0.089 connectionpool.py:377(_make_request)
        3    0.000    0.000    0.148    0.049 connectionpool.py:1085(_validate_conn)
        2    0.000    0.000    0.148    0.074 connection.py:669(connect)
        1    0.000    0.000    0.140    0.140 jmap.py:358(email_query)
        1    0.000    0.000    0.140    0.140 jmap.py:63(_make_request)
        1    0.000    0.000    0.140    0.140 sessions.py:626(post)
        1    0.000    0.000    0.135    0.135 jmap.py:857(get_jmap_client)
        1    0.000    0.000    0.135    0.135 jmap.py:18(__init__)
        1    0.000    0.000    0.135    0.135 jmap.py:28(_discover_config)
```

**relevance_search_messages**

New Search

```
46200 function calls (46160 primitive calls) in 2.063 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.064    2.064 {built-in method builtins.exec}
        1    0.000    0.000    2.064    2.064 <string>:1(<module>)
        1    0.000    0.000    2.063    2.063 mail_message.py:664(relevance_search_messages)
        4    0.000    0.000    2.020    0.505 sessions.py:500(request)
      6/4    0.000    0.000    2.016    0.504 sessions.py:673(send)
        6    0.000    0.000    1.668    0.278 adapters.py:613(send)
        6    0.000    0.000    1.664    0.277 connectionpool.py:592(urlopen)
        6    0.000    0.000    1.663    0.277 connectionpool.py:377(_make_request)
        6    0.000    0.000    1.298    0.216 connectionpool.py:1085(_validate_conn)
        4    0.000    0.000    1.298    0.325 connection.py:669(connect)
        2    0.000    0.000    1.230    0.615 jmap.py:857(get_jmap_client)
        2    0.000    0.000    1.230    0.615 jmap.py:18(__init__)
        2    0.000    0.000    1.229    0.615 jmap.py:28(_discover_config)
        2    0.000    0.000    1.229    0.615 sessions.py:593(get)
        4    0.000    0.000    1.162    0.291 connection.py:192(_new_conn)
        4    0.000    0.000    1.162    0.291 connection.py:27(create_connection)
        4    0.000    0.000    1.050    0.262 socket.py:938(getaddrinfo)
```

Repeated Search

```
10114 function calls (10094 primitive calls) in 0.380 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.380    0.380 {built-in method builtins.exec}
        1    0.000    0.000    0.380    0.380 <string>:1(<module>)
        1    0.000    0.000    0.380    0.380 mail_message.py:664(relevance_search_messages)
        2    0.000    0.000    0.378    0.189 sessions.py:500(request)
      3/2    0.000    0.000    0.376    0.188 sessions.py:673(send)
        3    0.000    0.000    0.373    0.124 adapters.py:613(send)
        3    0.000    0.000    0.371    0.124 connectionpool.py:592(urlopen)
        3    0.000    0.000    0.371    0.124 connectionpool.py:377(_make_request)
        3    0.000    0.000    0.224    0.075 connection.py:485(getresponse)
        3    0.000    0.000    0.223    0.074 client.py:1331(getresponse)
        3    0.000    0.000    0.223    0.074 client.py:311(begin)
        1    0.000    0.000    0.222    0.222 jmap.py:402(relevance_search)
        1    0.000    0.000    0.222    0.222 jmap.py:63(_make_request)
        1    0.000    0.000    0.222    0.222 sessions.py:626(post)
        3    0.000    0.000    0.221    0.074 client.py:278(_read_status)
       21    0.000    0.000    0.221    0.011 {method 'readline' of '_io.BufferedReader' objects}
        3    0.000    0.000    0.221    0.074 socket.py:691(readinto)
```
