### PR TITLE
fix: render plain text as HTML

### DIFF
--- a/mail/mail/doctype/mail_message/mail_message.py
+++ b/mail/mail/doctype/mail_message/mail_message.py
@@ -23,7 +23,7 @@ from mail.mail.doctype.jmap_sync_state.jmap_sync_state import (
 )
 from mail.mail.doctype.mail_contact.mail_contact import create_mail_contact
 from mail.mail.doctype.mail_queue.mail_queue import MailQueue
-from mail.utils import enqueue_job, parse_filters, user_context
+from mail.utils import convert_text_to_html, enqueue_job, parse_filters, user_context
 from mail.utils.cache import get_account_for_user
 from mail.utils.dt import parse_iso_datetime
 from mail.utils.email_parser import EmailParser
@@ -960,11 +960,16 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
 				)
 
 	for key, field in {"htmlBody": "html_body", "textBody": "text_body"}.items():
-		formatted_message[field] = (
+		value = (
 			message.get("bodyValues", {}).get(message[key][0]["partId"], {}).get("value")
 			if message.get(key)
 			else None
 		)
+
+		if key == "htmlBody" and value and ("<" not in value or ">" not in value):
+			value = convert_text_to_html(value)
+
+		formatted_message[field] = value
 
 	formatted_message["mailboxes"] = []
 	for mailbox_id, value in message["mailboxIds"].items():

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -20,6 +20,7 @@ from frappe import _
 from frappe.types.filter import FilterTuple
 from frappe.utils import get_bench_path
 from frappe.utils.caching import redis_cache
+from markdown_it import MarkdownIt
 
 
 def hash_password(password: str) -> str:
@@ -240,6 +241,13 @@ def convert_html_to_text(html: str) -> str:
 	soup = BeautifulSoup(html, "html.parser")
 	text = soup.get_text(separator=" ")
 	return re.sub(r"\s+", " ", text).strip()
+
+
+def convert_text_to_html(text: str) -> str:
+	"""Convert plain text to HTML."""
+
+	parsed_html = MarkdownIt().render(text)
+	return BeautifulSoup(parsed_html, "html.parser").prettify()
 
 
 def extract_filter_values(filters: list, conditions: list[dict]) -> tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "dnspython~=2.4.2",
     "xmltodict~=0.14.2",
     "dns-lexicon~=3.20.1",
+    "markdown-it-py~=4.0.0",
     "validate-email-address~=1.0.0",
 ]
 


### PR DESCRIPTION
Some emails may not have an HTML Body, so the server sets the HTML Body the same as the Text Body.

**Before:**

<img width="2542" height="1304" alt="Screenshot from 2025-09-17 12-14-15" src="https://github.com/user-attachments/assets/503b3fad-c7f5-49a2-aa62-952d61376d11" />

**After:**

<img width="2542" height="1304" alt="Screenshot from 2025-09-17 12-12-42" src="https://github.com/user-attachments/assets/1986b335-612d-4fe4-ad00-e4ef799a11da" />

