### PR TITLE
fix(Editor): mail formatting

### DIFF
--- a/frontend/src/components/ComposeMailEditor.vue
+++ b/frontend/src/components/ComposeMailEditor.vue
@@ -1,13 +1,16 @@
 <template>
 	<TextEditor
 		ref="textEditor"
-		editor-class="not-prose prose-sm max-w-none"
-		:extensions="[CustomImageExtension]"
-		:content="mail.html_body"
+		editor-class="prose-sm max-w-none"
+		:starterkit-options="{ paragraph: false }"
+		:extensions="[CustomImageExtension, CustomParagraphExtension]"
+		:content="mail.html_body.replaceAll('<div><br></div>', '<div></div>')"
 		class="flex flex-col max-sm:overflow-y-auto"
 		:class="{ 'pointer-events-none opacity-50': !show, 'sm:h-[75vh]': !isInThread }"
 		:style="isMobile && { height: editorHeight }"
-		@change="(val: string) => (mail.html_body = val)"
+		@change="
+			(val: string) => (mail.html_body = val.replaceAll('<div></div>', '<div><br></div>'))
+		"
 	>
 		<template #top>
 			<div class="flex flex-col gap-2.5 border-b pb-2.5 max-sm:px-3 max-sm:pt-2.5">
@@ -172,6 +175,7 @@ import {
 	ref,
 	useTemplateRef,
 } from 'vue'
+import { Node } from '@tiptap/core'
 import { EditorContent } from '@tiptap/vue-3'
 import { watchDebounced } from '@vueuse/core'
 import { ChevronDown, ChevronUp, ExternalLink, Forward, Reply, ReplyAll } from 'lucide-vue-next'
@@ -405,7 +409,7 @@ const isMailEmpty = computed(() => {
 })
 
 const openQuotedContent = () => {
-	mail.html_body += mail.quoted_content
+	mail.html_body += `<br>${mail.quoted_content}`
 	mail.quoted_content = ''
 }
 
@@ -425,6 +429,8 @@ const openAttachment = async (blob_id?: string, type?: string) => {
 	const url = URL.createObjectURL(blob)
 	window.open(url, '_blank')
 }
+
+// Custom Extensions
 
 const uploadFunction = async (file: File) => {
 	const fileUpload = useFileUpload()
@@ -451,6 +457,15 @@ const CustomImageExtension = ImageExtension.extend({
 				attributes['data-cid'] ? { 'data-cid': attributes['data-cid'] } : {},
 		},
 	}),
+})
+
+const CustomParagraphExtension = Node.create({
+	name: 'paragraph',
+	priority: 1000,
+	group: 'block',
+	content: 'inline*',
+	parseHTML: () => [{ tag: 'div' }, { tag: 'p' }],
+	renderHTML: ({ HTMLAttributes }) => ['div', HTMLAttributes, 0],
 })
 
 const TYPE_ICON_MAP = {

--- a/frontend/src/components/EmailContent.vue
+++ b/frontend/src/components/EmailContent.vue
@@ -72,9 +72,16 @@ const srcdoc = computed(() => {
 
 	const transformedContent = DOMPurify.sanitize(content, DOMPURIFY_CONFIG)
 		.replace(
-			/<div\s+class="(gmail_quote|frappe_mail_quote)"([^>]*)>([\s\S]*?)<\/div>/gi,
-			(_, quoteClass, otherAttrs, innerHtml) =>
-				`${collapseButton}<div class="quote-hidden ${quoteClass}"${otherAttrs}>${innerHtml}</div>`,
+			/<div\s+([^>]*)\bclass="([^"]*)"\s*([^>]*)>([\s\S]*?)<\/div>/gi,
+			(match, beforeAttrs, classValue, afterAttrs, innerHtml) => {
+				// Check if this div has gmail_quote or frappe_mail_quote class
+				if (/\b(gmail_quote|frappe_mail_quote)\b/.test(classValue)) {
+					const allAttrs = `${beforeAttrs} ${afterAttrs}`.trim()
+					const attrString = allAttrs ? ` ${allAttrs}` : ''
+					return `${collapseButton}<div class="quote-hidden ${classValue}"${attrString}>${innerHtml}</div>`
+				}
+				return match
+			},
 		)
 		.replace(/<([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>/g, '<b>&lt;$1&gt;</b>')
 

--- a/frontend/src/components/HeaderActions.vue
+++ b/frontend/src/components/HeaderActions.vue
@@ -33,24 +33,23 @@ const showSendModal = ref(false)
 const modifier = computed(() => (isMac ? '⌘' : 'Ctrl'))
 
 const handleKeydown = (e: KeyboardEvent) => {
+	const target = e.target as HTMLElement
+	if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+		return
+
+	const key = e.key.toLowerCase()
+
 	// Search shortcut
-	if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+	if ((e.metaKey || e.ctrlKey) && key === 'k') {
 		e.preventDefault()
 		showSearchModal.value = true
 		return
 	}
 
 	// Compose shortcut
-	if (e.key === 'c' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
-		const target = e.target as HTMLElement
-		if (
-			target.tagName !== 'INPUT' &&
-			target.tagName !== 'TEXTAREA' &&
-			!target.isContentEditable
-		) {
-			e.preventDefault()
-			showSendModal.value = true
-		}
+	if (key === 'c' && !e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+		e.preventDefault()
+		showSendModal.value = true
 	}
 }
 

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -662,14 +662,16 @@ const getQuotedContent = (mail: Mail) =>
 
 const getForwardedContent = (mail: Mail) =>
 	`
-		<br><br>
-		---------- Forwarded message ---------<br>
-		From: ${mail.from_name} < ${mail.from_email} ><br>
-		Date: ${dayjs(mail.received_at).format('ddd, MMM D, YYYY [at] h:mm A')}<br>
-		Subject: ${mail.subject || ''}<br>
-		To: ${mail.groupedRecipients.to.join(', ')}<br>
-		${mail.groupedRecipients.cc.length ? `Cc: ${mail.groupedRecipients.cc.join(', ')}<br>` : ''}
-		<br><br>
-		${mail.html_body || '&nbsp;'}
+		<div class="frappe_mail_quote">
+			<br><br>
+			---------- Forwarded message ---------<br>
+			From: ${mail.from_name} < ${mail.from_email} ><br>
+			Date: ${dayjs(mail.received_at).format('ddd, MMM D, YYYY [at] h:mm A')}<br>
+			Subject: ${mail.subject || ''}<br>
+			To: ${mail.groupedRecipients.to.join(', ')}<br>
+			${mail.groupedRecipients.cc.length ? `Cc: ${mail.groupedRecipients.cc.join(', ')}<br>` : ''}
+			<br><br>
+			${mail.html_body || '&nbsp;'}
+		</div>
 	`
 </script>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -705,6 +705,7 @@ const reloadThreads: (reloadMailboxes?: boolean, mailboxRoles?: MailboxRole[]) =
 watch(
 	() => mailbox,
 	() => {
+		threadsResource.value.data = []
 		filter.value = localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null
 		limit.value = 50
 		threadInFocus.value = undefined

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "noImplicitAny": true,
     "skipLibCheck": true,
-    "lib": ["dom", "webworker"],
+    "lib": ["dom", "webworker", "ES2021.String"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Closes: https://github.com/frappe/mail/issues/298; Closes: https://github.com/frappe/mail/issues/291

Most clients, like GMail and Outlook, use `<div>` as the default element for rendering text.

Tiptap uses `<p>` which causes issues with formatting because of the default styling employed by browsers. This PR overrides Frappe UI's TextEditor to make use of `<div>` instead of `<p>`, along with `<br>` for line breaks (similar to GMail/Outlook).