### PR TITLE
feat: add state indicator toasts

### DIFF
--- a/frontend/src/components/Controls/MultiselectInputControl.vue
+++ b/frontend/src/components/Controls/MultiselectInputControl.vue
@@ -13,7 +13,7 @@
 			class="!text-ink-gray-7 bg-surface-gray-2 flex min-h-7 cursor-default items-center rounded px-2 text-base"
 			@keydown.delete.capture.stop="removeLastValue"
 		>
-			<span :class="{ 'max-w-28 truncate': isMobile && !isFocused }">{{ value }}</span>
+			<span :class="{ 'max-w-24 truncate': isMobile && !isFocused }">{{ value }}</span>
 			<X
 				v-if="!isMobile || isFocused"
 				class="ml-1.5 h-3.5 w-3.5 cursor-pointer"

--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -36,7 +36,7 @@ import {
 	Star,
 	Trash2,
 } from 'lucide-vue-next'
-import { Button, Dropdown, createResource } from 'frappe-ui'
+import { Button, Dropdown, createResource, toast } from 'frappe-ui'
 
 import { useScreenSize } from '@/utils/composables'
 import { userStore } from '@/stores/user'
@@ -68,7 +68,7 @@ const {
 const emit = defineEmits(['reloadMails', 'starMails'])
 
 const { isMobile } = useScreenSize()
-const { mailboxIds } = userStore()
+const { mailboxes, mailboxIds } = userStore()
 const user = inject('$user')
 
 const primaryActions = (mail: Mail): MailAction[] => [
@@ -152,19 +152,19 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 			},
 			{
 				label: __('Mark as Junk'),
-				onClick: () => markAsSpam.submit([mail._id]),
+				onClick: () => handleMarkAsSpam(),
 				icon: BadgeAlert,
 				condition: () => ![mailboxIds.junk, mailboxIds.drafts].includes(mailbox),
 			},
 			{
 				label: __('Move to Trash'),
-				onClick: () => moveMail.submit({ _ids: [mail._id], mailbox: mailboxIds.trash }),
+				onClick: () => handleMoveMail(mailboxIds.trash),
 				icon: Trash2,
 				condition: () => mailbox !== mailboxIds.trash,
 			},
 			{
 				label: __('Delete Message'),
-				onClick: () => deleteMails.submit([mail.name]),
+				onClick: () => handleDeleteMail(),
 				icon: Trash2,
 				condition: () => mailbox === mailboxIds.trash,
 			},
@@ -186,21 +186,45 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 
 const markAsSpam = createResource({
 	url: 'mail.api.mail.set_mails_spam_status',
-	makeParams: (_ids: string[]) => ({ _ids, spam: true }),
+	makeParams: () => ({ _ids: [mail._id], spam: true }),
 	onSuccess: () => emit('reloadMails'),
 })
+
+const handleMarkAsSpam = () =>
+	toast.promise(markAsSpam.submit(), {
+		loading: __('Marking as Junk...'),
+		success: __('Mail marked as Junk.'),
+		error: __('Action failed. Please try again later.'),
+	})
 
 const moveMail = createResource({
 	url: 'mail.api.mail.move_mails',
-	makeParams: ({ _ids, mailbox }: { _ids: string[]; mailbox: string }) => ({ _ids, mailbox }),
+	makeParams: (mailbox: string) => ({ _ids: [mail._id], mailbox }),
 	onSuccess: () => emit('reloadMails'),
 })
 
-const deleteMails = createResource({
+const handleMoveMail = (mailbox: string) => {
+	const mailboxName = mailboxes.data?.find((m) => m.id === mailbox)._name
+
+	toast.promise(moveMail.submit(mailbox), {
+		loading: __('Moving to {0}...', [mailboxName]),
+		success: __('Mail moved to {0}.', [mailboxName]),
+		error: __('Action failed. Please try again later.'),
+	})
+}
+
+const deleteMail = createResource({
 	url: 'mail.mail.doctype.mail_message.mail_message.bulk_delete',
-	makeParams: (names: string[]) => ({ names }),
+	makeParams: () => ({ names: [mail.name] }),
 	onSuccess: () => emit('reloadMails'),
 })
+
+const handleDeleteMail = () =>
+	toast.promise(deleteMail.submit(), {
+		loading: __('Deleting...'),
+		success: __('Mail deleted.'),
+		error: __('Action failed. Please try again later.'),
+	})
 
 const starMails = createResource({
 	url: 'mail.api.mail.set_flagged',

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -227,7 +227,9 @@
 
 							<div v-if="mail.attachments?.length" class="mt-8 flex flex-wrap">
 								<AttachmentCapsule
-									v-for="attachment in mail.attachments"
+									v-for="attachment in mail.attachments.filter(
+										(a: Attachment) => a.disposition === 'attachment',
+									)"
 									:key="attachment.name"
 									:file-name="attachment.filename"
 									:blob-i-d="attachment.blob_id"
@@ -323,7 +325,7 @@ import MailDetailsPopover from '@/components/MailDetailsPopover.vue'
 import MailThreadPlaceholder from '@/components/MailThreadPlaceholder.vue'
 import SendMail from '@/components/SendMail.vue'
 
-import type { ComposeMailData, Mail } from '@/types'
+import type { Attachment, ComposeMailData, Mail } from '@/types'
 
 const { mailbox, threadID, threads } = defineProps<{
 	mailbox: string

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -428,6 +428,8 @@ interface MailAction {
 	condition?: boolean | (() => boolean)
 }
 
+// todo: fix junk condition & display
+
 const threadActions = computed((): MailAction[] =>
 	[
 		{

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -113,82 +113,90 @@
 				<!-- Mail list -->
 				<div
 					v-if="threadsResource?.data?.length"
-					ref="mailList"
 					class="h-full overflow-y-auto overscroll-contain"
 					@scroll="loadMoreThreads"
 				>
-					<div v-for="(group, key) in groupedThreads" :key="key">
-						<Tooltip
-							v-if="groupMessagesBy !== 'none'"
-							:text="
-								isLastGroup(key)
-									? ''
-									: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
-							"
-						>
-							<div
-								class="text-ink-gray-6 group flex items-center border-b p-3.5 text-xs font-semibold sm:px-5"
-								:class="{ 'cursor-pointer': !isLastGroup(key) }"
-								@click="toggleGroupCollapse(key)"
+					<TransitionGroup name="mail-group" tag="div">
+						<div v-for="(group, key) in groupedThreads" :key="key">
+							<Tooltip
+								v-if="groupMessagesBy !== 'none'"
+								:text="
+									isLastGroup(key)
+										? ''
+										: __(collapsedGroups.includes(key) ? 'Expand' : 'Collapse')
+								"
 							>
-								<Checkbox
-									:model-value="isGroupSelected(key)"
-									size="md"
-									class="ml-1.5 mr-[11px]"
-									@update:model-value="
-										toggleSelect(getGroupThreads(key), $event)
-									"
-									@click.stop
-								/>
-								<span class="select-none pt-[2px]">
-									{{
-										getFormattedDate(
-											key,
-											groupMessagesBy === 'month',
-										).toUpperCase()
-									}}
-								</span>
+								<div
+									class="text-ink-gray-6 group flex items-center border-b p-3.5 text-xs font-semibold sm:px-5"
+									:class="{ 'cursor-pointer': !isLastGroup(key) }"
+									@click="toggleGroupCollapse(key)"
+								>
+									<Checkbox
+										:model-value="isGroupSelected(key)"
+										size="md"
+										class="ml-1.5 mr-[11px]"
+										@update:model-value="
+											toggleSelect(getGroupThreads(key), $event)
+										"
+										@click.stop
+									/>
+									<span class="select-none pt-[2px]">
+										{{
+											getFormattedDate(
+												key,
+												groupMessagesBy === 'month',
+											).toUpperCase()
+										}}
+									</span>
 
-								<component
-									:is="
-										collapsedGroups.includes(key) ? ChevronRight : ChevronDown
+									<component
+										:is="
+											collapsedGroups.includes(key)
+												? ChevronRight
+												: ChevronDown
+										"
+										v-if="!isLastGroup(key)"
+										class="text-ink-gray-5 ml-auto h-4 w-4"
+									/>
+								</div>
+							</Tooltip>
+							<TransitionGroup
+								v-if="!collapsedGroups.includes(key)"
+								name="mail-item"
+								tag="div"
+							>
+								<MailListItem
+									v-for="mail in group"
+									ref="mailItems"
+									:key="mail.name"
+									:mailbox
+									:mail
+									:is-selected="selections.includes(mail.thread_id)"
+									class="border-l-transparent transition-all sm:border-l"
+									:class="{
+										'!bg-surface-blue-1': mail.thread_id === threadID,
+										'!border-l-blue-500': mail.thread_id === threadInFocus,
+									}"
+									@click="goToThread(mail.thread_id)"
+									@set-seen="
+										(seen: boolean) =>
+											setSeen.submit({ thread_ids: [mail.thread_id], seen })
 									"
-									v-if="!isLastGroup(key)"
-									class="text-ink-gray-5 ml-auto h-4 w-4"
+									@trash-thread="
+										moveThreads.submit({
+											thread_ids: [mail.thread_id],
+											move_to_mailbox: mailboxIds.trash,
+										})
+									"
+									@delete-thread="junkOrDeleteThreads([mail.thread_id], false)"
+									@set-selected="
+										(selected: boolean) =>
+											toggleSelect([mail.thread_id], selected)
+									"
 								/>
-							</div>
-						</Tooltip>
-						<template v-if="!collapsedGroups.includes(key)">
-							<MailListItem
-								v-for="mail in group"
-								ref="mailItems"
-								:key="mail.name"
-								:mailbox
-								:mail
-								:is-selected="selections.includes(mail.thread_id)"
-								class="border-l-transparent sm:border-l"
-								:class="{
-									'!bg-surface-blue-1': mail.thread_id === threadID,
-									'!border-l-blue-500': mail.thread_id === threadInFocus,
-								}"
-								@click="goToThread(mail.thread_id)"
-								@set-seen="
-									(seen: boolean) =>
-										setSeen.submit({ thread_ids: [mail.thread_id], seen })
-								"
-								@trash-thread="
-									moveThreads.submit({
-										thread_ids: [mail.thread_id],
-										move_to_mailbox: mailboxIds.trash,
-									})
-								"
-								@delete-thread="junkOrDeleteThreads([mail.thread_id], false)"
-								@set-selected="
-									(selected: boolean) => toggleSelect([mail.thread_id], selected)
-								"
-							/>
-						</template>
-					</div>
+							</TransitionGroup>
+						</div>
+					</TransitionGroup>
 					<div
 						v-if="threadsResource.loading"
 						class="flex items-center justify-center py-4"
@@ -524,7 +532,7 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 	if (key === (isMac ? 'backspace' : 'delete')) {
 		e.preventDefault()
 		if (e.shiftKey) return junkOrDeleteThreads(thread_ids, false)
-
+		if (mailbox === mailboxIds.trash) return
 		return moveThreads.submit({ thread_ids, mailbox, move_to_mailbox: mailboxIds.trash })
 	}
 
@@ -923,7 +931,9 @@ const handleSuccessAndRemoveFromList = (
 	reloadThreads()
 
 	if (excludeCommonMailboxes && ['search', 'starred'].includes(mailbox)) return
-	if (threadID && thread_ids.includes(threadID)) goToMailbox()
+	if (threadID && thread_ids.includes(threadID))
+		if (thread_ids.length === 1) goToThreadByOffset(1)
+		else goToMailbox()
 	threadsResource.value.data = threadsResource.value.data?.filter(
 		(thread: Thread) => !thread_ids.includes(thread.thread_id),
 	)
@@ -999,3 +1009,33 @@ const title = computed(() => {
 	}
 })
 </script>
+
+<style scoped>
+/* Mail item exit animation */
+.mail-item-leave-active {
+	transition: all 0.3s ease;
+}
+
+.mail-item-leave-to {
+	opacity: 0;
+	transform: translateX(-20px);
+}
+
+.mail-item-move {
+	transition: transform 0.3s ease;
+}
+
+/* Group exit animation */
+.mail-group-leave-active {
+	transition: all 0.3s ease;
+}
+
+.mail-group-leave-to {
+	opacity: 0;
+	transform: translateX(-20px);
+}
+
+.mail-group-move {
+	transition: transform 0.3s ease;
+}
+</style>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -40,7 +40,10 @@
 	>
 		<!-- Loading -->
 		<div
-			v-if="!threadsResource?.data?.length && threadsResource?.loading && limit === 50"
+			v-if="
+				(!threadsResource?.data?.length && threadsResource?.loading && limit === 50) ||
+				emptyMailbox.loading
+			"
 			class="flex w-full flex-col items-center justify-center"
 		>
 			<div class="text-ink-gray-5 flex items-center space-x-2">
@@ -179,14 +182,10 @@
 									}"
 									@click="goToThread(mail.thread_id)"
 									@set-seen="
-										(seen: boolean) =>
-											setSeen.submit({ thread_ids: [mail.thread_id], seen })
+										(seen: boolean) => handleSetSeen([mail.thread_id], seen)
 									"
 									@trash-thread="
-										moveThreads.submit({
-											thread_ids: [mail.thread_id],
-											move_to_mailbox: mailboxIds.trash,
-										})
+										handleMoveThreads([mail.thread_id], mailboxIds.trash)
 									"
 									@delete-thread="junkOrDeleteThreads([mail.thread_id], false)"
 									@set-selected="
@@ -235,16 +234,20 @@
 					:thread-i-d
 					:threads="threadIDs"
 					@reload-mails="reloadThreads"
-					@set-seen="(seen: boolean) => setSeen.submit({ thread_ids: [threadID], seen })"
+					@set-seen="
+						(seen: boolean) =>
+							seen
+								? setSeen.submit({ thread_ids: [threadID], seen })
+								: handleSetSeen([threadID], seen)
+					"
 					@move-thread="
-						(move_to_mailbox: string) =>
-							moveThreads.submit({ thread_ids: [threadID], move_to_mailbox })
+						(moveToMailbox: string) => handleMoveThreads([threadID], moveToMailbox)
 					"
 					@set-spam-status="
 						(spam: boolean) =>
 							spam
 								? junkOrDeleteThreads([threadID!], true)
-								: setThreadsSpamStatus.submit({ thread_ids: [threadID], spam })
+								: handleSetSpamStatus([threadID], spam)
 					"
 					@delete-thread="junkOrDeleteThreads([threadID!], false)"
 					@prev-thread="goToThreadByOffset(-1)"
@@ -298,6 +301,7 @@ import {
 	Dropdown,
 	Tooltip,
 	createResource,
+	toast,
 } from 'frappe-ui'
 
 import { getFormattedDate, isMac, raiseToast, shouldIgnoreKeypress, startResizing } from '@/utils'
@@ -531,9 +535,9 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 	// Delete/Trash (Backspace on Mac, Delete on Windows)
 	if (key === (isMac ? 'backspace' : 'delete')) {
 		e.preventDefault()
-		if (e.shiftKey) return junkOrDeleteThreads(thread_ids, false)
-		if (mailbox === mailboxIds.trash) return
-		return moveThreads.submit({ thread_ids, mailbox, move_to_mailbox: mailboxIds.trash })
+		if (e.shiftKey || mailbox === mailboxIds.trash)
+			return junkOrDeleteThreads(thread_ids, false)
+		return handleMoveThreads(thread_ids, mailboxIds.trash)
 	}
 
 	// Mark as junk (!)
@@ -545,7 +549,7 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 	// Mark as read/unread (u)
 	if (key === 'u') {
 		e.preventDefault()
-		return setSeen.submit({ thread_ids, seen: e.shiftKey })
+		return handleSetSeen(thread_ids, e.shiftKey)
 	}
 }
 
@@ -600,23 +604,13 @@ const selectActions = computed((): SelectAction[] =>
 		},
 		{
 			label: __('Mark as Not Junk'),
-			onClick: () =>
-				setThreadsSpamStatus.submit({
-					thread_ids: selections.value,
-					mailbox,
-					spam: false,
-				}),
+			onClick: () => handleSetSpamStatus(selections.value, false),
 			icon: CircleCheck,
 			condition: !!selections.value.length && mailbox === mailboxIds.junk,
 		},
 		{
 			label: __('Move to Trash (Delete)'),
-			onClick: () =>
-				moveThreads.submit({
-					thread_ids: selections.value,
-					mailbox,
-					move_to_mailbox: mailboxIds.trash,
-				}),
+			onClick: () => handleMoveThreads(selections.value, mailboxIds.trash),
 			icon: Trash2,
 			condition: !!selections.value.length && mailbox !== mailboxIds.trash,
 		},
@@ -628,26 +622,26 @@ const selectActions = computed((): SelectAction[] =>
 		},
 		{
 			label: __('Mark as Read (Shift+U)'),
-			onClick: () => setSeen.submit({ thread_ids: selections.value, seen: true }),
+			onClick: () => handleSetSeen(selections.value, true),
 			icon: MailOpen,
 			condition:
 				!!selections.value.length &&
 				selections.value.some(
 					(threadID) =>
 						threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
-							.seen === 0,
+							?.seen === 0,
 				),
 		},
 		{
 			label: __('Mark as Unread (U)'),
-			onClick: () => setSeen.submit({ thread_ids: selections.value, seen: false }),
+			onClick: () => handleSetSeen(selections.value, false),
 			icon: Mail,
 			condition:
 				!!selections.value.length &&
 				selections.value.some(
 					(threadID) =>
 						threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
-							.seen === 1,
+							?.seen === 1,
 				),
 		},
 		{
@@ -718,6 +712,7 @@ watch(
 		filter.value = localStorage.getItem(`user:${user.data.name}:filter:${mailbox}`) || null
 		limit.value = 50
 		threadInFocus.value = undefined
+		collapsedGroups.value = []
 		reloadThreads(false)
 	},
 	{ immediate: true },
@@ -823,8 +818,7 @@ const moveToOptions = computed(() =>
 		?.filter((m) => ![mailbox, mailboxIds.sent, mailboxIds.drafts].includes(m.id))
 		.map((m) => ({
 			label: m._name,
-			onClick: () =>
-				moveThreads.submit({ thread_ids: selections.value, move_to_mailbox: m.id }),
+			onClick: () => handleMoveThreads(selections.value, m.id),
 		})),
 )
 
@@ -833,7 +827,7 @@ interface SetThreadsSpamStatusParams {
 	spam: boolean
 }
 
-const setThreadsSpamStatus = createResource({
+const setSpamStatus = createResource({
 	url: 'mail.api.mail.set_threads_spam_status',
 	makeParams: ({ thread_ids, spam }: SetThreadsSpamStatusParams) => ({
 		thread_ids,
@@ -876,9 +870,8 @@ const junkOrDeleteMessage = computed(() => {
 })
 
 const handleJunkOrDelete = () => {
-	if (isJunkAction.value)
-		setThreadsSpamStatus.submit({ thread_ids: threadsToBeJunkedOrDeleted.value, spam: true })
-	else deleteThreads.submit(threadsToBeJunkedOrDeleted.value)
+	if (isJunkAction.value) handleSetSpamStatus(threadsToBeJunkedOrDeleted.value, true)
+	else handleDeleteThreads(threadsToBeJunkedOrDeleted.value)
 
 	showJunkOrDeleteThreads.value = false
 }
@@ -902,6 +895,7 @@ const emptyMailbox = createResource({
 	url: 'mail.api.mail.empty_user_mailbox',
 	makeParams: () => ({ mailbox }),
 	onSuccess: () => {
+		threadsResource.value.data = []
 		raiseToast(__('{0} emptied successfully', [mailboxName.value]))
 		reloadThreads()
 	},
@@ -937,6 +931,76 @@ const handleSuccessAndRemoveFromList = (
 	threadsResource.value.data = threadsResource.value.data?.filter(
 		(thread: Thread) => !thread_ids.includes(thread.thread_id),
 	)
+}
+
+// Action handlers
+
+const handleSetSeen = (thread_ids: string[], seen: boolean) => {
+	if (
+		!thread_ids?.length ||
+		thread_ids.every(
+			(threadID) =>
+				threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)?.seen ==
+				seen,
+		)
+	)
+		return
+
+	toast.promise(setSeen.submit({ thread_ids, seen }), {
+		loading:
+			thread_ids.length === 1
+				? __('Marking thread as {0}...', [seen ? __('read') : __('unread')])
+				: __('Marking threads as {0}...', [seen ? __('read') : __('unread')]),
+		success:
+			thread_ids.length === 1
+				? __('Thread marked as {0}.', [seen ? __('read') : __('unread')])
+				: __('Threads marked as {0}.', [seen ? __('read') : __('unread')]),
+		error: __('Action failed. Please try again.'),
+	})
+}
+
+const handleMoveThreads = (thread_ids: string[], move_to_mailbox: string) => {
+	if (!thread_ids?.length) return
+
+	const moveToMailboxName = mailboxes.data?.find((m) => m.id === move_to_mailbox)._name
+
+	toast.promise(moveThreads.submit({ thread_ids, move_to_mailbox }), {
+		loading:
+			thread_ids.length === 1
+				? __('Moving thread to {0}...', [moveToMailboxName])
+				: __('Moving threads to {0}...', [moveToMailboxName]),
+		success:
+			thread_ids.length === 1
+				? __('Thread moved to {0}.', [moveToMailboxName])
+				: __('Threads moved to {0}.', [moveToMailboxName]),
+		error: __('Action failed. Please try again later.'),
+	})
+}
+
+const handleSetSpamStatus = (thread_ids: string[], spam: boolean) => {
+	if (!thread_ids?.length) return
+
+	toast.promise(setSpamStatus.submit({ thread_ids, spam }), {
+		loading:
+			thread_ids.length === 1
+				? __('Marking thread as {0}...', [spam ? __('Junk') : __('Not Junk')])
+				: __('Marking threads as {0}...', [spam ? __('Junk') : __('Not Junk')]),
+		success:
+			thread_ids.length === 1
+				? __('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
+				: __('Threads marked as {0}.', [spam ? __('Junk') : __('Not Junk')]),
+		error: __('Action failed. Please try again later.'),
+	})
+}
+
+const handleDeleteThreads = (thread_ids: string[]) => {
+	if (!thread_ids?.length) return
+
+	toast.promise(deleteThreads.submit(thread_ids), {
+		loading: thread_ids.length === 1 ? __('Deleting thread...') : __('Deleting threads...'),
+		success: thread_ids.length === 1 ? __('Thread deleted.') : __('Threads deleted.'),
+		error: __('Action failed. Please try again later.'),
+	})
 }
 
 // Filter
@@ -1013,29 +1077,27 @@ const title = computed(() => {
 <style scoped>
 /* Mail item exit animation */
 .mail-item-leave-active {
-	transition: all 0.3s ease;
+	@apply transition-all duration-300 ease-in-out;
 }
 
 .mail-item-leave-to {
-	opacity: 0;
-	transform: translateX(-20px);
+	@apply -translate-x-5 opacity-0;
 }
 
 .mail-item-move {
-	transition: transform 0.3s ease;
+	@apply transition-transform duration-300 ease-in-out;
 }
 
 /* Group exit animation */
 .mail-group-leave-active {
-	transition: all 0.3s ease;
+	@apply transition-all duration-300 ease-in-out;
 }
 
 .mail-group-leave-to {
-	opacity: 0;
-	transform: translateX(-20px);
+	@apply -translate-x-5 opacity-0;
 }
 
 .mail-group-move {
-	transition: transform 0.3s ease;
+	@apply transition-transform duration-300 ease-in-out;
 }
 </style>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -807,10 +807,7 @@ const moveThreads = createResource({
 		mailbox,
 		move_to_mailbox,
 	}),
-	onSuccess: (thread_ids: string[]) => {
-		if (threadID && thread_ids.includes(threadID)) goToMailbox()
-		reloadThreads()
-	},
+	onSuccess: (thread_ids: string[]) => handleSuccessAndRemoveFromList(thread_ids),
 })
 
 const moveToOptions = computed(() =>
@@ -835,10 +832,7 @@ const setThreadsSpamStatus = createResource({
 		mailbox,
 		spam,
 	}),
-	onSuccess: (thread_ids: string[]) => {
-		if (threadID && thread_ids.includes(threadID)) goToMailbox()
-		reloadThreads()
-	},
+	onSuccess: (thread_ids: string[]) => handleSuccessAndRemoveFromList(thread_ids),
 })
 
 const showJunkOrDeleteThreads = ref(false)
@@ -891,10 +885,7 @@ const junkOrDeleteThreadsOptions = computed(() => ({
 const deleteThreads = createResource({
 	url: 'mail.api.mail.delete_threads',
 	makeParams: (thread_ids: string[]) => ({ thread_ids, mailbox }),
-	onSuccess: (thread_ids: string[]) => {
-		if (threadID && thread_ids.includes(threadID)) goToMailbox()
-		reloadThreads()
-	},
+	onSuccess: (thread_ids: string[]) => handleSuccessAndRemoveFromList(thread_ids, false),
 })
 
 const showEmptyMailbox = ref(false)
@@ -924,6 +915,19 @@ const emptyMailboxOptions = computed(() => ({
 		},
 	],
 }))
+
+const handleSuccessAndRemoveFromList = (
+	thread_ids: string[],
+	excludeCommonMailboxes: boolean = true,
+) => {
+	reloadThreads()
+
+	if (excludeCommonMailboxes && ['search', 'starred'].includes(mailbox)) return
+	if (threadID && thread_ids.includes(threadID)) goToMailbox()
+	threadsResource.value.data = threadsResource.value.data?.filter(
+		(thread: Thread) => !thread_ids.includes(thread.thread_id),
+	)
+}
 
 // Filter
 

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -947,10 +947,7 @@ const handleSetSeen = (thread_ids: string[], seen: boolean) => {
 		return
 
 	toast.promise(setSeen.submit({ thread_ids, seen }), {
-		loading:
-			thread_ids.length === 1
-				? __('Marking thread as {0}...', [seen ? __('read') : __('unread')])
-				: __('Marking threads as {0}...', [seen ? __('read') : __('unread')]),
+		loading: seen ? __('Marking as read...') : __('Marking as unread...'),
 		success:
 			thread_ids.length === 1
 				? __('Thread marked as {0}.', [seen ? __('read') : __('unread')])
@@ -965,10 +962,7 @@ const handleMoveThreads = (thread_ids: string[], move_to_mailbox: string) => {
 	const moveToMailboxName = mailboxes.data?.find((m) => m.id === move_to_mailbox)._name
 
 	toast.promise(moveThreads.submit({ thread_ids, move_to_mailbox }), {
-		loading:
-			thread_ids.length === 1
-				? __('Moving thread to {0}...', [moveToMailboxName])
-				: __('Moving threads to {0}...', [moveToMailboxName]),
+		loading: __('Moving to {0}...', [moveToMailboxName]),
 		success:
 			thread_ids.length === 1
 				? __('Thread moved to {0}.', [moveToMailboxName])
@@ -981,10 +975,7 @@ const handleSetSpamStatus = (thread_ids: string[], spam: boolean) => {
 	if (!thread_ids?.length) return
 
 	toast.promise(setSpamStatus.submit({ thread_ids, spam }), {
-		loading:
-			thread_ids.length === 1
-				? __('Marking thread as {0}...', [spam ? __('Junk') : __('Not Junk')])
-				: __('Marking threads as {0}...', [spam ? __('Junk') : __('Not Junk')]),
+		loading: spam ? __('Marking as Junk...') : __('Marking as Not Junk...'),
 		success:
 			thread_ids.length === 1
 				? __('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
@@ -997,7 +988,7 @@ const handleDeleteThreads = (thread_ids: string[]) => {
 	if (!thread_ids?.length) return
 
 	toast.promise(deleteThreads.submit(thread_ids), {
-		loading: thread_ids.length === 1 ? __('Deleting thread...') : __('Deleting threads...'),
+		loading: __('Deleting...'),
 		success: thread_ids.length === 1 ? __('Thread deleted.') : __('Threads deleted.'),
 		error: __('Action failed. Please try again later.'),
 	})

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -183,7 +183,7 @@ export const isMac = navigator.platform.toUpperCase().includes('MAC')
 
 export const isOverlayPresent = () =>
 	!!document.querySelector(
-		'[role="dialog"], [role="alertdialog"], .modal-open, [data-state="open"]',
+		'[role="dialog"]:not([role="alert"]), [role="alertdialog"], .modal-open, [data-state="open"]:not([data-reka-collection-item])',
 	)
 
 export const shouldIgnoreKeypress = (

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -173,7 +173,7 @@ def serialize_attachments(attachments: list[dict]) -> list[dict]:
 	return [
 		{field: attachment[field] for field in attachment_fields}
 		for attachment in attachments
-		if attachment.get("filename") and attachment.get("disposition") == "attachment"
+		if attachment.get("filename")
 	]
 
 
@@ -414,9 +414,8 @@ def get_mime_message(name: str) -> dict:
 	return result
 
 
-@frappe.whitelist()
-def set_seen(thread_ids: list[str], seen: bool, mailbox: str) -> dict:
-	"""Sets seen for mails."""
+def get_account_and_filtered_message_ids(thread_ids: list[str], mailbox: str) -> tuple[str, list[str]]:
+	"""Gets account and filtered message IDs for the given mailbox."""
 
 	account = get_account_for_user(frappe.session.user)
 	if mailbox == "starred":
@@ -424,6 +423,15 @@ def set_seen(thread_ids: list[str], seen: bool, mailbox: str) -> dict:
 	elif mailbox == "search":
 		mailbox = None
 	messages = get_message_ids(account, thread_ids, mailbox)
+
+	return account, messages
+
+
+@frappe.whitelist()
+def set_seen(thread_ids: list[str], seen: bool, mailbox: str) -> dict:
+	"""Sets seen for mails."""
+
+	account, messages = get_account_and_filtered_message_ids(thread_ids, mailbox)
 	set_seen_status(account, messages, seen)
 
 	return {"thread_ids": thread_ids, "seen": seen}
@@ -451,12 +459,7 @@ def move_mails(_ids: list[str], mailbox: str) -> None:
 def set_threads_mailbox(thread_ids: list[str], mailbox: str, move_to_mailbox) -> list[str]:
 	"""Sets mailbox for threads."""
 
-	account = get_account_for_user(frappe.session.user)
-	if mailbox == "starred":
-		mailbox = [d["id"] for d in get_account_mailboxes(account) if d["role"] != "trash"]
-	elif mailbox == "search":
-		mailbox = None
-	messages = get_message_ids(account, thread_ids, mailbox)
+	account, messages = get_account_and_filtered_message_ids(thread_ids, mailbox)
 	move_messages(account, messages, move_to_mailbox)
 
 	return thread_ids
@@ -476,12 +479,7 @@ def set_mails_spam_status(_ids: list[str], spam: bool) -> list[str]:
 def set_threads_spam_status(thread_ids: list[str], mailbox: str, spam: bool) -> list[str]:
 	"""Sets spam status for the mails belonging to the given threads."""
 
-	account = get_account_for_user(frappe.session.user)
-	if mailbox == "starred":
-		mailbox = [d["id"] for d in get_account_mailboxes(account) if d["role"] != "trash"]
-	elif mailbox == "search":
-		mailbox = None
-	messages = get_message_ids(account, thread_ids, mailbox)
+	account, messages = get_account_and_filtered_message_ids(thread_ids, mailbox)
 	set_spam_status(account, messages, spam)
 
 	return thread_ids
@@ -491,8 +489,7 @@ def set_threads_spam_status(thread_ids: list[str], mailbox: str, spam: bool) -> 
 def delete_threads(thread_ids: list[str], mailbox: str) -> list[str]:
 	"""Deletes mails belonging to the given threads."""
 
-	account = get_account_for_user(frappe.session.user)
-	messages = get_message_ids(account, thread_ids, mailbox)
+	account, messages = get_account_and_filtered_message_ids(thread_ids, mailbox)
 	delete_messages(account, messages)
 
 	return thread_ids


### PR DESCRIPTION
Adds state indicator toasts for threads as well as mails

Closes: https://github.com/frappe/mail/issues/314

https://github.com/user-attachments/assets/343e244e-2306-4cef-807d-8bb478c82d08

Other:
- Transition for items removed from thread list
- Move to next thread automatically when current thread is removed from list
- Update UI instantly after action instead of waiting for reload
- Fix issue where inline attachments weren't getting fetched
- Fix collapsed groups in other mailboxes bug
