### PR TITLE
fix: update Redis host configuration in init script

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,9 +14,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile
@@ -28,7 +28,7 @@ bench new-site mail.localhost \
     --force \
     --mariadb-root-password 123 \
     --admin-password admin \
-    --no-mariadb-socket
+    --mariadb-user-host-login-scope='%'
 
 bench --site mail.localhost install-app mail
 bench --site mail.localhost set-config developer_mode 1


### PR DESCRIPTION
This PR fix ` ValueError: Redis URL must specify one of the following schemes (redis://, rediss://, unix://)` and deprecation warning `--no-mariadb-socket is DEPRECATED; use --mariadb-user-host-login-scope='%' (wildcard) or --mariadb-user-host-login-scope=<myhostscope>, instead. The name of this option was misleading: it had nothing to do with sockets.`