### PR TITLE
fix: disable page cache to prevent CSRFTokenError

### DIFF
--- a/mail/www/mail.py
+++ b/mail/www/mail.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe import _
 
+no_cache = 1
+
 
 def get_context():
 	frappe.db.commit()

--- a/mail/www/mail.py
+++ b/mail/www/mail.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe import _
 
+# Disable caching to ensure fresh session-specific CSRF tokens from get_boot()
 no_cache = 1
 
 


### PR DESCRIPTION
## Summary
Fixes CSRFTokenError that occurs when sending emails or performing other POST operations on the `/mail` page.

## Problem
The `/mail` page injects session-specific CSRF tokens into `window.csrf_token` via the `get_boot()` function. However, without `no_cache = 1`, Frappe's default caching serves the page with:
- `max-age=300` (5 minutes)
- `stale-while-revalidate=10800` (3 hours)

This causes users to receive stale cached pages containing outdated CSRF tokens that don't match their current session, resulting in `CSRFTokenError` when making API calls.

## Solution
Add `no_cache = 1` module variable to disable page caching, ensuring:
- Fresh CSRF tokens on every page load
- Cache-Control headers: `no-store,no-cache,must-revalidate,max-age=0`

## Testing
1. Deploy without fix → send email → CSRFTokenError after ~5 minutes
2. Deploy with fix → send email → works reliably

## Related
This is a common pattern in Frappe apps where pages inject session-specific data. See similar usage in other Frappe apps.