### PR TITLE
feat: Add autodiscovery DNS records for email client auto-configuration

### DIFF
--- a/mail/server/doctype/mail_principal/mail_principal.py
+++ b/mail/server/doctype/mail_principal/mail_principal.py
@@ -1065,92 +1065,11 @@ class MailPrincipal(Document):
 				"content": f"0 0 110 {hostname}",
 			})
 
-		def add_autodiscovery_records() -> None:
-			"""Add autodiscovery DNS records for email client auto-configuration.
-			
-			This adds CNAME records for autoconfig (Mozilla/Thunderbird) and
-			autodiscover (Microsoft Outlook), plus SRV records for IMAP, SMTP,
-			and POP3 services as per RFC 6186.
-			"""
-			nonlocal dns_records
-			
-			# Remove any existing autodiscovery records to avoid duplicates
-			dns_records = [
-				record for record in dns_records
-				if not (
-					record["type"] == "CNAME" and ("autoconfig" in record["name"] or "autodiscover" in record["name"])
-				) and not (
-					record["type"] == "SRV" and (
-						"_autodiscover" in record["name"] or
-						"_imap" in record["name"] or
-						"_submission" in record["name"] or
-						"_pop3" in record["name"]
-					)
-				)
-			]
-			
-			# Autoconfig (Mozilla/Thunderbird)
-			dns_records.append({
-				"type": "CNAME",
-				"name": f"autoconfig.{domain}",
-				"content": hostname,
-			})
-			
-			# Autodiscover (Microsoft Outlook)
-			dns_records.append({
-				"type": "CNAME",
-				"name": f"autodiscover.{domain}",
-				"content": hostname,
-			})
-			
-			# SRV record for autodiscovery
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_autodiscover._tcp.{domain}",
-				"content": f"0 0 443 {hostname}",
-			})
-			
-			# IMAP SRV records
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_imaps._tcp.{domain}",
-				"content": f"0 0 993 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_imap._tcp.{domain}",
-				"content": f"0 0 143 {hostname}",
-			})
-			
-			# SMTP Submission SRV records
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_submissions._tcp.{domain}",
-				"content": f"0 0 465 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_submission._tcp.{domain}",
-				"content": f"0 0 587 {hostname}",
-			})
-			
-			# POP3 SRV records (optional but good for compatibility)
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_pop3s._tcp.{domain}",
-				"content": f"0 0 995 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_pop3._tcp.{domain}",
-				"content": f"0 0 110 {hostname}",
-			})
 		domain = domain.rstrip(".")
 		hostname = cluster.rstrip(".") + "."
 
 		replace_mx_records()
 		replace_spf_record()
-		add_autodiscovery_records()
 		add_autodiscovery_records()
 
 		formatted_records = []

--- a/mail/server/doctype/mail_principal/mail_principal.py
+++ b/mail/server/doctype/mail_principal/mail_principal.py
@@ -986,13 +986,13 @@ class MailPrincipal(Document):
 
 		def add_autodiscovery_records() -> None:
 			"""Add autodiscovery DNS records for email client auto-configuration.
-			
+
 			This adds CNAME records for autoconfig (Mozilla/Thunderbird) and
 			autodiscover (Microsoft Outlook), plus SRV records for IMAP, SMTP,
 			and POP3 services as per RFC 6186.
 			"""
 			nonlocal dns_records
-			
+
 			# Remove any existing autodiscovery records to avoid duplicates
 			dns_records = [
 				record for record in dns_records
@@ -1007,28 +1007,28 @@ class MailPrincipal(Document):
 					)
 				)
 			]
-			
+
 			# Autoconfig (Mozilla/Thunderbird)
 			dns_records.append({
 				"type": "CNAME",
 				"name": f"autoconfig.{domain}",
 				"content": hostname,
 			})
-			
+
 			# Autodiscover (Microsoft Outlook)
 			dns_records.append({
 				"type": "CNAME",
 				"name": f"autodiscover.{domain}",
 				"content": hostname,
 			})
-			
+
 			# SRV record for autodiscovery
 			dns_records.append({
 				"type": "SRV",
 				"name": f"_autodiscover._tcp.{domain}",
 				"content": f"0 0 443 {hostname}",
 			})
-			
+
 			# IMAP SRV records
 			dns_records.append({
 				"type": "SRV",
@@ -1040,7 +1040,7 @@ class MailPrincipal(Document):
 				"name": f"_imap._tcp.{domain}",
 				"content": f"0 0 143 {hostname}",
 			})
-			
+
 			# SMTP Submission SRV records
 			dns_records.append({
 				"type": "SRV",
@@ -1052,7 +1052,7 @@ class MailPrincipal(Document):
 				"name": f"_submission._tcp.{domain}",
 				"content": f"0 0 587 {hostname}",
 			})
-			
+
 			# POP3 SRV records (optional but good for compatibility)
 			dns_records.append({
 				"type": "SRV",

--- a/mail/server/doctype/mail_principal/mail_principal.py
+++ b/mail/server/doctype/mail_principal/mail_principal.py
@@ -983,7 +983,6 @@ class MailPrincipal(Document):
 
 			return False
 
-
 		def add_autodiscovery_records() -> None:
 			"""Add autodiscovery DNS records for email client auto-configuration.
 
@@ -995,75 +994,97 @@ class MailPrincipal(Document):
 
 			# Remove any existing autodiscovery records to avoid duplicates
 			dns_records = [
-				record for record in dns_records
+				record
+				for record in dns_records
 				if not (
-					record["type"] == "CNAME" and ("autoconfig" in record["name"] or "autodiscover" in record["name"])
-				) and not (
-					record["type"] == "SRV" and (
-						"_autodiscover" in record["name"] or
-						"_imap" in record["name"] or
-						"_submission" in record["name"] or
-						"_pop3" in record["name"]
+					record["type"] == "CNAME"
+					and ("autoconfig" in record["name"] or "autodiscover" in record["name"])
+				)
+				and not (
+					record["type"] == "SRV"
+					and (
+						"_autodiscover" in record["name"]
+						or "_imap" in record["name"]
+						or "_submission" in record["name"]
+						or "_pop3" in record["name"]
 					)
 				)
 			]
 
 			# Autoconfig (Mozilla/Thunderbird)
-			dns_records.append({
-				"type": "CNAME",
-				"name": f"autoconfig.{domain}",
-				"content": hostname,
-			})
+			dns_records.append(
+				{
+					"type": "CNAME",
+					"name": f"autoconfig.{domain}",
+					"content": hostname,
+				}
+			)
 
 			# Autodiscover (Microsoft Outlook)
-			dns_records.append({
-				"type": "CNAME",
-				"name": f"autodiscover.{domain}",
-				"content": hostname,
-			})
+			dns_records.append(
+				{
+					"type": "CNAME",
+					"name": f"autodiscover.{domain}",
+					"content": hostname,
+				}
+			)
 
 			# SRV record for autodiscovery
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_autodiscover._tcp.{domain}",
-				"content": f"0 0 443 {hostname}",
-			})
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_autodiscover._tcp.{domain}",
+					"content": f"0 0 443 {hostname}",
+				}
+			)
 
 			# IMAP SRV records
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_imaps._tcp.{domain}",
-				"content": f"0 0 993 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_imap._tcp.{domain}",
-				"content": f"0 0 143 {hostname}",
-			})
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_imaps._tcp.{domain}",
+					"content": f"0 0 993 {hostname}",
+				}
+			)
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_imap._tcp.{domain}",
+					"content": f"0 0 143 {hostname}",
+				}
+			)
 
 			# SMTP Submission SRV records
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_submissions._tcp.{domain}",
-				"content": f"0 0 465 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_submission._tcp.{domain}",
-				"content": f"0 0 587 {hostname}",
-			})
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_submissions._tcp.{domain}",
+					"content": f"0 0 465 {hostname}",
+				}
+			)
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_submission._tcp.{domain}",
+					"content": f"0 0 587 {hostname}",
+				}
+			)
 
 			# POP3 SRV records (optional but good for compatibility)
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_pop3s._tcp.{domain}",
-				"content": f"0 0 995 {hostname}",
-			})
-			dns_records.append({
-				"type": "SRV",
-				"name": f"_pop3._tcp.{domain}",
-				"content": f"0 0 110 {hostname}",
-			})
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_pop3s._tcp.{domain}",
+					"content": f"0 0 995 {hostname}",
+				}
+			)
+			dns_records.append(
+				{
+					"type": "SRV",
+					"name": f"_pop3._tcp.{domain}",
+					"content": f"0 0 110 {hostname}",
+				}
+			)
 
 		domain = domain.rstrip(".")
 		hostname = cluster.rstrip(".") + "."

--- a/mail/server/doctype/mail_principal/mail_principal.py
+++ b/mail/server/doctype/mail_principal/mail_principal.py
@@ -983,11 +983,175 @@ class MailPrincipal(Document):
 
 			return False
 
+
+		def add_autodiscovery_records() -> None:
+			"""Add autodiscovery DNS records for email client auto-configuration.
+			
+			This adds CNAME records for autoconfig (Mozilla/Thunderbird) and
+			autodiscover (Microsoft Outlook), plus SRV records for IMAP, SMTP,
+			and POP3 services as per RFC 6186.
+			"""
+			nonlocal dns_records
+			
+			# Remove any existing autodiscovery records to avoid duplicates
+			dns_records = [
+				record for record in dns_records
+				if not (
+					record["type"] == "CNAME" and ("autoconfig" in record["name"] or "autodiscover" in record["name"])
+				) and not (
+					record["type"] == "SRV" and (
+						"_autodiscover" in record["name"] or
+						"_imap" in record["name"] or
+						"_submission" in record["name"] or
+						"_pop3" in record["name"]
+					)
+				)
+			]
+			
+			# Autoconfig (Mozilla/Thunderbird)
+			dns_records.append({
+				"type": "CNAME",
+				"name": f"autoconfig.{domain}",
+				"content": hostname,
+			})
+			
+			# Autodiscover (Microsoft Outlook)
+			dns_records.append({
+				"type": "CNAME",
+				"name": f"autodiscover.{domain}",
+				"content": hostname,
+			})
+			
+			# SRV record for autodiscovery
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_autodiscover._tcp.{domain}",
+				"content": f"0 0 443 {hostname}",
+			})
+			
+			# IMAP SRV records
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_imaps._tcp.{domain}",
+				"content": f"0 0 993 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_imap._tcp.{domain}",
+				"content": f"0 0 143 {hostname}",
+			})
+			
+			# SMTP Submission SRV records
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_submissions._tcp.{domain}",
+				"content": f"0 0 465 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_submission._tcp.{domain}",
+				"content": f"0 0 587 {hostname}",
+			})
+			
+			# POP3 SRV records (optional but good for compatibility)
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_pop3s._tcp.{domain}",
+				"content": f"0 0 995 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_pop3._tcp.{domain}",
+				"content": f"0 0 110 {hostname}",
+			})
+
+		def add_autodiscovery_records() -> None:
+			"""Add autodiscovery DNS records for email client auto-configuration.
+			
+			This adds CNAME records for autoconfig (Mozilla/Thunderbird) and
+			autodiscover (Microsoft Outlook), plus SRV records for IMAP, SMTP,
+			and POP3 services as per RFC 6186.
+			"""
+			nonlocal dns_records
+			
+			# Remove any existing autodiscovery records to avoid duplicates
+			dns_records = [
+				record for record in dns_records
+				if not (
+					record["type"] == "CNAME" and ("autoconfig" in record["name"] or "autodiscover" in record["name"])
+				) and not (
+					record["type"] == "SRV" and (
+						"_autodiscover" in record["name"] or
+						"_imap" in record["name"] or
+						"_submission" in record["name"] or
+						"_pop3" in record["name"]
+					)
+				)
+			]
+			
+			# Autoconfig (Mozilla/Thunderbird)
+			dns_records.append({
+				"type": "CNAME",
+				"name": f"autoconfig.{domain}",
+				"content": hostname,
+			})
+			
+			# Autodiscover (Microsoft Outlook)
+			dns_records.append({
+				"type": "CNAME",
+				"name": f"autodiscover.{domain}",
+				"content": hostname,
+			})
+			
+			# SRV record for autodiscovery
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_autodiscover._tcp.{domain}",
+				"content": f"0 0 443 {hostname}",
+			})
+			
+			# IMAP SRV records
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_imaps._tcp.{domain}",
+				"content": f"0 0 993 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_imap._tcp.{domain}",
+				"content": f"0 0 143 {hostname}",
+			})
+			
+			# SMTP Submission SRV records
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_submissions._tcp.{domain}",
+				"content": f"0 0 465 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_submission._tcp.{domain}",
+				"content": f"0 0 587 {hostname}",
+			})
+			
+			# POP3 SRV records (optional but good for compatibility)
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_pop3s._tcp.{domain}",
+				"content": f"0 0 995 {hostname}",
+			})
+			dns_records.append({
+				"type": "SRV",
+				"name": f"_pop3._tcp.{domain}",
+				"content": f"0 0 110 {hostname}",
+			})
 		domain = domain.rstrip(".")
 		hostname = cluster.rstrip(".") + "."
 
 		replace_mx_records()
 		replace_spf_record()
+		add_autodiscovery_records()
+		add_autodiscovery_records()
 
 		formatted_records = []
 		for record in dns_records:


### PR DESCRIPTION
## Summary
Adds autodiscovery DNS records to the domain principal DNS records list, enabling automatic email client configuration for iOS, macOS, Android, Outlook, and Thunderbird.

## Changes
- Added `add_autodiscovery_records()` function inside `_format_dns_records()`
- Generates CNAME and SRV records for email client autodiscovery

## DNS Records Added

### CNAME Records
| Record | Target |
|--------|--------|
| `autoconfig.{domain}` | cluster hostname |
| `autodiscover.{domain}` | cluster hostname |

### SRV Records (per RFC 6186)
| Record | Value |
|--------|-------|
| `_autodiscover._tcp.{domain}` | 0 0 443 {cluster} |
| `_imaps._tcp.{domain}` | 0 0 993 {cluster} |
| `_imap._tcp.{domain}` | 0 0 143 {cluster} |
| `_submissions._tcp.{domain}` | 0 0 465 {cluster} |
| `_submission._tcp.{domain}` | 0 0 587 {cluster} |
| `_pop3s._tcp.{domain}` | 0 0 995 {cluster} |
| `_pop3._tcp.{domain}` | 0 0 110 {cluster} |

## Client Compatibility
- ✅ Mozilla Thunderbird (autoconfig)
- ✅ Microsoft Outlook (autodiscover)
- ✅ Apple Mail (iOS/macOS)
- ✅ Android email clients
- ✅ Other RFC 6186 compliant clients

## Testing
Tested with a live Frappe Mail + Stalwart setup with 3 domains (icloud.mn, frappe.mn, sumber.mn). All autodiscovery endpoints work correctly after adding the DNS records.

## Related Issue
Closes #362

## References
- RFC 6186: Use of SRV Records for Locating Email Submission/Access Services
- [Mozilla Autoconfig](https://wiki.mozilla.org/Thunderbird:Autoconfiguration)
- [Microsoft Autodiscover](https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/autodiscover-for-exchange)