### PR TITLE
fix: remove unsafe quoted-printable decoding in EmailContent

### DIFF
--- a/frontend/src/components/EmailContent.vue
+++ b/frontend/src/components/EmailContent.vue
@@ -50,9 +50,6 @@ const handleMessage = (event: MessageEvent) => {
 onMounted(() => window.addEventListener('message', handleMessage))
 onUnmounted(() => window.removeEventListener('message', handleMessage))
 
-const decodeQuotedPrintable = (text: string): string =>
-	text.replace(/=([0-9A-F]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
-
 const srcdoc = computed(() => {
 	const collapseButton = `
 		<button
@@ -72,10 +69,7 @@ const srcdoc = computed(() => {
 			&middot;&middot;&middot;
 		</button>
 	`
-
-	const decodedContent = decodeQuotedPrintable(content)
-
-	const transformedContent = DOMPurify.sanitize(decodedContent, DOMPURIFY_CONFIG)
+	const transformedContent = DOMPurify.sanitize(content, DOMPURIFY_CONFIG)
 		.replace(
 			/<div\s+([^>]*)\bclass="([^"]*)"\s*([^>]*)>([\s\S]*?)<\/div>/gi,
 			(match, beforeAttrs, classValue, afterAttrs, innerHtml) => {


### PR DESCRIPTION
Before:
<img width="1260" height="729" alt="image" src="https://github.com/user-attachments/assets/5abe3cd7-a788-4198-9f22-7ba1e10227d1" />

After:
<img width="1260" height="729" alt="image" src="https://github.com/user-attachments/assets/25e59a24-8699-4ce8-901c-0802efe24894" />

Also fixes HTTP inline image rendering issues.

closes: https://github.com/frappe/mail/issues/389