### PR TITLE
feat: Sieve Script

### DIFF
--- a/mail/client/doctype/sieve_script/sieve_script.js
+++ b/mail/client/doctype/sieve_script/sieve_script.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Sieve Script', {
+	validate_script(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: 'validate_script',
+			freeze: true,
+			freeze_message: __('Validating Script...'),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh()
+				}
+			},
+		})
+	},
+})

--- a/mail/client/doctype/sieve_script/sieve_script.json
+++ b/mail/client/doctype/sieve_script/sieve_script.json
@@ -8,6 +8,7 @@
   "user",
   "column_break_cesj",
   "active",
+  "read_only",
   "section_break_cmyq",
   "id",
   "_name",
@@ -29,7 +30,6 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "User",
-   "no_copy": 1,
    "options": "User",
    "reqd": 1,
    "set_only_once": 1
@@ -45,13 +45,16 @@
    "set_only_once": 1
   },
   {
-   "description": "User-visible name for the SieveScript.",
+   "description": "Display name of the Sieve script.",
    "fieldname": "_name",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Name",
-   "reqd": 1
+   "no_copy": 1,
+   "read_only_depends_on": "eval: doc.read_only",
+   "reqd": 1,
+   "unique": 1
   },
   {
    "description": "The ID of the blob containing the raw octets of the script.",
@@ -64,11 +67,14 @@
   },
   {
    "default": "0",
+   "description": "Indicates whether this script is currently active.",
    "fieldname": "active",
    "fieldtype": "Check",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Active"
+   "label": "Active",
+   "no_copy": 1,
+   "read_only_depends_on": "eval: doc.read_only"
   },
   {
    "fieldname": "column_break_cesj",
@@ -87,22 +93,36 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "The Sieve script code used for mail filtering rules.",
    "fieldname": "content",
    "fieldtype": "Code",
    "label": "Content",
+   "read_only_depends_on": "eval: doc.read_only",
    "reqd": 1
   },
   {
+   "depends_on": "eval: !doc.read_only",
    "fieldname": "validate_script",
    "fieldtype": "Button",
    "label": "Validate Script"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.read_only",
+   "description": "Prevents editing of system scripts (e.g., vacation).",
+   "fieldname": "read_only",
+   "fieldtype": "Check",
+   "label": "Read Only",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2026-03-06 12:48:48.568488",
+ "modified": "2026-03-06 17:20:17.751947",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Sieve Script",

--- a/mail/client/doctype/sieve_script/sieve_script.json
+++ b/mail/client/doctype/sieve_script/sieve_script.json
@@ -1,0 +1,136 @@
+{
+ "actions": [],
+ "creation": "2026-03-06 09:15:28.245348",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_iw72",
+  "user",
+  "column_break_cesj",
+  "active",
+  "section_break_cmyq",
+  "id",
+  "_name",
+  "column_break_wrwl",
+  "blob_id",
+  "section_break_jwqh",
+  "content",
+  "validate_script"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_iw72",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "The user this script belongs to.",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "User",
+   "no_copy": 1,
+   "options": "User",
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "description": "The ID of the script.",
+   "fieldname": "id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "description": "User-visible name for the SieveScript.",
+   "fieldname": "_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Name",
+   "reqd": 1
+  },
+  {
+   "description": "The ID of the blob containing the raw octets of the script.",
+   "fieldname": "blob_id",
+   "fieldtype": "Data",
+   "label": "Blob ID",
+   "no_copy": 1,
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "active",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Active"
+  },
+  {
+   "fieldname": "column_break_cesj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_cmyq",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_wrwl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_jwqh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "content",
+   "fieldtype": "Code",
+   "label": "Content",
+   "reqd": 1
+  },
+  {
+   "fieldname": "validate_script",
+   "fieldtype": "Button",
+   "label": "Validate Script"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_virtual": 1,
+ "links": [],
+ "modified": "2026-03-06 12:48:48.568488",
+ "modified_by": "Administrator",
+ "module": "Client",
+ "name": "Sieve Script",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Mail User",
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -290,6 +290,8 @@ def bulk_delete(names: str | list[str]) -> None:
 def format_sieve_script(user: str, script: dict) -> dict:
 	"""Format the sieve script for display.z"""
 
+	read_only = script["name"].lower() == "vacation"
+
 	return {
 		"name": f"{user}|{script['id']}",
 		"user": user,
@@ -298,6 +300,7 @@ def format_sieve_script(user: str, script: dict) -> dict:
 		"active": cint(script["isActive"]),
 		"blob_id": script["blobId"],
 		"content": script.get("content") or "",
+		"read_only": read_only,
 		"creation": today(),
 		"modified": today(),
 	}

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import json
+from uuid import uuid7
 
 import frappe
 from frappe import _
@@ -15,7 +16,8 @@ from mail.utils.validation import has_permission_for_user
 
 class SieveScript(Document):
 	def db_insert(self, *args, **kwargs) -> None:
-		raise NotImplementedError
+		self.id = SieveScript._add_sieve_script(self.user, self._name, self.content, bool(self.active))
+		self.name = f"{self.user}|{self.id}"
 
 	def load_from_db(self) -> "SieveScript":
 		user, id = self.name.split("|")
@@ -79,6 +81,31 @@ class SieveScript(Document):
 	@staticmethod
 	def get_stats(**kwargs) -> dict:
 		return {}
+
+	@classmethod
+	def _add_sieve_script(
+		cls,
+		user: str,
+		name: str,
+		content: str,
+		active: bool = False,
+	) -> str:
+		"""Adds a sieve script for the given user with the specified parameters."""
+
+		has_permission_for_user(user)
+
+		creation_id = str(uuid7())
+		client = get_jmap_client(user)
+		blob = client.upload_blob(content.encode("utf-8"), "application/sieve")
+		response = client.sieve_script_create(creation_id, name, blob["blobId"], active)
+
+		title = _("Sieve Script Creation Error")
+		if response.get("created"):
+			return response["created"][creation_id]["id"]
+		elif response.get("notCreated"):
+			frappe.throw(_(response["notCreated"][creation_id]["description"]), title=title)
+		else:
+			frappe.throw(_(response["description"]), title=title)
 
 	@classmethod
 	def _fetch_sieve_scripts(
@@ -159,6 +186,16 @@ class SieveScript(Document):
 			)
 
 	@classmethod
+	def _update_sieve_script(
+		cls,
+		user: str,
+		id: str,
+		content: str,
+		active: bool = False,
+	) -> None:
+		pass
+
+	@classmethod
 	def _delete_sieve_scripts(cls, user: str, ids: list[str]) -> None:
 		"""Deletes sieve scripts for the given list of IDs and user."""
 
@@ -210,16 +247,6 @@ def bulk_delete(names: str | list[str]) -> None:
 		SieveScript._delete_sieve_scripts(user, ids)
 
 	frappe.msgprint(_("Sieve Scripts deleted successfully."), alert=True)
-
-
-@frappe.whitelist()
-def add_sieve_script() -> str:
-	pass
-
-
-@frappe.whitelist()
-def update_sieve_script() -> None:
-	pass
 
 
 def format_sieve_script(user: str, script: dict) -> dict:

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -236,3 +236,10 @@ def format_sieve_script(user: str, script: dict) -> dict:
 		"creation": today(),
 		"modified": today(),
 	}
+
+
+def has_permission(doc: "Document", ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Sieve Script":
+		return False
+
+	return has_permission_for_user(doc.user, raise_exception=False)

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -21,8 +21,7 @@ class SieveScript(Document):
 
 	def load_from_db(self) -> "SieveScript":
 		user, id = self.name.split("|")
-		frappe.flags.download_sieve_script_content = True
-		if scripts := SieveScript._get_sieve_scripts(user, [id]):
+		if scripts := SieveScript._get_sieve_scripts(user, [id], download_content=True):
 			return super(Document, self).__init__(scripts[0])
 
 		frappe.throw(
@@ -148,7 +147,7 @@ class SieveScript(Document):
 		return scripts[:limit], total
 
 	@classmethod
-	def _get_sieve_scripts(cls, user: str, ids: list[str]) -> list[dict]:
+	def _get_sieve_scripts(cls, user: str, ids: list[str], download_content: bool = False) -> list[dict]:
 		"""Returns a list of sieve scripts for the provided IDs in the same order as ids."""
 
 		has_permission_for_user(user)
@@ -158,7 +157,7 @@ class SieveScript(Document):
 		client = get_jmap_client(user)
 		scripts = client.sieve_script_get(ids)
 
-		if frappe.flags.download_sieve_script_content:
+		if download_content:
 			blobs = [(s["blobId"], None) for s in scripts if s["blobId"]]
 			data = client.download_blobs_concurrently(blobs)
 

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import cint, today
+
+from mail.jmap import get_jmap_client
+from mail.utils import parse_filters
+from mail.utils.validation import has_permission_for_user
+
+
+class SieveScript(Document):
+	def db_insert(self, *args, **kwargs) -> None:
+		raise NotImplementedError
+
+	def load_from_db(self) -> "SieveScript":
+		user, id = self.name.split("|")
+		frappe.flags.download_sieve_script_content = True
+		if scripts := SieveScript._get_sieve_scripts(user, [id]):
+			return super(Document, self).__init__(scripts[0])
+
+		frappe.throw(
+			_("Sieve Script with ID {0} not found in user {1}.").format(frappe.bold(id), frappe.bold(user)),
+			title=_("Sieve Script Not Found"),
+		)
+
+	def db_update(self) -> None:
+		raise NotImplementedError
+
+	def delete(self) -> None:
+		user, id = self.name.split("|")
+		SieveScript._delete_sieve_scripts(user, [id])
+
+	@staticmethod
+	def get_list(filters=None, page_length=20, **kwargs) -> list:
+		filters = parse_filters(filters)
+		id = filters.get("id")
+		user = filters.get("user") or frappe.session.user
+
+		if not user or user in ("Guest", "Administrator"):
+			frappe.msgprint(_("Please select a user to view the Sieve Scripts."), alert=True)
+			return []
+
+		scripts = []
+		if id:
+			scripts = SieveScript._get_sieve_scripts(user, [id])
+			total = len(scripts)
+		else:
+			filter = {}
+			if value := filters.get("_name"):
+				filter["name"] = value
+			if value := filters.get("active"):
+				filter["isActive"] = bool(cint(value))
+
+			limit = cint(kwargs.get("start")) + page_length
+			scripts, total = SieveScript._fetch_sieve_scripts(user, filter, limit=limit)
+
+		frappe.cache.set_value(_get_total_cache_key(user), total, expires_in_sec=600)
+
+		if not scripts:
+			frappe.msgprint(_("No sieve scripts found."), alert=True)
+
+		return scripts
+
+	@staticmethod
+	def get_count(filters=None, **kwargs) -> int:
+		filters = parse_filters(filters)
+		user = filters.get("user") or frappe.session.user
+		return (
+			frappe.cache.get_value(_get_total_cache_key(user))
+			if user and has_permission_for_user(user, raise_exception=False)
+			else 0
+		)
+
+	@staticmethod
+	def get_stats(**kwargs) -> dict:
+		return {}
+
+	@classmethod
+	def _fetch_sieve_scripts(
+		cls,
+		user: str,
+		filter: dict | None = None,
+		position: int = 0,
+		limit: int = 50,
+	) -> list:
+		"""Returns a list of sieve scripts for the given user."""
+
+		has_permission_for_user(user)
+
+		scripts = []
+		client = get_jmap_client(user)
+
+		while len(scripts) < limit:
+			result = client.sieve_script_query(filter, position, limit)
+			ids = result["ids"]
+			total = result["total"]
+
+			if not ids:
+				break
+
+			scripts.extend(SieveScript._get_sieve_scripts(user, ids))
+
+			if len(scripts) >= limit:
+				break
+
+			position += len(ids)
+
+			if position >= total:
+				break
+
+		return scripts[:limit], total
+
+	@classmethod
+	def _get_sieve_scripts(cls, user: str, ids: list[str]) -> list[dict]:
+		"""Returns a list of sieve scripts for the provided IDs in the same order as ids."""
+
+		has_permission_for_user(user)
+
+		sieve_scripts = {}
+
+		client = get_jmap_client(user)
+		scripts = client.sieve_script_get(ids)
+
+		if frappe.flags.download_sieve_script_content:
+			blobs = [(s["blobId"], None) for s in scripts if s["blobId"]]
+			data = client.download_blobs_concurrently(blobs)
+
+			for script in scripts:
+				script["content"] = data.get(script["blobId"], b"").decode("utf-8")
+
+		for script in scripts:
+			script = format_sieve_script(user, script)
+			sieve_scripts[script["id"]] = script
+
+		return [sieve_scripts[id] for id in ids if id in sieve_scripts]
+
+	@classmethod
+	def _validate_sieve_script(cls, user: str, content: str) -> None:
+		"""Validates a sieve script for the given user."""
+
+		if not content.strip():
+			frappe.throw(_("Sieve script content cannot be empty."))
+
+		has_permission_for_user(user)
+
+		client = get_jmap_client(user)
+		blob = client.upload_blob(content.encode("utf-8"), "application/sieve")
+		response = client.sieve_script_validate(blob["blobId"])
+
+		if error := response.get("error"):
+			frappe.throw(
+				_("{0}: {1}").format(error.get("type"), error.get("description")),
+				title=_("Sieve Script Validation Error"),
+			)
+
+	@classmethod
+	def _delete_sieve_scripts(cls, user: str, ids: list[str]) -> None:
+		"""Deletes sieve scripts for the given list of IDs and user."""
+
+		has_permission_for_user(user)
+
+		client = get_jmap_client(user)
+		response = client.sieve_script_delete(ids)
+
+		if response.get("notDestroyed"):
+			error_messages = []
+			for id, error in response["notDestroyed"].items():
+				error_messages.append(f"{id}: {error['description']}")
+			frappe.throw(
+				_("Sieve Script Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+				title=_("Sieve Script Deletion Error"),
+			)
+
+	@frappe.whitelist()
+	def validate_script(self) -> None:
+		"""Validates the sieve script content."""
+
+		user, _id = self.name.split("|")
+
+		has_permission_for_user(user)
+
+		self._validate_sieve_script(user, self.content)
+		frappe.msgprint(_("Sieve script is valid."), indicator="green", alert=True)
+
+
+def _get_total_cache_key(user: str) -> str:
+	"""Returns a cache key for total sieve scripts count for the given user."""
+
+	return f"{user}:sieve_scripts:total"
+
+
+@frappe.whitelist()
+def bulk_delete(names: str | list[str]) -> None:
+	"""Deletes multiple sieve scripts given their names."""
+
+	if isinstance(names, str):
+		names = json.loads(names)
+
+	user_ids_map = {}
+	for name in names:
+		user, id = name.split("|")
+		user_ids_map.setdefault(user, []).append(id)
+
+	for user, ids in user_ids_map.items():
+		SieveScript._delete_sieve_scripts(user, ids)
+
+	frappe.msgprint(_("Sieve Scripts deleted successfully."), alert=True)
+
+
+@frappe.whitelist()
+def add_sieve_script() -> str:
+	pass
+
+
+@frappe.whitelist()
+def update_sieve_script() -> None:
+	pass
+
+
+def format_sieve_script(user: str, script: dict) -> dict:
+	"""Format the sieve script for display.z"""
+
+	return {
+		"name": f"{user}|{script['id']}",
+		"user": user,
+		"id": script["id"],
+		"_name": script["name"],
+		"active": cint(script["isActive"]),
+		"blob_id": script["blobId"],
+		"content": script.get("content") or "",
+		"creation": today(),
+		"modified": today(),
+	}

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -96,6 +96,9 @@ class SieveScript(Document):
 	) -> str:
 		"""Adds a sieve script for the given user with the specified parameters."""
 
+		if not content or not content.strip():
+			frappe.throw(_("Sieve script content cannot be empty."))
+
 		has_permission_for_user(user)
 
 		creation_id = str(uuid7())
@@ -174,7 +177,7 @@ class SieveScript(Document):
 	def _validate_sieve_script(cls, user: str, content: str) -> None:
 		"""Validates a sieve script for the given user."""
 
-		if not content.strip():
+		if not content or not content.strip():
 			frappe.throw(_("Sieve script content cannot be empty."))
 
 		has_permission_for_user(user)
@@ -200,7 +203,7 @@ class SieveScript(Document):
 	) -> None:
 		"""Updates a sieve script for the given user and ID with the specified parameters."""
 
-		if not content.strip():
+		if not content or not content.strip():
 			frappe.throw(_("Sieve script content cannot be empty."))
 
 		has_permission_for_user(user)

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -251,6 +251,13 @@ class SieveScript(Document):
 				title=_("Sieve Script Deletion Error"),
 			)
 
+	def validate(self) -> None:
+		if self.read_only:
+			frappe.throw(
+				_("The '{0}' sieve script cannot be modified.").format(self._name),
+				title=_("Read-Only Sieve Script"),
+			)
+
 	@frappe.whitelist()
 	def validate_script(self) -> None:
 		"""Validates the sieve script content."""

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -295,7 +295,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 
 def format_sieve_script(user: str, script: dict) -> dict:
-	"""Format the sieve script for display.z"""
+	"""Format the sieve script for display."""
 
 	read_only = script["name"].lower() == "vacation"
 

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -31,10 +31,15 @@ class SieveScript(Document):
 		)
 
 	def db_update(self) -> None:
-		raise NotImplementedError
+		SieveScript._update_sieve_script(self.user, self.id, self._name, self.content, bool(self.active))
+		self.reload()
 
 	def delete(self) -> None:
 		user, id = self.name.split("|")
+
+		if self.active:
+			frappe.throw(_("Cannot delete an active sieve script. Please deactivate it first."))
+
 		SieveScript._delete_sieve_scripts(user, [id])
 
 	@staticmethod
@@ -190,10 +195,43 @@ class SieveScript(Document):
 		cls,
 		user: str,
 		id: str,
+		name: str,
 		content: str,
 		active: bool = False,
 	) -> None:
-		pass
+		"""Updates a sieve script for the given user and ID with the specified parameters."""
+
+		if not content.strip():
+			frappe.throw(_("Sieve script content cannot be empty."))
+
+		has_permission_for_user(user)
+
+		client = get_jmap_client(user)
+		scripts = client.sieve_script_get([id])
+
+		if not scripts:
+			frappe.throw(
+				_("Sieve Script with ID {0} not found.").format(frappe.bold(id)),
+				title=_("Sieve Script Not Found"),
+			)
+
+		script = scripts[0]
+		blob_id = script["blobId"]
+		current_content = client.download_blob(blob_id).decode("utf-8")
+
+		if content != current_content:
+			new_blob = client.upload_blob(content.encode("utf-8"), "application/sieve")
+			blob_id = new_blob["blobId"]
+
+		deactivate = script["isActive"] and not active
+		response = client.sieve_script_update(id, name, blob_id, active, deactivate)
+
+		title = _("Sieve Script Update Error")
+		if not response.get("updated"):
+			if response.get("notUpdated"):
+				frappe.throw(_(response["notUpdated"][id]["description"]), title=title)
+			else:
+				frappe.throw(_(response["description"]), title=title)
 
 	@classmethod
 	def _delete_sieve_scripts(cls, user: str, ids: list[str]) -> None:

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -118,7 +118,7 @@ class SieveScript(Document):
 		filter: dict | None = None,
 		position: int = 0,
 		limit: int = 50,
-	) -> list:
+	) -> tuple[list, int]:
 		"""Returns a list of sieve scripts for the given user."""
 
 		has_permission_for_user(user)

--- a/mail/client/doctype/sieve_script/sieve_script_list.js
+++ b/mail/client/doctype/sieve_script/sieve_script_list.js
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings['Sieve Script'] = {
+	refresh: (listview) => {
+		add_bulk_delete_button_to_actions(listview)
+	},
+}
+
+function add_bulk_delete_button_to_actions(listview) {
+	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
+		const count = listview.get_checked_items().length
+
+		frappe.confirm(
+			__('Delete {0} {1} permanently?', [count, count === 1 ? 'item' : 'items']),
+			() => {
+				frappe.call({
+					method: 'mail.client.doctype.sieve_script.sieve_script.bulk_delete',
+					args: {
+						names: listview.get_checked_items(true),
+					},
+					callback: (r) => {
+						if (!r.exc) {
+							listview.refresh()
+						}
+					},
+				})
+			},
+		)
+	})
+}

--- a/mail/client/doctype/sieve_script/test_sieve_script.py
+++ b/mail/client/doctype/sieve_script/test_sieve_script.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestSieveScript(IntegrationTestCase):
+	"""
+	Integration tests for SieveScript.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -192,6 +192,7 @@ has_permission = {
 	"Participant Identity": "mail.client.doctype.participant_identity.participant_identity.has_permission",
 	"Push Subscription": "mail.client.doctype.push_subscription.push_subscription.has_permission",
 	"Quota": "mail.client.doctype.quota.quota.has_permission",
+	"Sieve Script": "mail.client.doctype.sieve_script.sieve_script.has_permission",
 	"Vacation Response": "mail.client.doctype.vacation_response.vacation_response.has_permission",
 }
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -2761,6 +2761,7 @@ class JMAPClient:
 		"""Query sieve scripts in batches until reaching the limit."""
 
 		_filter = {}
+		filter = filter or {}
 		for key in ["name", "isActive"]:
 			if value := filter.get(key):
 				_filter[key] = value

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -2791,8 +2791,8 @@ class JMAPClient:
 		_filter = {}
 		filter = filter or {}
 		for key in ["name", "isActive"]:
-			if value := filter.get(key):
-				_filter[key] = value
+			if key in filter and filter[key] is not None:
+				_filter[key] = filter[key]
 
 		ids = []
 		total = None

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -2678,6 +2678,151 @@ class JMAPClient:
 		return response["methodResponses"][0][1]
 
 	# -------------------------------
+	# Sieve Script
+	# -------------------------------
+
+	def sieve_script_get(self, ids: list[str] | None = None) -> list[dict]:
+		"""Returns the sieve scripts for the provided sieve script IDs."""
+
+		def fetch(ids_batch: list[str] | None) -> list[dict]:
+			response = self._make_request(
+				using=["urn:ietf:params:jmap:sieve"],
+				method_calls=[
+					[
+						"SieveScript/get",
+						{
+							"accountId": self.primary_account_id,
+							"ids": ids_batch,
+						},
+						"0",
+					]
+				],
+			)
+			return response["methodResponses"][0][1]["list"]
+
+		if ids and len(ids) > self.max_objects_in_get:
+			scripts = []
+			for ids_batch in create_batch(ids, self.max_objects_in_get):
+				scripts.extend(fetch(ids_batch))
+			return scripts
+
+		return fetch(ids)
+
+	def sieve_script_update(self, id: str, name: str, active: bool = False) -> dict:
+		"""Updates the sieve script with the given parameters."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:sieve"],
+			method_calls=[
+				[
+					"SieveScript/set",
+					{
+						"accountId": self.primary_account_id,
+						"update": {
+							id: {
+								"name": name,
+								"isActive": active or False,
+							}
+						},
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]
+
+	def sieve_script_delete(self, ids: list[str]) -> dict:
+		"""Destroys the sieve scripts with the given IDs."""
+
+		result = {"destroyed": [], "notDestroyed": {}}
+		for ids_batch in create_batch(ids, self.max_objects_in_set):
+			response = self._make_request(
+				using=["urn:ietf:params:jmap:sieve"],
+				method_calls=[
+					[
+						"SieveScript/set",
+						{
+							"accountId": self.primary_account_id,
+							"destroy": ids_batch,
+						},
+						"0",
+					]
+				],
+			)
+
+			result["destroyed"].extend(response["methodResponses"][0][1].get("destroyed", []))
+			if not_destroyed := response["methodResponses"][0][1].get("notDestroyed", {}):
+				result["notDestroyed"].update(not_destroyed)
+
+		return result
+
+	def sieve_script_query(self, filter: dict | None = None, position: int = 0, limit: int = 50) -> dict:
+		"""Query sieve scripts in batches until reaching the limit."""
+
+		_filter = {}
+		for key in ["name", "isActive"]:
+			if value := filter.get(key):
+				_filter[key] = value
+
+		ids = []
+		total = None
+		batch_size = min(limit, self.max_objects_in_get)
+
+		while len(ids) < limit:
+			response = self._make_request(
+				using=["urn:ietf:params:jmap:sieve"],
+				method_calls=[
+					[
+						"SieveScript/query",
+						{
+							"accountId": self.primary_account_id,
+							"filter": _filter,
+							"position": position,
+							"limit": batch_size,
+							"calculateTotal": True if total is None else False,
+						},
+						"0",
+					]
+				],
+			)
+			result = response["methodResponses"][0][1]
+
+			if total is None:
+				total = result["total"]
+
+			_ids = result["ids"]
+			if not _ids:
+				break
+
+			ids.extend(_ids)
+			position += len(_ids)
+
+			if len(_ids) < batch_size:
+				break
+
+		return {"ids": ids[:limit], "total": total}
+
+	def sieve_script_validate(self, blob_id: str) -> dict:
+		"""Validates the sieve script content in the provided blob ID."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:sieve"],
+			method_calls=[
+				[
+					"SieveScript/validate",
+					{
+						"accountId": self.primary_account_id,
+						"blobId": blob_id,
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]
+
+	# -------------------------------
 	# Blob
 	# -------------------------------
 

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -2684,21 +2684,27 @@ class JMAPClient:
 	def sieve_script_create(self, creation_id: str, name: str, blob_id: str, active: bool = False) -> dict:
 		"""Creates a sieve script with the given parameters."""
 
+		payload = (
+			{
+				"accountId": self.primary_account_id,
+				"create": {
+					creation_id: {
+						"name": name,
+						"blobId": blob_id,
+					}
+				},
+			},
+		)
+
+		if active:
+			payload["onSuccessActivateScript"] = f"#{creation_id}"
+
 		response = self._make_request(
 			using=["urn:ietf:params:jmap:sieve"],
 			method_calls=[
 				[
 					"SieveScript/set",
-					{
-						"accountId": self.primary_account_id,
-						"create": {
-							creation_id: {
-								"name": name,
-								"blobId": blob_id,
-							}
-						},
-						"onSuccessActivateScript": f"#{creation_id}" if active else None,
-					},
+					payload,
 					"0",
 				]
 			],
@@ -2733,23 +2739,33 @@ class JMAPClient:
 
 		return fetch(ids)
 
-	def sieve_script_update(self, id: str, name: str, active: bool = False) -> dict:
+	def sieve_script_update(
+		self, id: str, name: str, blob_id: str, active: bool = False, deactivate: bool = False
+	) -> dict:
 		"""Updates the sieve script with the given parameters."""
+
+		payload = {
+			"accountId": self.primary_account_id,
+			"update": {
+				id: {
+					"name": name,
+					"blobId": blob_id,
+				}
+			},
+		}
+
+		if active:
+			payload["onSuccessActivateScript"] = id
+
+		if deactivate:
+			payload["onSuccessDeactivateScript"] = True
 
 		response = self._make_request(
 			using=["urn:ietf:params:jmap:sieve"],
 			method_calls=[
 				[
 					"SieveScript/set",
-					{
-						"accountId": self.primary_account_id,
-						"update": {
-							id: {
-								"name": name,
-								"isActive": active or False,
-							}
-						},
-					},
+					payload,
 					"0",
 				]
 			],

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -864,17 +864,15 @@ class JMAPClient:
 				call_id += 1
 
 		else:
-			method_calls.append(
-				[
-					"Email/set",
-					{
-						"accountId": self.primary_account_id,
-						"create": {draft_ref: build_draft_payload(draft_mailbox_id)},
-						"destroy": [existing_id] if existing_id else None,
-					},
-					str(call_id),
-				]
-			)
+			payload = {
+				"accountId": self.primary_account_id,
+				"create": {draft_ref: build_draft_payload(draft_mailbox_id)},
+			}
+
+			if existing_id:
+				payload["destroy"] = [existing_id]
+
+			method_calls.append(["Email/set", payload, str(call_id)])
 			call_id += 1
 
 		if save_as_draft:
@@ -1450,27 +1448,25 @@ class JMAPClient:
 	) -> dict:
 		"""Creates a address book with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"create": {
+				creation_id: {
+					"name": name,
+					"description": description or None,
+					"sortOrder": sort_order or 0,
+					"isSubscribed": subscribed or False,
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = f"#{creation_id}"
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:contacts"],
-			method_calls=[
-				[
-					"AddressBook/set",
-					{
-						"accountId": self.primary_account_id,
-						"create": {
-							creation_id: {
-								"name": name,
-								"description": description or None,
-								"sortOrder": sort_order or 0,
-								"isSubscribed": subscribed or False,
-							}
-						},
-						"onSuccessSetIsDefault": f"#{creation_id}" if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:contacts"], method_calls=[["AddressBook/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def address_book_get(self, ids: list[str] | None = None) -> list[dict]:
@@ -1511,27 +1507,25 @@ class JMAPClient:
 	) -> dict:
 		"""Updates the address book with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"update": {
+				id: {
+					"name": name,
+					"description": description or None,
+					"sortOrder": sort_order or 0,
+					"isSubscribed": subscribed or False,
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = id
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:contacts"],
-			method_calls=[
-				[
-					"AddressBook/set",
-					{
-						"accountId": self.primary_account_id,
-						"update": {
-							id: {
-								"name": name,
-								"description": description or None,
-								"sortOrder": sort_order or 0,
-								"isSubscribed": subscribed or False,
-							}
-						},
-						"onSuccessSetIsDefault": id if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:contacts"], method_calls=[["AddressBook/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def address_book_delete(self, ids: list[str], remove_contents: bool = False) -> dict:
@@ -1880,31 +1874,29 @@ class JMAPClient:
 	) -> dict:
 		"""Creates a calendar book with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"create": {
+				creation_id: {
+					"name": name,
+					"color": color or None,
+					"description": description or None,
+					"sortOrder": sort_order or 0,
+					"includeInAvailability": include_in_availability,
+					"timeZone": time_zone or None,
+					"isSubscribed": subscribed or False,
+					"isVisible": visible or True,
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = f"#{creation_id}"
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:calendars"],
-			method_calls=[
-				[
-					"Calendar/set",
-					{
-						"accountId": self.primary_account_id,
-						"create": {
-							creation_id: {
-								"name": name,
-								"color": color or None,
-								"description": description or None,
-								"sortOrder": sort_order or 0,
-								"includeInAvailability": include_in_availability,
-								"timeZone": time_zone or None,
-								"isSubscribed": subscribed or False,
-								"isVisible": visible or True,
-							}
-						},
-						"onSuccessSetIsDefault": f"#{creation_id}" if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:calendars"], method_calls=[["Calendar/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def calendar_get(self, ids: list[str] | None = None) -> list[dict]:
@@ -1949,31 +1941,29 @@ class JMAPClient:
 	) -> dict:
 		"""Updates the calendar with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"update": {
+				id: {
+					"name": name,
+					"color": color or None,
+					"description": description or None,
+					"sortOrder": sort_order or 0,
+					"includeInAvailability": include_in_availability,
+					"timeZone": time_zone or None,
+					"isSubscribed": subscribed or False,
+					"isVisible": visible or False,
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = id
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:calendars"],
-			method_calls=[
-				[
-					"Calendar/set",
-					{
-						"accountId": self.primary_account_id,
-						"update": {
-							id: {
-								"name": name,
-								"color": color or None,
-								"description": description or None,
-								"sortOrder": sort_order or 0,
-								"includeInAvailability": include_in_availability,
-								"timeZone": time_zone or None,
-								"isSubscribed": subscribed or False,
-								"isVisible": visible or False,
-							}
-						},
-						"onSuccessSetIsDefault": id if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:calendars"], method_calls=[["Calendar/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def calendar_delete(self, ids: list[str], remove_events: bool = False) -> dict:
@@ -2375,25 +2365,23 @@ class JMAPClient:
 	) -> dict:
 		"""Creates a participant identity with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"create": {
+				creation_id: {
+					"name": name,
+					"calendarAddress": f"mailto:{email}",
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = f"#{creation_id}"
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:calendars"],
-			method_calls=[
-				[
-					"ParticipantIdentity/set",
-					{
-						"accountId": self.primary_account_id,
-						"create": {
-							creation_id: {
-								"name": name,
-								"calendarAddress": f"mailto:{email}",
-							}
-						},
-						"onSuccessSetIsDefault": f"#{creation_id}" if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:calendars"], method_calls=[["ParticipantIdentity/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def participant_identity_get(self, ids: list[str] | None = None) -> list[dict]:
@@ -2432,25 +2420,23 @@ class JMAPClient:
 	) -> dict:
 		"""Updates the participant identity with the given parameters."""
 
+		payload = {
+			"accountId": self.primary_account_id,
+			"update": {
+				id: {
+					"name": name,
+					"calendarAddress": f"mailto:{email}",
+				}
+			},
+		}
+
+		if default:
+			payload["onSuccessSetIsDefault"] = id
+
 		response = self._make_request(
-			using=["urn:ietf:params:jmap:calendars"],
-			method_calls=[
-				[
-					"ParticipantIdentity/set",
-					{
-						"accountId": self.primary_account_id,
-						"update": {
-							id: {
-								"name": name,
-								"calendarAddress": f"mailto:{email}",
-							}
-						},
-						"onSuccessSetIsDefault": id if default else None,
-					},
-					"0",
-				]
-			],
+			using=["urn:ietf:params:jmap:calendars"], method_calls=[["ParticipantIdentity/set", payload, "0"]]
 		)
+
 		return response["methodResponses"][0][1]
 
 	def participant_identity_delete(self, ids: list[str]) -> dict:
@@ -2684,17 +2670,15 @@ class JMAPClient:
 	def sieve_script_create(self, creation_id: str, name: str, blob_id: str, active: bool = False) -> dict:
 		"""Creates a sieve script with the given parameters."""
 
-		payload = (
-			{
-				"accountId": self.primary_account_id,
-				"create": {
-					creation_id: {
-						"name": name,
-						"blobId": blob_id,
-					}
-				},
+		payload = {
+			"accountId": self.primary_account_id,
+			"create": {
+				creation_id: {
+					"name": name,
+					"blobId": blob_id,
+				}
 			},
-		)
+		}
 
 		if active:
 			payload["onSuccessActivateScript"] = f"#{creation_id}"
@@ -2743,6 +2727,9 @@ class JMAPClient:
 		self, id: str, name: str, blob_id: str, active: bool = False, deactivate: bool = False
 	) -> dict:
 		"""Updates the sieve script with the given parameters."""
+
+		if active and deactivate:
+			frappe.throw(_("A sieve script cannot be activated and deactivated at the same time."))
 
 		payload = {
 			"accountId": self.primary_account_id,

--- a/mail/jmap.py
+++ b/mail/jmap.py
@@ -2681,6 +2681,31 @@ class JMAPClient:
 	# Sieve Script
 	# -------------------------------
 
+	def sieve_script_create(self, creation_id: str, name: str, blob_id: str, active: bool = False) -> dict:
+		"""Creates a sieve script with the given parameters."""
+
+		response = self._make_request(
+			using=["urn:ietf:params:jmap:sieve"],
+			method_calls=[
+				[
+					"SieveScript/set",
+					{
+						"accountId": self.primary_account_id,
+						"create": {
+							creation_id: {
+								"name": name,
+								"blobId": blob_id,
+							}
+						},
+						"onSuccessActivateScript": f"#{creation_id}" if active else None,
+					},
+					"0",
+				]
+			],
+		)
+
+		return response["methodResponses"][0][1]
+
 	def sieve_script_get(self, ids: list[str] | None = None) -> list[dict]:
 		"""Returns the sieve scripts for the provided sieve script IDs."""
 


### PR DESCRIPTION
<img width="2474" height="1039" alt="image" src="https://github.com/user-attachments/assets/d0d5c63f-36a1-461b-8ce8-1c9a724cc83c" />

The `vacation` script is a special Sieve script that is automatically managed by the server. It is implicitly updated by the server whenever the Vacation Response is modified through the `VacationResponse/set` method.

<img width="2474" height="1166" alt="image" src="https://github.com/user-attachments/assets/dfa65970-164c-462a-bf70-a7da2a42bcca" />

**Note:** Only one Sieve script can be active at a time for an account. When a script is activated, the server automatically deactivates any previously active script.

**Edge case:** If an account already has a custom Sieve script with `isActive = true`, enabling the Vacation Response will activate the vacation script and automatically deactivate the existing active script.

Reference: https://www.ietf.org/archive/id/draft-ietf-jmap-sieve-14.html
