### PR TITLE
feat: setting to disable push notification for mailbox

### DIFF
--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -1205,34 +1205,38 @@ def fetch_changes(user: str, email_state: str | None = None, ctx: dict | None = 
 			logger.info({**ctx, "event": "new-messages-created", "count": len(created_ids)})
 
 			if messages := get_messages(user, ids=created_ids):
-				inbox_id = mailbox_service.get_mailbox_id_by_role(
-					"inbox", create_if_not_exists=True, raise_exception=True
-				)
+				subscribed_mailboxes = set([m["id"] for m in mailbox_service.mailboxes if m["isSubscribed"]])
+				logger.debug({**ctx, "subscribed_mailboxes": subscribed_mailboxes})
 
-				mailboxes = set()
+				disabled_mailboxes = set(
+					frappe.db.get_all(
+						"Mailbox Settings", {"user": user, "disable_push_notification": 1}, pluck="mailbox_id"
+					)
+				)
+				logger.debug({**ctx, "disabled_mailboxes_for_notification": disabled_mailboxes})
+
 				notify_candidates = []
+				mailboxes_to_reload = set()
+
 				for message in messages:
-					if not message["draft"] and not message["seen"]:
-						for mailbox in message["mailboxes"]:
-							mailboxes.add(mailbox["mailbox_id"])
-							if mailbox["mailbox_id"] == inbox_id:
-								notify_candidates.append(message)
-							else:
-								logger.debug(
-									{
-										**ctx,
-										"event": "skipping-notification-for-non-inbox",
-										"message_id": message["id"],
-									}
-								)
-					else:
-						logger.debug(
-							{
-								**ctx,
-								"event": "skipping-notification-for-draft-seen",
-								"message_id": message["id"],
-							}
-						)
+					if message["draft"] or message["seen"]:
+						continue
+
+					mailbox_id = None
+					is_candidate = False
+
+					for mailbox in message["mailboxes"]:
+						if mailbox["mailbox_id"] not in subscribed_mailboxes:
+							continue
+
+						mailboxes_to_reload.add(mailbox["mailbox_id"])
+
+						if not is_candidate and mailbox["mailbox_id"] not in disabled_mailboxes:
+							mailbox_id = mailbox["mailbox_id"]
+							is_candidate = True
+
+					if is_candidate:
+						notify_candidates.append((mailbox_id, message))
 
 				logger.debug({**ctx, "notify_candidates_count": len(notify_candidates)})
 
@@ -1247,19 +1251,19 @@ def fetch_changes(user: str, email_state: str | None = None, ctx: dict | None = 
 					logger.info({**ctx, "event": "sending-push-notifications", "count": len(recent_messages)})
 
 					url = frappe.utils.get_url()
-					for message in recent_messages:
+					for mailbox_id, message in recent_messages:
 						pn.send_notification_to_user(
 							user,
 							message["from_name"] or message["from_email"],
 							message["subject"] or _("[No subject]"),
-							f"{url}/mail/mailbox/{inbox_id}/{message['thread_id']}",
+							f"{url}/mail/mailbox/{mailbox_id}/{message['thread_id']}",
 							f"{url}/assets/mail/frontend/manifest/manifest-icon-192.maskable.png",
 						)
 				else:
 					logger.info({**ctx, "event": "push-notifications-disabled"})
 
-				if mailboxes:
-					frappe.publish_realtime("new_mail_created", list(mailboxes), user=user)
+				if mailboxes_to_reload:
+					frappe.publish_realtime("new_mail_created", list(mailboxes_to_reload), user=user)
 
 		if updated_ids := result["updated"]:
 			logger.info({**ctx, "event": "messages-updated", "count": len(updated_ids)})

--- a/mail/client/doctype/mailbox_settings/mailbox_settings.json
+++ b/mail/client/doctype/mailbox_settings/mailbox_settings.json
@@ -11,7 +11,8 @@
   "section_break_qhyu",
   "icon",
   "color",
-  "column_break_mbnv"
+  "column_break_mbnv",
+  "disable_push_notification"
  ],
  "fields": [
   {
@@ -19,7 +20,7 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "The user this setting belongs to.",
+   "description": "The user to whom these mailbox settings apply.",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -35,6 +36,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Unique identifier of the mailbox associated with the user.",
    "fieldname": "mailbox_id",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -49,11 +51,13 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "Icon used to visually represent the mailbox in the UI.",
    "fieldname": "icon",
    "fieldtype": "Icon",
    "label": "Icon"
   },
   {
+   "description": "Color assigned to the mailbox for easy identification and UI customization.",
    "fieldname": "color",
    "fieldtype": "Color",
    "label": "Color"
@@ -61,12 +65,20 @@
   {
    "fieldname": "column_break_mbnv",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Check to disable push notifications for this mailbox.",
+   "fieldname": "disable_push_notification",
+   "fieldtype": "Check",
+   "label": "Disable Push Notification",
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-27 12:27:14.092609",
+ "modified": "2026-04-10 10:05:17.331537",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Mailbox Settings",


### PR DESCRIPTION
By default, push notifications are now enabled for all subscribed mailboxes (except drafts and junk). Set the `disable_push_notification` to `1` to disable notifications for the specific mailbox.

<img width="2061" height="585" alt="image" src="https://github.com/user-attachments/assets/16630024-a8ad-4185-b067-333205fd64cf" />
