### PR TITLE
fix: scope app list cache to user

### DIFF
--- a/mail/api/__init__.py
+++ b/mail/api/__init__.py
@@ -48,7 +48,7 @@ def get_translations() -> dict:
 
 
 @frappe.whitelist()
-@redis_cache()
+@redis_cache(user=True)
 def get_permitted_apps():
 	apps = get_apps()
 	if not is_system_manager(frappe.session.user):


### PR DESCRIPTION
Currently, the cache is reused for all users, and there are instances where users with desk access won't see desk as an option because the cache was created based on a user without desk access 
eg:

<img width="344" height="161" alt="Screenshot 2026-05-17 at 10 32 12 PM" src="https://github.com/user-attachments/assets/72c4bf67-825f-4525-a93b-e718e31bd16d" />
<img width="344" height="161" alt="Screenshot 2026-05-17 at 10 32 42 PM" src="https://github.com/user-attachments/assets/66849e4c-6ded-40a3-a9cf-7bd3890fd668" />

ref: [frappe/utils/caching.py#L170](https://github.com/frappe/frappe/blob/368b13aa42bf80db75fbf96ba008e5cb8a3f0152/frappe/utils/caching.py#L170)
