### PR TITLE
feat(mobile): OAuth2 mobile endpoint and Mail Settings field (#485)

### DIFF
--- a/mail/api/mobile.py
+++ b/mail/api/mobile.py
@@ -1,0 +1,72 @@
+import frappe
+from frappe import _
+
+# Redirect URI registered in the mobile app's Info.plist (iOS) and AndroidManifest.xml (Android).
+MOBILE_REDIRECT_URI = "com.frappe.mail://oauth"
+
+
+@frappe.whitelist(allow_guest=True)
+def get_client_id() -> dict:
+	"""Returns the OAuth2 client ID and site metadata needed by the mobile app.
+
+	Called before login — no authentication required. Returns an error if the
+	site admin has not yet configured a mobile OAuth client.
+	"""
+	client_id = frappe.db.get_single_value("Mail Settings", "mobile_oauth_client")
+	if not client_id:
+		frappe.throw(
+			_(
+				"Mobile OAuth client is not configured. "
+				"Ask your site administrator to set it up in Mail Settings → Mobile."
+			),
+			frappe.DoesNotExistError,
+		)
+
+	app_name = (
+		frappe.db.get_single_value("Website Settings", "app_name") or "Frappe Mail"
+	)
+	logo = (
+		frappe.db.get_single_value("Website Settings", "favicon")
+		or "/assets/mail/images/mail-logo.svg"
+	)
+
+	return {
+		"client_id": client_id,
+		"app_name": app_name,
+		"logo": logo,
+		"sitename": frappe.local.site,
+	}
+
+
+@frappe.whitelist(methods=["POST"])
+def create_oauth_client() -> dict:
+	"""Creates (or updates) the OAuth2 client for the Frappe Mail mobile app.
+
+	Must be called by a System Manager. Stores the resulting client ID in
+	Mail Settings so that get_client_id() can return it to the mobile app.
+	"""
+	if not frappe.has_permission("Mail Settings", "write"):
+		frappe.throw(_("You do not have permission to configure mobile OAuth settings."), frappe.PermissionError)
+
+	existing_client_id = frappe.db.get_single_value("Mail Settings", "mobile_oauth_client")
+
+	if existing_client_id and frappe.db.exists("OAuth Client", existing_client_id):
+		oauth_client = frappe.get_doc("OAuth Client", existing_client_id)
+	else:
+		oauth_client = frappe.new_doc("OAuth Client")
+
+	oauth_client.app_name = "Frappe Mail Mobile"
+	oauth_client.scopes = "all openid"
+	oauth_client.redirect_uris = MOBILE_REDIRECT_URI
+	oauth_client.default_redirect_uri = MOBILE_REDIRECT_URI
+	oauth_client.grant_type = "Authorization Code"
+	oauth_client.response_type = "Code"
+	oauth_client.skip_authorization = 1
+	oauth_client.save(ignore_permissions=True)
+
+	frappe.db.set_single_value("Mail Settings", "mobile_oauth_client", oauth_client.name)
+
+	return {
+		"client_id": oauth_client.name,
+		"message": _("Mobile OAuth client configured successfully."),
+	}

--- a/mail/api/mobile.py
+++ b/mail/api/mobile.py
@@ -5,7 +5,9 @@ from frappe import _
 MOBILE_REDIRECT_URI = "com.frappe.mail://oauth"
 
 
-@frappe.whitelist(allow_guest=True)
+# Guest access is intentional: the mobile app fetches the public OAuth client_id
+# before login to begin the auth flow. Only non-sensitive public config is returned.
+@frappe.whitelist(allow_guest=True)  # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
 def get_client_id() -> dict:
 	"""Returns the OAuth2 client ID and site metadata needed by the mobile app.
 

--- a/mail/api/mobile.py
+++ b/mail/api/mobile.py
@@ -22,13 +22,8 @@ def get_client_id() -> dict:
 			frappe.DoesNotExistError,
 		)
 
-	app_name = (
-		frappe.db.get_single_value("Website Settings", "app_name") or "Frappe Mail"
-	)
-	logo = (
-		frappe.db.get_single_value("Website Settings", "favicon")
-		or "/assets/mail/images/mail-logo.svg"
-	)
+	app_name = frappe.db.get_single_value("Website Settings", "app_name") or "Frappe Mail"
+	logo = frappe.db.get_single_value("Website Settings", "favicon") or "/assets/mail/images/mail-logo.svg"
 
 	return {
 		"client_id": client_id,
@@ -46,7 +41,9 @@ def create_oauth_client() -> dict:
 	Mail Settings so that get_client_id() can return it to the mobile app.
 	"""
 	if not frappe.has_permission("Mail Settings", "write"):
-		frappe.throw(_("You do not have permission to configure mobile OAuth settings."), frappe.PermissionError)
+		frappe.throw(
+			_("You do not have permission to configure mobile OAuth settings."), frappe.PermissionError
+		)
 
 	existing_client_id = frappe.db.get_single_value("Mail Settings", "mobile_oauth_client")
 

--- a/mail/mail/doctype/mail_settings/mail_settings.js
+++ b/mail/mail/doctype/mail_settings/mail_settings.js
@@ -50,6 +50,25 @@ frappe.ui.form.on('Mail Settings', {
 			() => frm.trigger('generate_jmap_push_keys'),
 			__('Actions'),
 		)
+		frm.add_custom_button(
+			__('Setup Mobile OAuth Client'),
+			() => frm.trigger('setup_mobile_oauth_client'),
+			__('Actions'),
+		)
+	},
+
+	setup_mobile_oauth_client(frm) {
+		frappe.call({
+			method: 'mail.api.mobile.create_oauth_client',
+			freeze: true,
+			freeze_message: __('Setting up mobile OAuth client…'),
+			callback: (r) => {
+				if (!r.exc) {
+					frappe.show_alert({ message: r.message.message, indicator: 'green' })
+					frm.reload_doc()
+				}
+			},
+		})
 	},
 
 	generate_jmap_push_keys(frm) {

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -28,6 +28,9 @@
   "allow_signup",
   "column_break_daqm",
   "signup_domains",
+  "mobile_tab",
+  "section_break_mobile",
+  "mobile_oauth_client",
   "spamassassin_tab",
   "section_break_hgqa",
   "enable_spamd",
@@ -262,12 +265,28 @@
    "fieldname": "signup_tab",
    "fieldtype": "Tab Break",
    "label": "Signup"
+  },
+  {
+   "fieldname": "mobile_tab",
+   "fieldtype": "Tab Break",
+   "label": "Mobile"
+  },
+  {
+   "fieldname": "section_break_mobile",
+   "fieldtype": "Section Break"
+  },
+  {
+   "description": "OAuth 2.0 client used by the Frappe Mail mobile app. Use the 'Setup Mobile OAuth Client' button to create one automatically.",
+   "fieldname": "mobile_oauth_client",
+   "fieldtype": "Link",
+   "label": "Mobile OAuth Client",
+   "options": "OAuth Client"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-27 09:25:58.236007",
+ "modified": "2026-05-27 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",


### PR DESCRIPTION
## Summary

- Adds `mail/api/mobile.py` with two endpoints:
  - **`get_client_id`** (`allow_guest=True`) — called by the mobile app before login to validate the site and fetch the OAuth client ID, app name, logo, and sitename. Returns only non-sensitive public config; reviewed and marked `# nosemgrep` for the `guest-whitelisted-method` rule (same pattern as Raven's equivalent endpoint).
  - **`create_oauth_client`** (requires Mail Settings *write* permission) — auto-creates or updates a Frappe `OAuth Client` doc and stores its ID in Mail Settings, so admins don't need to configure it manually
- Adds `mobile_oauth_client` (Link → OAuth Client) field to Mail Settings under a new **Mobile** tab
- Adds a **Setup Mobile OAuth Client** button (Mail Settings → Actions) that calls `create_oauth_client` and reloads the form
- Redirect URI is `com.frappe.mail://oauth` — matches the iOS `Info.plist` and Android `AndroidManifest.xml` stubs added in #484

Modeled on Raven's mobile-login approach (guest `get_client_id` discovery + admin `create_oauth_client`, Authorization Code flow against Frappe's OAuth provider). Note: mail users are identified by `is_jmap_configured` (a `User Settings` check), not a role, so the OAuth client is not role-gated — the mail APIs already enforce `is_jmap_configured`.

## Admin setup flow

1. Open **Mail Settings → Mobile** tab in Frappe Desk
2. Click **Setup Mobile OAuth Client** under **Actions** — creates/updates the OAuth Client automatically and stores its ID
3. Mobile app users can now enter the site URL and the app will fetch the `client_id` from `get_client_id`

## Test plan

Verified on a dev site (`bench migrate` + console/HTTP):

- [x] `get_client_id` raises `DoesNotExistError` when no OAuth client is configured
- [x] After `create_oauth_client`, `get_client_id` returns `client_id`, `app_name`, `logo`, `sitename` (also confirmed over HTTP as guest — no auth)
- [x] `create_oauth_client` raises `PermissionError` for users without Mail Settings write permission
- [x] Mail Settings shows the Mobile tab + OAuth Client link field after `bench migrate`
- [x] The created OAuth Client has the expected config (redirect `com.frappe.mail://oauth`, Authorization Code / Code, `scopes = all openid`)

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)