### PR TITLE
feat(mobile): thread detail / email reading (#489)

### DIFF
--- a/mobile/app/components/ThreadRow.vue
+++ b/mobile/app/components/ThreadRow.vue
@@ -1,13 +1,11 @@
 <template>
-	<!-- One thread list row. A full-row overlay opens the thread; the star is layered
-	     on top as its own tap target. NativeScript routes a tap to the front-most view
-	     with a handler, so the star wins in its area and the overlay (open) everywhere
-	     else — tapping anywhere but the star navigates. Horizontal insets are margins
-	     on grid children, not container padding, per the iOS spacing constraints. -->
+	<!-- One thread list row. A full-row transparent overlay opens the thread; the star
+	     sits on top of it as its own tap target. The overlay is layered ABOVE the avatar/
+	     content (so iOS hit-testing — which returns the top-most view, not the first with a
+	     handler — routes those taps to it) but BELOW the star (so the star still wins in its
+	     area). Tapping anywhere but the star navigates. Horizontal insets are margins on grid
+	     children, not container padding, per the iOS spacing constraints. -->
 	<GridLayout columns="auto, *, auto" class="border-outline-gray-1 border-b py-3">
-		<!-- full-row tap target: open the thread (behind everything, no background) -->
-		<GridLayout col="0" colSpan="3" @tap="$emit('open')" />
-
 		<!-- avatar: sender image, else monochrome initials -->
 		<UserAvatar
 			col="0"
@@ -97,6 +95,10 @@
 			horizontalAlignment="right"
 			verticalAlignment="top"
 		/>
+
+		<!-- full-row tap target: open the thread (transparent, above content, below star) -->
+		<GridLayout col="0" colSpan="3" @tap="$emit('open')" />
+
 		<GridLayout
 			col="2"
 			class="mr-1 h-7 w-9"

--- a/mobile/app/pages/ThreadView.vue
+++ b/mobile/app/pages/ThreadView.vue
@@ -200,13 +200,18 @@ async function load() {
 	}
 }
 
-// Hide Android's on-screen zoom (-/+) widget while keeping pinch-to-zoom.
 function onWebViewLoaded(args: EventData) {
 	if (!isAndroid) return
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const settings = (args.object as any).android?.getSettings?.()
+	const native = (args.object as any).android
+	// Hide Android's on-screen zoom (-/+) widget while keeping pinch-to-zoom.
+	const settings = native?.getSettings?.()
 	settings?.setBuiltInZoomControls(true)
 	settings?.setDisplayZoomControls(false)
+	// Render on a software layer so the WebView can be captured in the page
+	// transition bitmap — otherwise Android flashes white (then redraws) when
+	// navigating back. (1 = android.view.View.LAYER_TYPE_SOFTWARE)
+	native?.setLayerType?.(1, null)
 }
 
 // Links navigate to an `x-open:` scheme we intercept here, so taps open in the

--- a/mobile/app/pages/ThreadView.vue
+++ b/mobile/app/pages/ThreadView.vue
@@ -1,96 +1,224 @@
 <template>
 	<Page actionBarHidden="true">
-		<!-- Placeholder thread detail. The real reading view (rendered messages,
-		     reply/forward, attachments) is built in #489 — this just wires the
-		     navigation and shows the thread's subject + sender. -->
-		<GridLayout rows="auto, *" class="bg-surface-white">
-			<!-- top bar -->
-			<GridLayout
-				row="0"
-				columns="auto, *, auto, auto"
-				class="border-outline-gray-1 border-b px-1 py-2"
-				:marginTop="safeTop"
-			>
-				<GridLayout col="0" class="h-10 w-10" @tap="goBack">
-					<Label
-						:text="lucide('chevron-left')"
-						class="font-lucide text-ink-gray-7 text-2xl"
-						horizontalAlignment="center"
-						verticalAlignment="center"
-					/>
+		<GridLayout class="bg-surface-white">
+			<GridLayout rows="auto, *, auto">
+				<!-- top bar: back + actions (reading-only; actions are placeholders) -->
+				<GridLayout
+					row="0"
+					columns="auto, *, auto, auto, auto"
+					class="border-outline-gray-1 border-b px-1 py-2"
+					:marginTop="safeTop"
+				>
+					<GridLayout col="0" class="h-10 w-10" @tap="goBack">
+						<Label
+							:text="lucide('chevron-left')"
+							class="font-lucide text-ink-gray-7 text-2xl"
+							horizontalAlignment="center"
+							verticalAlignment="center"
+						/>
+					</GridLayout>
+					<GridLayout col="2" class="h-10 w-10" @tap="flash(__('Archive coming soon'))">
+						<Label
+							:text="lucide('archive')"
+							class="font-lucide text-ink-gray-6 text-xl"
+							horizontalAlignment="center"
+							verticalAlignment="center"
+						/>
+					</GridLayout>
+					<GridLayout col="3" class="h-10 w-10" @tap="flash(__('Delete coming soon'))">
+						<Label
+							:text="lucide('trash-2')"
+							class="font-lucide text-ink-gray-6 text-xl"
+							horizontalAlignment="center"
+							verticalAlignment="center"
+						/>
+					</GridLayout>
+					<GridLayout col="4" class="h-10 w-10" @tap="flash(__('More coming soon'))">
+						<Label
+							:text="lucide('ellipsis')"
+							class="font-lucide text-ink-gray-6 text-xl"
+							horizontalAlignment="center"
+							verticalAlignment="center"
+						/>
+					</GridLayout>
 				</GridLayout>
-				<GridLayout col="2" class="h-10 w-10" @tap="() => {}">
-					<Label
-						:text="lucide('archive')"
-						class="font-lucide text-ink-gray-6 text-xl"
-						horizontalAlignment="center"
+
+				<!-- thread body -->
+				<GridLayout row="1">
+					<WebView v-if="html" :src="html" @loadStarted="onLoadStarted" />
+
+					<StackLayout
+						v-else-if="loading"
 						verticalAlignment="center"
-					/>
+						horizontalAlignment="center"
+					>
+						<ActivityIndicator busy="true" />
+					</StackLayout>
+
+					<StackLayout
+						v-else
+						verticalAlignment="center"
+						horizontalAlignment="center"
+						class="px-10"
+					>
+						<Label
+							:text="__('Couldn’t load this thread')"
+							class="text-ink-gray-8 text-lg font-bold"
+							textAlignment="center"
+						/>
+						<Label
+							v-if="error"
+							:text="error"
+							class="text-ink-gray-5 mt-1 text-sm"
+							textAlignment="center"
+							textWrap="true"
+						/>
+						<GridLayout
+							class="bg-surface-gray-2 mt-4 rounded-lg px-5 py-2.5"
+							@tap="load"
+						>
+							<Label :text="__('Retry')" class="text-ink-gray-8 font-semibold" />
+						</GridLayout>
+					</StackLayout>
 				</GridLayout>
-				<GridLayout col="3" class="h-10 w-10" @tap="() => {}">
-					<Label
-						:text="lucide('trash-2')"
-						class="font-lucide text-ink-gray-6 text-xl"
-						horizontalAlignment="center"
-						verticalAlignment="center"
-					/>
+
+				<!-- bottom action bar (reply/forward → compose, #490) -->
+				<GridLayout
+					row="2"
+					columns="*, *"
+					class="border-outline-gray-1 border-t px-4 pb-7 pt-3"
+					:marginBottom="safeBottom"
+				>
+					<GridLayout
+						col="0"
+						class="border-outline-gray-2 mr-2 rounded-xl border py-3"
+						@tap="flash(__('Reply coming soon'))"
+					>
+						<StackLayout orientation="horizontal" horizontalAlignment="center">
+							<Label
+								:text="lucide('reply')"
+								class="font-lucide text-ink-gray-8 text-lg"
+								verticalAlignment="center"
+							/>
+							<Label
+								:text="__('Reply')"
+								class="text-ink-gray-8 ml-2 font-semibold"
+								verticalAlignment="center"
+							/>
+						</StackLayout>
+					</GridLayout>
+					<GridLayout
+						col="1"
+						class="border-outline-gray-2 ml-2 rounded-xl border py-3"
+						@tap="flash(__('Forward coming soon'))"
+					>
+						<StackLayout orientation="horizontal" horizontalAlignment="center">
+							<Label
+								:text="lucide('forward')"
+								class="font-lucide text-ink-gray-8 text-lg"
+								verticalAlignment="center"
+							/>
+							<Label
+								:text="__('Forward')"
+								class="text-ink-gray-8 ml-2 font-semibold"
+								verticalAlignment="center"
+							/>
+						</StackLayout>
+					</GridLayout>
 				</GridLayout>
 			</GridLayout>
 
-			<!-- body -->
-			<StackLayout row="1" class="p-5">
-				<Label
-					:text="thread?.subject || __('[No subject]')"
-					class="text-ink-gray-9 text-2xl font-bold"
-					textWrap="true"
-				/>
-				<StackLayout orientation="horizontal" class="mt-4">
-					<Label
-						:text="thread?.from_name || thread?.from_email"
-						class="text-ink-gray-8 font-semibold"
-						verticalAlignment="center"
-					/>
-				</StackLayout>
-				<Label
-					:text="thread?.preview || __('— No message body —')"
-					class="text-ink-gray-6 mt-6 text-base"
-					textWrap="true"
-				/>
-				<Label
-					:text="__('Full thread view coming soon')"
-					class="text-ink-gray-4 mt-8 text-sm"
-				/>
-			</StackLayout>
+			<!-- local toast (this page has its own Frame, outside AppShell's provider) -->
+			<Label
+				v-if="toast"
+				:text="toast"
+				class="bg-surface-gray-7 rounded-full px-5 py-3 text-base font-semibold text-white"
+				horizontalAlignment="center"
+				verticalAlignment="bottom"
+				marginBottom="120"
+				textWrap="false"
+			/>
 		</GridLayout>
 	</Page>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
+import { Utils } from '@nativescript/core'
 import { $navigateBack } from 'nativescript-vue'
 
 import { selectedThread as thread, selectedThreadMailbox } from '@/state/selectedThread'
 import { useApi } from '@/utils/api'
 import { lucide } from '@/utils/lucide'
-import { safeAreaTop } from '@/utils/safeArea'
+import { safeAreaBottom, safeAreaTop } from '@/utils/safeArea'
+import { buildThreadDocument } from '@/utils/threadHtml'
 import { userStore } from '@/stores/user'
+
+import type { Mail } from '@mail/types'
+import type { LoadEventData } from '@nativescript/core'
 
 const store = userStore()
 const api = useApi()
 const safeTop = safeAreaTop()
+const safeBottom = safeAreaBottom()
 
-// Mark the thread seen when the detail view opens, so it happens however the
-// user reaches the mail. Optimistically updates the shared thread object (the
-// same reference the list renders), then persists via set_seen.
+const html = ref('')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const toast = ref<string | null>(null)
+let toastTimer: ReturnType<typeof setTimeout> | null = null
+function flash(msg: string) {
+	toast.value = msg
+	if (toastTimer) clearTimeout(toastTimer)
+	toastTimer = setTimeout(() => (toast.value = null), 1800)
+}
+
+async function load() {
+	const t = thread.value
+	if (!t) {
+		error.value = __('No thread selected')
+		return
+	}
+	loading.value = true
+	error.value = null
+	try {
+		const mails = await api.call<Mail[]>('mail.api.mail.get_thread', {
+			account: store.account,
+			thread_id: t.thread_id,
+		})
+		html.value = buildThreadDocument(mails ?? [], t.subject ?? '')
+	} catch (e) {
+		error.value = (e as { message?: string })?.message ?? __('Failed to load this thread')
+	} finally {
+		loading.value = false
+	}
+}
+
+// Links navigate to an `x-open:` scheme we intercept here, so taps open in the
+// system browser instead of inside the sandboxed WebView.
+function onLoadStarted(args: LoadEventData) {
+	const url = args.url ?? ''
+	if (!url.startsWith('x-open:')) return
+	const view = args.object as unknown as { stopLoading?: () => void }
+	view.stopLoading?.()
+	const target = decodeURIComponent(url.slice('x-open:'.length))
+	if (target) Utils.openUrl(target)
+}
+
+// Mark the thread seen when the detail view opens (path-independent), mutating
+// the shared thread object so the list row updates too.
 onMounted(() => {
 	const t = thread.value
-	if (!t || t.seen) return
-	t.seen = 1
-	api.call('mail.api.mail.set_seen', {
-		account: store.account,
-		thread_ids: { true: [t.thread_id] },
-		mailbox: selectedThreadMailbox.value,
-	}).catch(() => (t.seen = 0))
+	if (t && !t.seen) {
+		t.seen = 1
+		api.call('mail.api.mail.set_seen', {
+			account: store.account,
+			thread_ids: { true: [t.thread_id] },
+			mailbox: selectedThreadMailbox.value,
+		}).catch(() => (t.seen = 0))
+	}
+	load()
 })
 
 function goBack() {

--- a/mobile/app/pages/ThreadView.vue
+++ b/mobile/app/pages/ThreadView.vue
@@ -87,16 +87,16 @@
 					</StackLayout>
 				</GridLayout>
 
-				<!-- bottom action bar (reply/forward → compose, #490) -->
+				<!-- bottom action bar (reply / reply-all / forward → compose, #490) -->
 				<GridLayout
 					row="2"
-					columns="*, *"
+					:columns="showReplyAll ? '*, *, *' : '*, *'"
 					class="border-outline-gray-1 border-t px-4 pb-7 pt-3"
 					:marginBottom="safeBottom"
 				>
 					<GridLayout
 						col="0"
-						class="border-outline-gray-2 mr-2 rounded-xl border py-3"
+						class="border-outline-gray-2 mr-1.5 rounded-xl border py-3"
 						@tap="flash(__('Reply coming soon'))"
 					>
 						<StackLayout orientation="horizontal" horizontalAlignment="center">
@@ -107,14 +107,33 @@
 							/>
 							<Label
 								:text="__('Reply')"
-								class="text-ink-gray-8 ml-2 font-semibold"
+								class="text-ink-gray-8 ml-1.5 font-semibold"
 								verticalAlignment="center"
 							/>
 						</StackLayout>
 					</GridLayout>
 					<GridLayout
+						v-if="showReplyAll"
 						col="1"
-						class="border-outline-gray-2 ml-2 rounded-xl border py-3"
+						class="border-outline-gray-2 mx-1.5 rounded-xl border py-3"
+						@tap="flash(__('Reply all coming soon'))"
+					>
+						<StackLayout orientation="horizontal" horizontalAlignment="center">
+							<Label
+								:text="lucide('reply-all')"
+								class="font-lucide text-ink-gray-8 text-lg"
+								verticalAlignment="center"
+							/>
+							<Label
+								:text="__('Reply all')"
+								class="text-ink-gray-8 ml-1.5 font-semibold"
+								verticalAlignment="center"
+							/>
+						</StackLayout>
+					</GridLayout>
+					<GridLayout
+						:col="showReplyAll ? 2 : 1"
+						class="border-outline-gray-2 ml-1.5 rounded-xl border py-3"
 						@tap="flash(__('Forward coming soon'))"
 					>
 						<StackLayout orientation="horizontal" horizontalAlignment="center">
@@ -125,7 +144,7 @@
 							/>
 							<Label
 								:text="__('Forward')"
-								class="text-ink-gray-8 ml-2 font-semibold"
+								class="text-ink-gray-8 ml-1.5 font-semibold"
 								verticalAlignment="center"
 							/>
 						</StackLayout>
@@ -148,7 +167,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { Utils, isAndroid } from '@nativescript/core'
 import { $navigateBack } from 'nativescript-vue'
 
@@ -170,6 +189,15 @@ const safeBottom = safeAreaBottom()
 const html = ref('')
 const loading = ref(false)
 const error = ref<string | null>(null)
+const mails = ref<Mail[]>([])
+
+// Reply-all is offered when the (last) message has recipients besides you —
+// mirrors the web MailThread showReplyAll.
+const showReplyAll = computed(() => {
+	const last = mails.value[mails.value.length - 1]
+	if (!last) return false
+	return (last.recipients || []).filter((r) => r.type === 'To' || r.type === 'Cc').length > 1
+})
 
 const toast = ref<string | null>(null)
 let toastTimer: ReturnType<typeof setTimeout> | null = null
@@ -188,11 +216,13 @@ async function load() {
 	loading.value = true
 	error.value = null
 	try {
-		const mails = await api.call<Mail[]>('mail.api.mail.get_thread', {
+		const data = await api.call<Mail[]>('mail.api.mail.get_thread', {
 			account: store.account,
 			thread_id: t.thread_id,
 		})
-		html.value = buildThreadDocument(mails ?? [], t.subject ?? '')
+		mails.value = data ?? []
+		// Use the first message's subject (the original), not the thread's latest.
+		html.value = buildThreadDocument(mails.value, mails.value[0]?.subject || t.subject || '')
 	} catch (e) {
 		error.value = (e as { message?: string })?.message ?? __('Failed to load this thread')
 	} finally {

--- a/mobile/app/pages/ThreadView.vue
+++ b/mobile/app/pages/ThreadView.vue
@@ -45,7 +45,12 @@
 
 				<!-- thread body -->
 				<GridLayout row="1">
-					<WebView v-if="html" :src="html" @loadStarted="onLoadStarted" />
+					<WebView
+						v-if="html"
+						:src="html"
+						@loaded="onWebViewLoaded"
+						@loadStarted="onLoadStarted"
+					/>
 
 					<StackLayout
 						v-else-if="loading"
@@ -144,7 +149,7 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import { Utils } from '@nativescript/core'
+import { Utils, isAndroid } from '@nativescript/core'
 import { $navigateBack } from 'nativescript-vue'
 
 import { selectedThread as thread, selectedThreadMailbox } from '@/state/selectedThread'
@@ -155,7 +160,7 @@ import { buildThreadDocument } from '@/utils/threadHtml'
 import { userStore } from '@/stores/user'
 
 import type { Mail } from '@mail/types'
-import type { LoadEventData } from '@nativescript/core'
+import type { EventData, LoadEventData } from '@nativescript/core'
 
 const store = userStore()
 const api = useApi()
@@ -195,15 +200,29 @@ async function load() {
 	}
 }
 
+// Hide Android's on-screen zoom (-/+) widget while keeping pinch-to-zoom.
+function onWebViewLoaded(args: EventData) {
+	if (!isAndroid) return
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const settings = (args.object as any).android?.getSettings?.()
+	settings?.setBuiltInZoomControls(true)
+	settings?.setDisplayZoomControls(false)
+}
+
 // Links navigate to an `x-open:` scheme we intercept here, so taps open in the
 // system browser instead of inside the sandboxed WebView.
 function onLoadStarted(args: LoadEventData) {
 	const url = args.url ?? ''
-	if (!url.startsWith('x-open:')) return
 	const view = args.object as unknown as { stopLoading?: () => void }
-	view.stopLoading?.()
-	const target = decodeURIComponent(url.slice('x-open:'.length))
-	if (target) Utils.openUrl(target)
+	if (url.startsWith('x-open:')) {
+		view.stopLoading?.()
+		const target = decodeURIComponent(url.slice('x-open:'.length))
+		if (target) Utils.openUrl(target)
+	} else if (url.startsWith('x-more:')) {
+		// Per-message "more" button — actions land in #490.
+		view.stopLoading?.()
+		flash(__('More coming soon'))
+	}
 }
 
 // Mark the thread seen when the detail view opens (path-independent), mutating

--- a/mobile/app/utils/format.ts
+++ b/mobile/app/utils/format.ts
@@ -39,9 +39,11 @@ export function formatDate(date: string | Date): string {
 	return d.format('MMM D, YYYY')
 }
 
-// Full date + time for the thread detail message header.
-export function formatFullDate(date: string | Date): string {
-	return dayjs(date).format('MMM D, YYYY, h:mm A')
+// Relative "x hours ago" for the thread detail message header, capitalized to
+// match the web MailDate.vue (which uses useTimeAgo in the non-list view).
+export function formatTimeAgo(date: string | Date): string {
+	const s = dayjs(date).fromNow()
+	return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 export function formatRelative(date: string | Date): string {

--- a/mobile/app/utils/format.ts
+++ b/mobile/app/utils/format.ts
@@ -39,6 +39,11 @@ export function formatDate(date: string | Date): string {
 	return d.format('MMM D, YYYY')
 }
 
+// Full date + time for the thread detail message header.
+export function formatFullDate(date: string | Date): string {
+	return dayjs(date).format('MMM D, YYYY, h:mm A')
+}
+
 export function formatRelative(date: string | Date): string {
 	return dayjs(date).fromNow()
 }

--- a/mobile/app/utils/threadHtml.ts
+++ b/mobile/app/utils/threadHtml.ts
@@ -90,7 +90,7 @@ function attachmentChips(mail: Mail): string {
 	return `<div class="atts">${chips}</div>`
 }
 
-function messageHtml(mail: Mail, index: number): string {
+function messageHtml(mail: Mail, index: number, isLast: boolean): string {
 	const name = mail.from_name || mail.from_email || '?'
 	const avatar =
 		`<div class="avatar"><span>${escapeHtml(initials(name))}</span>` +
@@ -100,16 +100,78 @@ function messageHtml(mail: Mail, index: number): string {
 		`<span class="date">${escapeHtml(formatTimeAgo(mail.received_at))}</span></div>` +
 		`<div class="to">${escapeHtml(formatRecipients(mail.recipients || []))}</div></div>`
 	const more = `<span class="more" data-i="${index}">&#8942;</span>`
+	const preview = `<div class="preview">${escapeHtml(mail.preview || '')}</div>`
 	const body = hasHtmlContent(mail.html_body)
 		? `<div class="body">${sanitizeBody(mail.html_body)}</div>`
 		: `<div class="body"><pre>${escapeHtml(mail.html_body || mail.text_body || '')}</pre></div>`
-	return `<div class="msg"><div class="mhead">${avatar}${meta}${more}</div>${body}${attachmentChips(mail)}</div>`
+	// Seen messages start collapsed (preview only); the last message and unseen
+	// messages stay expanded — mirrors the web MailThread isCollapsed logic.
+	const collapsible = !isLast
+	const collapsed = collapsible && !!mail.seen
+	const cls = ['msg', collapsible && 'collapsible', collapsed && 'collapsed']
+		.filter(Boolean)
+		.join(' ')
+	return `<div class="${cls}"><div class="mhead">${avatar}${meta}${more}</div>${preview}${body}${attachmentChips(mail)}</div>`
 }
 
 export function buildThreadDocument(mails: Mail[], subject: string): string {
 	// Per-load nonce so only our own inline script is allowed by the CSP.
 	const nonce = Math.random().toString(36).slice(2)
-	const messages = mails.map((m, i) => messageHtml(m, i)).join('<hr class="divider">')
+
+	const lastIndex = mails.length - 1
+	const lastName = mails[lastIndex]?.name
+
+	// "N new messages" divider above the first unseen message (mirrors the web).
+	const firstUnseen = mails.findIndex((m) => !m.seen && !m.draft)
+	const unseenCount = mails.filter((m) => !m.seen && !m.draft).length
+	const unseenMessage =
+		unseenCount === 1 ? __('1 new message') : __('{0} new messages', [String(unseenCount)])
+
+	// Collapsed group: hide the middle seen messages behind a "N more messages"
+	// divider when there are >= 4 seen, non-last messages (mirrors the web
+	// setCollapsedGroup / collapsedMailNames). Tapping it reveals them.
+	const seenMails = mails.filter((m) => m.seen && !m.draft && m.name !== lastName)
+	const hiddenNames =
+		seenMails.length >= 4
+			? new Set(seenMails.slice(1, -1).map((m) => m.name))
+			: new Set<string>()
+	const firstGroupName = hiddenNames.size ? (seenMails[1]?.name ?? null) : null
+	const groupMessage = __('{0} more messages', [String(hiddenNames.size)])
+
+	const parts: string[] = []
+	let prevHidden = false
+	mails.forEach((m, i) => {
+		const isHidden = hiddenNames.has(m.name)
+		const isFirstHidden = m.name === firstGroupName
+		// Separator that precedes this message.
+		let sep = ''
+		if (unseenCount > 0 && i === firstUnseen) {
+			sep = `<div class="unseen-marker"><span class="pill">${escapeHtml(unseenMessage)}</span></div>`
+		} else if (i > 0) {
+			sep = '<hr class="divider">'
+		}
+		// The group divider stands in for the separator at the first hidden message.
+		if (isFirstHidden) {
+			parts.push(
+				`<div class="group-divider"><span class="pill">${escapeHtml(groupMessage)}</span></div>`,
+			)
+		}
+		const msg = messageHtml(m, i, i === lastIndex)
+		if (isHidden) {
+			// Wrap the message and its separator so they hide/reveal together. The
+			// first one keeps its separator too (hidden now, shown on expand) — the
+			// group divider stands in for it while collapsed.
+			parts.push(`<div class="group-hidden">${sep}${msg}</div>`)
+		} else {
+			// The first message after the group: its separator would double up under
+			// the group divider (the hidden group has no height), so hide it while
+			// collapsed — it reveals with the group.
+			if (sep) parts.push(prevHidden ? `<div class="group-hidden">${sep}</div>` : sep)
+			parts.push(msg)
+		}
+		prevHidden = isHidden
+	})
+	const messages = parts.join('')
 
 	const csp =
 		"default-src 'none'; img-src http: https: data: cid:; style-src 'unsafe-inline'; " +
@@ -136,7 +198,31 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 			document.querySelectorAll('.more').forEach(function (el) {
 				el.addEventListener('click', function (e) {
 					e.preventDefault();
+					e.stopPropagation();
 					location.href = 'x-more:' + (el.getAttribute('data-i') || '');
+				});
+			});
+			// Tap the "N more messages" divider to reveal the hidden middle messages.
+			var gd = document.querySelector('.group-divider');
+			if (gd) {
+				gd.addEventListener('click', function () {
+					document.querySelectorAll('.group-hidden').forEach(function (el) {
+						el.classList.remove('group-hidden');
+					});
+					gd.remove();
+				});
+			}
+			// Tap anywhere on a collapsed message to expand it; tap the header to
+			// collapse it again (body taps are left alone so links/selection work).
+			document.querySelectorAll('.msg.collapsible').forEach(function (msg) {
+				msg.addEventListener('click', function (e) {
+					var t = e.target;
+					if (t && t.closest && t.closest('.more')) return;
+					if (msg.classList.contains('collapsed')) {
+						msg.classList.remove('collapsed');
+					} else if (t && t.closest && t.closest('.mhead')) {
+						msg.classList.add('collapsed');
+					}
 				});
 			});
 			document.addEventListener('click', function (e) {
@@ -156,7 +242,7 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Security-Policy" content="${csp}">
 <style>
-	* { box-sizing: border-box; }
+	* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
 	/* Guard our chrome from a message's own <style> (e.g. body{background}/body{color}),
 	   which targets this single document's body since we render the thread in one doc. */
 	html body { background-color: #ffffff !important; }
@@ -164,8 +250,8 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 		line-height: 1.5; color: #171717; margin: 0; padding: 16px 16px 96px;
 		-webkit-text-size-adjust: 100%; overflow-wrap: anywhere; }
 	.subject { color: #171717; font-size: 22px; font-weight: 700; line-height: 1.3; margin: 4px 0 18px; }
-	.msg { padding: 2px 0; }
-	.mhead { display: flex; gap: 12px; align-items: center; margin: 14px 0 12px; }
+	.msg { padding: 18px 0; }
+	.mhead { display: flex; gap: 12px; align-items: center; }
 	.avatar { position: relative; width: 40px; height: 40px; border-radius: 40px;
 		background: #F3F3F3; flex-shrink: 0; overflow: hidden; }
 	.avatar span { position: absolute; inset: 0; display: flex; align-items: center;
@@ -181,7 +267,26 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 	.more { flex-shrink: 0; align-self: flex-start; width: 24px; height: 24px; margin-left: 2px;
 		display: flex; align-items: center; justify-content: center; color: #7c7c7c;
 		font-size: 17px; line-height: 1; border-radius: 24px; }
-	.body { font-size: 15px; line-height: 1.6; color: #383838; }
+	.msg.collapsed { cursor: pointer; }
+	.msg.collapsible:not(.collapsed) > .mhead { cursor: pointer; }
+	.preview { display: none; font-size: 14px; color: #7c7c7c; margin: 10px 0 0;
+		overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.msg.collapsed .preview { display: block; }
+	.msg.collapsed .body, .msg.collapsed .atts, .msg.collapsed .more { display: none; }
+	.unseen-marker { display: flex; align-items: center; gap: 0; margin: 0 -16px;
+		color: #0289f7; font-size: 14px; }
+	.unseen-marker::before, .unseen-marker::after { content: ''; flex: 1; height: 1px;
+		background: #a7d7fd; }
+	.unseen-marker .pill { flex-shrink: 0; border: 1px solid #a7d7fd; border-radius: 40px;
+		padding: 4px 12px; }
+	.group-divider { display: flex; align-items: center; gap: 0; margin: 0 -16px;
+		color: #7c7c7c; font-size: 13px; cursor: pointer; }
+	.group-divider::before, .group-divider::after { content: ''; flex: 1; height: 1px;
+		background: #ededed; }
+	.group-divider .pill { flex-shrink: 0; border: 1px solid #e2e2e2; border-radius: 40px;
+		padding: 5px 14px; }
+	.group-hidden { display: none; }
+	.body { font-size: 15px; line-height: 1.6; color: #383838; margin-top: 14px; }
 	.body img { max-width: 100%; height: auto; }
 	.body table { max-width: 100%; }
 	blockquote { margin: 8px 0; padding-left: 12px; border-left: 2px solid #ededed; color: #525252; }
@@ -189,7 +294,7 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 		overflow-wrap: anywhere; }
 	.quote-hidden { display: none; }
 	.email-pixel { display: none !important; width: 0 !important; height: 0 !important; }
-	.divider { border: none; border-top: 1px solid #ededed; margin: 22px 0; }
+	.divider { border: none; border-top: 1px solid #ededed; margin: 0 -16px; }
 	.atts { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
 	.chip { display: inline-flex; align-items: center; gap: 8px; border: 1px solid #e2e2e2;
 		border-radius: 10px; padding: 7px 11px; font-size: 13px; color: #525252; max-width: 100%; }

--- a/mobile/app/utils/threadHtml.ts
+++ b/mobile/app/utils/threadHtml.ts
@@ -1,0 +1,191 @@
+// Builds the single sandboxed HTML document that renders an entire thread inside
+// one WebView. NativeScript has no DOM, so we can't run DOMPurify in-app (as the
+// web does in EmailContent.vue); instead the document carries a strict CSP that
+// blocks all untrusted scripts, inline event handlers and javascript: URLs, and
+// we additionally strip those with regex as a backstop. Only our nonce'd helper
+// script (quote-collapse + external link handling) is allowed to run.
+
+import { formatFullDate, formatRecipients } from '@/utils/format'
+import { gravatarUrl } from '@/utils/gravatar'
+
+import type { Mail } from '@mail/types'
+
+export function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
+function initials(name: string): string {
+	const parts = name.trim().split(/\s+/).filter(Boolean)
+	if (parts.length === 0) return '?'
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+	return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+// Mirrors the web hasHtmlContent (frontend/src/utils/index.ts).
+export function hasHtmlContent(content?: string | null): boolean {
+	if (!content) return false
+	return /<(html|head|body|div|p|span|table|td|tr|a|img|br|hr|h[1-6]|ul|ol|li|strong|em|b|i|font|style)[^>]*>/i.test(
+		content,
+	)
+}
+
+// Regex backstop (the CSP is the real guard): drop scripts, inline event
+// handlers, and javascript:/data:text/html URLs from an untrusted body.
+function sanitizeBody(html: string): string {
+	return html
+		.replace(/<script\b[\s\S]*?<\/script>/gi, '')
+		.replace(/\son\w+\s*=\s*"[^"]*"/gi, '')
+		.replace(/\son\w+\s*=\s*'[^']*'/gi, '')
+		.replace(/\son\w+\s*=\s*[^\s>]+/gi, '')
+		.replace(/(href|src)\s*=\s*("|')\s*javascript:[^"']*\2/gi, '$1=$2#$2')
+		.replace(/(href|src)\s*=\s*("|')\s*data:text\/html[^"']*\2/gi, '$1=$2#$2')
+}
+
+// Colored file-type badge as inline SVG (same look as the list's bundled PNGs),
+// so chips need no external/bundled asset inside the WebView.
+const BADGE = (symbol: string) =>
+	`<svg width="16" height="16" viewBox="0 0 16 16" fill="none">${symbol}</svg>`
+const FILE_ICONS: Record<string, string> = {
+	image: BADGE(
+		'<path fill-rule="evenodd" clip-rule="evenodd" d="M4 1C2.34315 1 1 2.34315 1 4V12C1 13.6569 2.34315 15 4 15H12C13.6569 15 15 13.6569 15 12V4C15 2.34315 13.6569 1 12 1H4ZM5.25002 7C6.21652 7 7.00002 6.2165 7.00002 5.25C7.00002 4.2835 6.21652 3.5 5.25002 3.5C4.28352 3.5 3.50002 4.2835 3.50002 5.25C3.50002 6.2165 4.28352 7 5.25002 7ZM3.67581 14C3.44371 14 3.33689 13.7112 3.51312 13.5602L9.7211 8.23906C9.88705 8.09682 10.1262 8.07885 10.3115 8.19469L13.765 10.3531C13.9112 10.4445 14 10.6047 14 10.7771V12C14 13.1046 13.1046 14 12 14H3.67581Z" fill="#3BBDE5"/>',
+	),
+	pdf: BADGE(
+		'<path fill-rule="evenodd" clip-rule="evenodd" d="M4 1C2.34315 1 1 2.34315 1 4V12C1 13.6569 2.34315 15 4 15H12C13.6569 15 15 13.6569 15 12V4C15 2.34315 13.6569 1 12 1H4ZM5.80893 10.6773C4.63445 12.7569 4.02298 13 3.66401 13C3.48964 13 3.32827 12.9308 3.19736 12.7999C3.03677 12.6393 2.97231 12.4388 3.01087 12.22C3.14435 11.4651 4.55054 10.6893 5.4324 10.2721C5.74113 9.71489 6.06198 9.07811 6.3865 8.37778C6.67422 7.757 6.93539 7.12033 7.14466 6.52956C6.69545 5.46922 6.34749 4.03811 6.79536 3.35278C6.94617 3.122 7.17178 3 7.44773 3C7.69489 3 7.89782 3.10178 8.03485 3.29411C8.38115 3.78089 8.27179 4.86178 7.70989 6.50744C7.91738 6.96589 8.16155 7.39778 8.43672 7.79256C8.72956 8.21311 9.15365 8.61222 9.6671 8.95089C10.1745 8.87467 10.6485 8.836 11.0775 8.836C11.9395 8.836 12.5214 8.98744 12.8068 9.28622C12.9413 9.42689 13.0078 9.59978 12.9993 9.78656C12.993 9.92289 12.9118 10.3681 12.1247 10.3681C11.4129 10.3681 10.413 10.03 9.55263 9.50189C9.03074 9.58889 8.49662 9.71311 7.96295 9.87111C7.22857 10.0888 6.48574 10.3669 5.80893 10.6773ZM12.426 9.64967C12.3616 9.58222 12.074 9.36233 11.0774 9.36233C10.879 9.36233 10.6699 9.37122 10.4512 9.38878C11.1161 9.69889 11.7339 9.84167 12.1246 9.84167C12.3747 9.84167 12.4628 9.78422 12.4728 9.76867C12.4747 9.73267 12.4702 9.69578 12.426 9.64967ZM7.44773 3.52633C7.35182 3.52633 7.28847 3.56056 7.23612 3.64067C7.04864 3.92744 7.06575 4.717 7.40427 5.73189C7.77046 4.48589 7.76013 3.81611 7.60576 3.59911C7.57464 3.55544 7.53586 3.52633 7.44773 3.52633ZM7.4485 7.22411C7.27413 7.67544 7.07609 8.14167 6.86415 8.599C6.65 9.06144 6.43706 9.49711 6.22779 9.90133L6.24869 9.89156L6.23213 9.92122C6.74613 9.71222 7.28214 9.524 7.81347 9.36656C8.17722 9.25878 8.54163 9.16611 8.9026 9.08967L8.88004 9.07522L8.93283 9.067C8.56019 8.76833 8.24479 8.43822 8.00463 8.09333C7.81014 7.81411 7.63021 7.51789 7.46662 7.20767L7.45551 7.23978L7.4485 7.22411ZM4.93196 11.1197C4.02443 11.6269 3.57288 12.0651 3.52932 12.3116C3.52209 12.3526 3.52643 12.3846 3.56955 12.4279C3.60989 12.4681 3.63879 12.4737 3.66401 12.4737C3.74059 12.4737 4.11922 12.3991 4.93196 11.1197Z" fill="#E03636"/>',
+	),
+	video: BADGE(
+		'<path fill-rule="evenodd" clip-rule="evenodd" d="M4 1C2.34315 1 1 2.34315 1 4V12C1 13.6569 2.34315 15 4 15H12C13.6569 15 15 13.6569 15 12V4C15 2.34315 13.6569 1 12 1H4ZM7.09287 10.8763L10.7212 8.47937C10.8945 8.37679 11 8.19537 11 8C11 7.80463 10.8945 7.62321 10.7212 7.52063L7.09287 5.12375C6.891 4.9855 6.62753 4.96127 6.40197 5.06021C6.17641 5.15916 6.02312 5.36619 6 5.60313V10.3969C6.02312 10.6338 6.17641 10.8408 6.40197 10.9398C6.62753 11.0387 6.891 11.0145 7.09287 10.8763Z" fill="#E86C13"/>',
+	),
+	audio: BADGE(
+		'<path fill-rule="evenodd" clip-rule="evenodd" d="M4 1C2.34315 1 1 2.34315 1 4V12C1 13.6569 2.34315 15 4 15H12C13.6569 15 15 13.6569 15 12V4C15 2.34315 13.6569 1 12 1H4ZM9.99364 3.86769C10.2674 3.82819 10.5444 3.91261 10.7509 4.09842C10.9528 4.28078 11.0669 4.54233 11.0638 4.81589V10.3381C11.0638 11.0366 10.3629 11.6024 9.49922 11.6024C8.63555 11.6024 7.93461 11.0366 7.93461 10.3381C7.93461 9.6396 8.63555 9.07384 9.49922 9.07384C9.82973 9.07182 10.1544 9.16147 10.438 9.33302V5.64521L6.68293 6.18569V10.8776C6.68293 11.5761 5.98198 12.1418 5.11832 12.1418C4.25465 12.1418 3.55371 11.5761 3.55371 10.8776C3.55371 10.1791 4.25465 9.61332 5.11832 9.61332C5.44883 9.6113 5.77354 9.70094 6.05708 9.87249V5.26786C6.05245 4.79193 6.39784 4.38627 6.86442 4.31966L9.99364 3.86769Z" fill="#9C45E3"/>',
+	),
+	file: BADGE(
+		'<path d="M4 1C2.34315 1 1 2.34315 1 4V12C1 13.6569 2.34315 15 4 15H12C13.6569 15 15 13.6569 15 12V4C15 2.34315 13.6569 1 12 1H4Z" fill="#A3A3A3"/>',
+	),
+}
+function fileIconSvg(type: string): string {
+	if (type.startsWith('image/')) return FILE_ICONS.image
+	if (type === 'application/pdf') return FILE_ICONS.pdf
+	if (type.startsWith('video/')) return FILE_ICONS.video
+	if (type.startsWith('audio/')) return FILE_ICONS.audio
+	return FILE_ICONS.file
+}
+
+// Mirrors the web filteredAttachments: real attachments (skip inline images).
+function attachmentChips(mail: Mail): string {
+	const atts = (mail.attachments || []).filter(
+		(a) => a.filename && (a.disposition === 'attachment' || !a.type?.startsWith('image/')),
+	)
+	if (!atts.length) return ''
+	const chips = atts
+		.map(
+			(a) =>
+				`<div class="chip">${fileIconSvg(a.type || '')}<span>${escapeHtml(a.filename)}</span></div>`,
+		)
+		.join('')
+	return `<div class="atts">${chips}</div>`
+}
+
+function messageHtml(mail: Mail): string {
+	const name = mail.from_name || mail.from_email || '?'
+	const avatar =
+		`<div class="avatar"><span>${escapeHtml(initials(name))}</span>` +
+		`<img src="${escapeHtml(gravatarUrl(mail.from_email || ''))}" alt=""></div>`
+	const emailTag = mail.from_email
+		? ` <span class="email">&lt;${escapeHtml(mail.from_email)}&gt;</span>`
+		: ''
+	const meta =
+		`<div class="meta"><div class="from">${escapeHtml(name)}${emailTag}</div>` +
+		`<div class="to">${escapeHtml(formatRecipients(mail.recipients || []))} &middot; ${escapeHtml(formatFullDate(mail.received_at))}</div></div>`
+	const body = hasHtmlContent(mail.html_body)
+		? `<div class="body">${sanitizeBody(mail.html_body)}</div>`
+		: `<div class="body"><pre>${escapeHtml(mail.html_body || mail.text_body || '')}</pre></div>`
+	return `<div class="msg"><div class="mhead">${avatar}${meta}</div>${body}${attachmentChips(mail)}</div>`
+}
+
+export function buildThreadDocument(mails: Mail[], subject: string): string {
+	// Per-load nonce so only our own inline script is allowed by the CSP.
+	const nonce = Math.random().toString(36).slice(2)
+	const messages = mails.map(messageHtml).join('<hr class="divider">')
+
+	const csp =
+		"default-src 'none'; img-src http: https: data: cid:; style-src 'unsafe-inline'; " +
+		`font-src data: https:; script-src 'nonce-${nonce}';`
+
+	const script = `
+		(function () {
+			document.querySelectorAll('.gmail_quote, .frappe_mail_quote').forEach(function (q) {
+				q.classList.add('quote-hidden');
+				var b = document.createElement('button');
+				b.className = 'collapse-btn'; b.textContent = '\\u00b7\\u00b7\\u00b7';
+				b.addEventListener('click', function () { q.classList.toggle('quote-hidden'); });
+				q.parentNode && q.parentNode.insertBefore(b, q);
+			});
+			document.querySelectorAll('img[width="1"], img[height="1"]').forEach(function (i) {
+				i.className += ' email-pixel';
+			});
+			document.addEventListener('click', function (e) {
+				var a = e.target && e.target.closest && e.target.closest('a');
+				if (a && a.getAttribute('href')) {
+					e.preventDefault();
+					location.href = 'x-open:' + encodeURIComponent(a.href);
+				}
+			});
+		})();
+	`
+
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<style>
+	* { box-sizing: border-box; }
+	body { font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif; font-size: 15px;
+		line-height: 1.5; color: #171717; margin: 0; padding: 16px 16px 96px;
+		-webkit-text-size-adjust: 100%; overflow-wrap: anywhere; }
+	.subject { font-size: 22px; font-weight: 700; line-height: 1.3; margin: 4px 0 18px; }
+	.msg { padding: 2px 0; }
+	.mhead { display: flex; gap: 12px; align-items: center; margin: 14px 0 12px; }
+	.avatar { position: relative; width: 40px; height: 40px; border-radius: 40px;
+		background: #F3F3F3; flex-shrink: 0; overflow: hidden; }
+	.avatar span { position: absolute; inset: 0; display: flex; align-items: center;
+		justify-content: center; font-size: 14px; font-weight: 600; color: #525252; }
+	.avatar img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+	.meta { min-width: 0; flex: 1; }
+	.from { font-size: 15px; font-weight: 600; color: #171717; }
+	.from .email { font-weight: 400; color: #7c7c7c; }
+	.to { font-size: 13px; color: #7c7c7c; margin-top: 2px; word-break: break-word; }
+	.body { font-size: 15px; line-height: 1.6; color: #383838; }
+	.body img { max-width: 100%; height: auto; }
+	.body table { max-width: 100%; }
+	blockquote { margin: 8px 0; padding-left: 12px; border-left: 2px solid #ededed; color: #525252; }
+	pre, code { font-family: ui-monospace, Menlo, Courier, monospace; white-space: pre-wrap;
+		overflow-wrap: anywhere; }
+	.quote-hidden { display: none; }
+	.email-pixel { display: none !important; width: 0 !important; height: 0 !important; }
+	.divider { border: none; border-top: 1px solid #ededed; margin: 22px 0; }
+	.atts { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 14px; }
+	.chip { display: inline-flex; align-items: center; gap: 8px; border: 1px solid #e2e2e2;
+		border-radius: 10px; padding: 7px 11px; font-size: 13px; color: #525252; max-width: 100%; }
+	.chip svg { flex-shrink: 0; }
+	.chip span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.collapse-btn { background: #F3F3F3; color: #383838; border: none; padding: 1px 8px;
+		border-radius: 8px; margin: 12px 0; font-size: 14px; line-height: 1.4; }
+	@media (max-width: 640px) {
+		table[width="600"], table[width="600px"] { width: 100% !important; }
+	}
+</style>
+</head>
+<body>
+	<div class="subject">${escapeHtml(subject || '[No subject]')}</div>
+	${messages}
+	<script nonce="${nonce}">${script}</script>
+</body>
+</html>`
+}

--- a/mobile/app/utils/threadHtml.ts
+++ b/mobile/app/utils/threadHtml.ts
@@ -103,7 +103,7 @@ function messageHtml(mail: Mail, index: number, isLast: boolean): string {
 	const preview = `<div class="preview">${escapeHtml(mail.preview || '')}</div>`
 	const body = hasHtmlContent(mail.html_body)
 		? `<div class="body">${sanitizeBody(mail.html_body)}</div>`
-		: `<div class="body"><pre>${escapeHtml(mail.html_body || mail.text_body || '')}</pre></div>`
+		: `<div class="body"><pre class="plaintext">${escapeHtml(mail.html_body || mail.text_body || '')}</pre></div>`
 	// Seen messages start collapsed (preview only); the last message and unseen
 	// messages stay expanded — mirrors the web MailThread isCollapsed logic.
 	const collapsible = !isLast
@@ -292,6 +292,8 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 	blockquote { margin: 8px 0; padding-left: 12px; border-left: 2px solid #ededed; color: #525252; }
 	pre, code { font-family: ui-monospace, Menlo, Courier, monospace; white-space: pre-wrap;
 		overflow-wrap: anywhere; }
+	/* text/plain bodies: keep newlines but render in the regular (sans-serif) font. */
+	.plaintext { font-family: inherit; margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
 	.quote-hidden { display: none; }
 	.email-pixel { display: none !important; width: 0 !important; height: 0 !important; }
 	.divider { border: none; border-top: 1px solid #ededed; margin: 0 -16px; }

--- a/mobile/app/utils/threadHtml.ts
+++ b/mobile/app/utils/threadHtml.ts
@@ -5,7 +5,7 @@
 // we additionally strip those with regex as a backstop. Only our nonce'd helper
 // script (quote-collapse + external link handling) is allowed to run.
 
-import { formatFullDate, formatRecipients } from '@/utils/format'
+import { formatRecipients, formatTimeAgo } from '@/utils/format'
 import { gravatarUrl } from '@/utils/gravatar'
 
 import type { Mail } from '@mail/types'
@@ -90,27 +90,26 @@ function attachmentChips(mail: Mail): string {
 	return `<div class="atts">${chips}</div>`
 }
 
-function messageHtml(mail: Mail): string {
+function messageHtml(mail: Mail, index: number): string {
 	const name = mail.from_name || mail.from_email || '?'
 	const avatar =
 		`<div class="avatar"><span>${escapeHtml(initials(name))}</span>` +
 		`<img src="${escapeHtml(gravatarUrl(mail.from_email || ''))}" alt=""></div>`
-	const emailTag = mail.from_email
-		? ` <span class="email">&lt;${escapeHtml(mail.from_email)}&gt;</span>`
-		: ''
 	const meta =
-		`<div class="meta"><div class="from">${escapeHtml(name)}${emailTag}</div>` +
-		`<div class="to">${escapeHtml(formatRecipients(mail.recipients || []))} &middot; ${escapeHtml(formatFullDate(mail.received_at))}</div></div>`
+		`<div class="meta"><div class="from"><span class="from-name">${escapeHtml(name)}</span>` +
+		`<span class="date">${escapeHtml(formatTimeAgo(mail.received_at))}</span></div>` +
+		`<div class="to">${escapeHtml(formatRecipients(mail.recipients || []))}</div></div>`
+	const more = `<span class="more" data-i="${index}">&#8942;</span>`
 	const body = hasHtmlContent(mail.html_body)
 		? `<div class="body">${sanitizeBody(mail.html_body)}</div>`
 		: `<div class="body"><pre>${escapeHtml(mail.html_body || mail.text_body || '')}</pre></div>`
-	return `<div class="msg"><div class="mhead">${avatar}${meta}</div>${body}${attachmentChips(mail)}</div>`
+	return `<div class="msg"><div class="mhead">${avatar}${meta}${more}</div>${body}${attachmentChips(mail)}</div>`
 }
 
 export function buildThreadDocument(mails: Mail[], subject: string): string {
 	// Per-load nonce so only our own inline script is allowed by the CSP.
 	const nonce = Math.random().toString(36).slice(2)
-	const messages = mails.map(messageHtml).join('<hr class="divider">')
+	const messages = mails.map((m, i) => messageHtml(m, i)).join('<hr class="divider">')
 
 	const csp =
 		"default-src 'none'; img-src http: https: data: cid:; style-src 'unsafe-inline'; " +
@@ -118,6 +117,12 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 
 	const script = `
 		(function () {
+			// Reveal avatar images only once they load — a broken/404 gravatar stays
+			// hidden so the initials underneath show (we can't use onerror under CSP).
+			document.querySelectorAll('.avatar img').forEach(function (img) {
+				function show() { if (img.naturalWidth > 0) img.style.display = 'block'; }
+				if (img.complete) show(); else img.addEventListener('load', show);
+			});
 			document.querySelectorAll('.gmail_quote, .frappe_mail_quote').forEach(function (q) {
 				q.classList.add('quote-hidden');
 				var b = document.createElement('button');
@@ -127,6 +132,12 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 			});
 			document.querySelectorAll('img[width="1"], img[height="1"]').forEach(function (i) {
 				i.className += ' email-pixel';
+			});
+			document.querySelectorAll('.more').forEach(function (el) {
+				el.addEventListener('click', function (e) {
+					e.preventDefault();
+					location.href = 'x-more:' + (el.getAttribute('data-i') || '');
+				});
 			});
 			document.addEventListener('click', function (e) {
 				var a = e.target && e.target.closest && e.target.closest('a');
@@ -146,21 +157,30 @@ export function buildThreadDocument(mails: Mail[], subject: string): string {
 <meta http-equiv="Content-Security-Policy" content="${csp}">
 <style>
 	* { box-sizing: border-box; }
+	/* Guard our chrome from a message's own <style> (e.g. body{background}/body{color}),
+	   which targets this single document's body since we render the thread in one doc. */
+	html body { background-color: #ffffff !important; }
 	body { font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif; font-size: 15px;
 		line-height: 1.5; color: #171717; margin: 0; padding: 16px 16px 96px;
 		-webkit-text-size-adjust: 100%; overflow-wrap: anywhere; }
-	.subject { font-size: 22px; font-weight: 700; line-height: 1.3; margin: 4px 0 18px; }
+	.subject { color: #171717; font-size: 22px; font-weight: 700; line-height: 1.3; margin: 4px 0 18px; }
 	.msg { padding: 2px 0; }
 	.mhead { display: flex; gap: 12px; align-items: center; margin: 14px 0 12px; }
 	.avatar { position: relative; width: 40px; height: 40px; border-radius: 40px;
 		background: #F3F3F3; flex-shrink: 0; overflow: hidden; }
 	.avatar span { position: absolute; inset: 0; display: flex; align-items: center;
 		justify-content: center; font-size: 14px; font-weight: 600; color: #525252; }
-	.avatar img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+	.avatar img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;
+		display: none; }
 	.meta { min-width: 0; flex: 1; }
-	.from { font-size: 15px; font-weight: 600; color: #171717; }
-	.from .email { font-weight: 400; color: #7c7c7c; }
+	.from { display: flex; align-items: baseline; gap: 8px; }
+	.from-name { flex: 1; min-width: 0; font-size: 15px; font-weight: 600; color: #171717;
+		overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.date { flex-shrink: 0; font-size: 13px; font-weight: 400; color: #7c7c7c; }
 	.to { font-size: 13px; color: #7c7c7c; margin-top: 2px; word-break: break-word; }
+	.more { flex-shrink: 0; align-self: flex-start; width: 24px; height: 24px; margin-left: 2px;
+		display: flex; align-items: center; justify-content: center; color: #7c7c7c;
+		font-size: 17px; line-height: 1; border-radius: 24px; }
 	.body { font-size: 15px; line-height: 1.6; color: #383838; }
 	.body img { max-width: 100%; height: auto; }
 	.body table { max-width: 100%; }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -65,6 +65,7 @@ export interface Mail {
 	subject: string
 	html_body: string
 	text_body: string
+	preview: string | null
 	received_at: string
 	draft: 0 | 1
 	flagged: 0 | 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,6 +382,11 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
+"@nativescript-community/ui-pulltorefresh@^2.5.11":
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/@nativescript-community/ui-pulltorefresh/-/ui-pulltorefresh-2.5.11.tgz#bb0e4de2c2c87033c9976ce442f0dec5225e36b9"
+  integrity sha512-Z0pI4Xpf+G9AtvcpZUQdXy0Vt+IPaxWJYkeC+2cXyzZJpfMWLmI29MyOWEbx8p2uvgFEl9+NLoYUiy3Gv8HaEA==
+
 "@nativescript/android@~8.9.0":
   version "8.9.2"
   resolved "https://registry.yarnpkg.com/@nativescript/android/-/android-8.9.2.tgz#ed2027a0dac8808ce3bf04787b950e1bec89b97d"
@@ -656,6 +661,11 @@
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
   dependencies:
     tslib "^2.4.0"
+
+"@types/blueimp-md5@^2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@types/blueimp-md5/-/blueimp-md5-2.18.2.tgz#4fd6fb720990b22229c30b3e06f61e6ec2ef92b8"
+  integrity sha512-dJ9yRry9Olt5GAWlgCtE5dK9d/Dfhn/V7hna86eEO2Pn76+E8Y0S0n61iEUEGhWXXgtKtHxtZLVNwL8X+vLHzg==
 
 "@types/cors@^2.8.12":
   version "2.8.19"
@@ -1455,6 +1465,11 @@ binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+blueimp-md5@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.19.0.tgz#b53feea5498dcb53dc6ec4b823adb84b729c4af0"
+  integrity sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==
 
 body-parser@~1.20.5:
   version "1.20.5"


### PR DESCRIPTION
Closes frappe/mail#489. **Stacked on frappe/mail#504 (#488)** — review the `mobile/489-thread-detail` commits, or after frappe/mail#504 merges this diff narrows to just the detail view.

Turns the `ThreadView` placeholder into the real **thread reading** screen.

## Rendering
- The whole thread renders as one sandboxed **WebView** document (NativeScript has no DOM, so DOMPurify can't run in-app). A strict **CSP** (`script-src` nonce-only) blocks untrusted scripts, inline handlers, and `javascript:` URLs; a regex backstop strips them too. Only a nonce'd helper runs (quote-collapse, links, collapse toggles).
- Per message: avatar (gravatar→initials, CSS-layered), sender, recipients, relative date (`MailDate`-style), HTML body or sans-serif plain text, attachment chips (inline colored SVG badges), and a "⋮" more button.
- Subject = the **first** message's subject. App chrome is guarded from a message's own `<style>` (forced white background, etc.).

## Reading UX (mirrors web `MailThread`)
- **Collapse** seen, non-last messages to a preview line (last + unseen stay expanded); tap a collapsed message to expand, tap the header to collapse.
- **"N new messages"** marker (bordered blue pill) above the first unseen message.
- **Collapsed group**: hide the middle seen messages behind a "N more messages" pill when there are ≥4 seen, non-last messages; tap to reveal (no refetch).
- Marks the thread seen on open; links open in the system browser.

## Chrome & actions
- Back + archive/trash/more (placeholders); bottom **Reply / Reply all (when needed) / Forward** bar → toasts (compose is frappe/mail#490; attachment download is frappe/suite#63).
- Android: hide the WebView zoom widget, render on a software layer (no white flash on back), and remove the tap-highlight.

## Notes for reviewers
- Adds `blueimp-md5` + `@nativescript-community/ui-pulltorefresh` (carried from frappe/mail#488), recorded in `yarn.lock`.
- Pure-frontend; no backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)