### PR TITLE
fix(mergify): allow PR authors to run the backport command

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,3 +35,13 @@ pull_request_rules:
           - v1
         assignees:
           - "{{ author }}"
+
+commands_restrictions:
+  # By default Mergify only lets users with write access run `@Mergifyio backport`, so a PR
+  # author commenting the backport command on their own merged PR is silently ignored. Allow the
+  # author to backport their own PR in addition to maintainers.
+  backport:
+    conditions:
+      - or:
+          - sender-permission>=write
+          - sender={{ author }}


### PR DESCRIPTION
## Problem

The merged-PR comment tells contributors to comment `@Mergifyio backport v0` / `v1`, but commenting it doesn't open a backport PR.

Mergify's **default** restriction on the `backport` command is `sender-permission >= write` (unlike `rebase`/`update`, there is no author exception). So when a contributor's PR is merged and they follow the bot's instructions, the command is **silently ignored** because they don't have write access — no backport PR is created.

## Fix

Add a `commands_restrictions` block so the **PR author** can run the backport command on their own merged PR, in addition to maintainers:

```yaml
commands_restrictions:
  backport:
    conditions:
      - or:
          - sender-permission>=write
          - sender={{ author }}
```

The existing label-triggered `backport to v0/v1` rules and the instruction comment are unchanged.

## Heads-up (not addressed here)

The `v1` branch doesn't currently exist in this repo (`v0` does), so `@Mergifyio backport v1` will fail regardless until that branch is created — or the `v1` references should be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)