### PR TITLE
fix: prevent duplicate blank compose box in open thread

### DIFF
--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -558,9 +558,14 @@ const syncWithSource = () => {
 		if (fresh) mail.mailboxes = fresh.mailboxes
 	})
 
-	// Append any newly-arrived messages, before a trailing draft.
+	// Append any newly-arrived messages, before a trailing draft. Drafts are excluded: the only draft
+	// that belongs in an open thread is the one being composed locally (tracked as a `draft:` item whose
+	// saved id isn't known here), so a draft returning from a background reload would otherwise be
+	// mistaken for a new message and spawn a duplicate, blank compose editor.
 	const existing = new Set(thread.value.map((mail) => mail.id))
-	const additions = transformThreadMails(source).filter((mail) => !existing.has(mail.id))
+	const additions = transformThreadMails(source).filter(
+		(mail) => !existing.has(mail.id) && !mail.draft,
+	)
 	if (!additions.length) return
 
 	const draftIndex = thread.value.findIndex((mail) => mail.draft)

--- a/frontend/src/components/ThreadHeader.vue
+++ b/frontend/src/components/ThreadHeader.vue
@@ -153,10 +153,14 @@ const threadMailboxes = computed(() => {
 // Every mailbox the thread's mails touch (union), and whether any mail is in more than one — used by
 // Remove From, which is only offered when removing won't orphan a mail.
 const threadMailboxesUnion = computed(() => [
-	...new Set((thread ?? []).flatMap((mail: Mail) => mail.mailboxes.map((m) => m.mailbox_id))),
+	...new Set(
+		(thread ?? [])
+			.filter((mail: Mail) => mail.id)
+			.flatMap((mail: Mail) => mail.mailboxes.map((m) => m.mailbox_id)),
+	),
 ])
 const canRemoveFrom = computed(() =>
-	(thread ?? []).some((mail: Mail) => mail.mailboxes.length > 1),
+	(thread ?? []).some((mail: Mail) => mail.id && mail.mailboxes.length > 1),
 )
 
 const threadActions = computed((): Action[] => [


### PR DESCRIPTION
### Problem

While composing an inline reply to a thread, a second **blank** compose box (empty "To", subject, body) randomly pops up. Reported with a screen recording; the "randomly" is the 30s background poll (and realtime mailbox updates) firing mid-compose.

### Root cause

1. Clicking Reply creates a **local-only** thread item named `draft:<sourceMail>` with **no `id`** and renders a `ComposeMailEditor` for it.
2. Autosave (2s debounce) saves it to the backend, which assigns a real `id` — but that id is only written to the editor's internal copy, never back to the thread item / `draftMails`.
3. `MailboxView` reloads `get_threads` every 30s; the response includes the now-saved draft. `MailThread.syncWithSource()` compares by `id`, doesn't recognise the local draft (id `undefined`), and appends the backend draft as a "newly-arrived message".
4. That item has `draft: 1`, so a **second** editor renders — but its `draftMails` entry was never populated, hence the blank "To".

A related crash surfaced in the same flow: `ThreadHeader`'s `threadMailboxesUnion` / `canRemoveFrom` iterate every mail and read `mail.mailboxes.length`, but the unsaved local draft has no `mailboxes` field → `Cannot read properties of undefined (reading 'length')` (plus a cascading `Cannot set properties of null (setting '__vnode')`).

### Fix

- `syncWithSource`: exclude drafts from the appended additions — the only draft that belongs in an open thread is the one being composed locally.
- `ThreadHeader`: guard `threadMailboxesUnion` and `canRemoveFrom` against items without an `id`, mirroring the existing `mail.id` guard in `threadMailboxes`.

### Testing

Open a thread, click Reply, type, and wait ~30s (or trigger a list refresh). Before: a blank second compose appears and the console throws. After: only the reply box remains, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)