### PR TITLE
fix: prevent duplicate blank compose box in open thread (v1 backport)

### DIFF
--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -558,9 +558,14 @@ const syncWithSource = () => {
 		if (fresh) mail.mailboxes = fresh.mailboxes
 	})
 
-	// Append any newly-arrived messages, before a trailing draft.
+	// Append any newly-arrived messages, before a trailing draft. Drafts are excluded: the only draft
+	// that belongs in an open thread is the one being composed locally (tracked as a `draft:` item whose
+	// saved id isn't known here), so a draft returning from a background reload would otherwise be
+	// mistaken for a new message and spawn a duplicate, blank compose editor.
 	const existing = new Set(thread.value.map((mail) => mail.id))
-	const additions = transformThreadMails(source).filter((mail) => !existing.has(mail.id))
+	const additions = transformThreadMails(source).filter(
+		(mail) => !existing.has(mail.id) && !mail.draft,
+	)
 	if (!additions.length) return
 
 	const draftIndex = thread.value.findIndex((mail) => mail.draft)

--- a/frontend/src/components/ThreadHeader.vue
+++ b/frontend/src/components/ThreadHeader.vue
@@ -153,10 +153,14 @@ const threadMailboxes = computed(() => {
 // Every mailbox the thread's mails touch (union), and whether any mail is in more than one — used by
 // Remove From, which is only offered when removing won't orphan a mail.
 const threadMailboxesUnion = computed(() => [
-	...new Set((thread ?? []).flatMap((mail: Mail) => mail.mailboxes.map((m) => m.mailbox_id))),
+	...new Set(
+		(thread ?? [])
+			.filter((mail: Mail) => mail.id)
+			.flatMap((mail: Mail) => mail.mailboxes.map((m) => m.mailbox_id)),
+	),
 ])
 const canRemoveFrom = computed(() =>
-	(thread ?? []).some((mail: Mail) => mail.mailboxes.length > 1),
+	(thread ?? []).some((mail: Mail) => mail.id && mail.mailboxes.length > 1),
 )
 
 const threadActions = computed((): Action[] => [


### PR DESCRIPTION
Backport of #518 to `v1`.

### Problem
While composing an inline reply, a background thread reload (the 30s poll, or a realtime mailbox update) could spawn a second, blank `ComposeMailEditor` (empty To/subject/body), plus a `Cannot read properties of undefined (reading 'length')` crash in `ThreadHeader`.

### Fix
- `syncWithSource`: exclude drafts from the appended additions — the only draft that belongs in an open thread is the one being composed locally (whose saved id isn't propagated back, so it isn't recognised on reload).
- `ThreadHeader`: guard `threadMailboxesUnion` and `canRemoveFrom` against the unsaved local draft (no `mailboxes` field), mirroring the existing `mail.id` guard in `threadMailboxes`.

See #518 for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)