### PR TITLE
feat: reorder thread actions to mirror Gmail (backport v0)

### DIFF
--- a/frontend/src/components/ThreadHeader.vue
+++ b/frontend/src/components/ThreadHeader.vue
@@ -37,6 +37,13 @@
 					</Button>
 				</template>
 
+				<Dropdown :options="moveToOptions">
+					<Button variant="ghost" :tooltip="__('Move To')">
+						<template #icon>
+							<FolderInput class="icon" />
+						</template>
+					</Button>
+				</Dropdown>
 				<Dropdown v-if="showAddTo" :options="addToOptions">
 					<Button variant="ghost" :tooltip="__('Add To')">
 						<template #icon>
@@ -48,13 +55,6 @@
 					<Button variant="ghost" :tooltip="__('Remove From')">
 						<template #icon>
 							<FolderMinus class="icon" />
-						</template>
-					</Button>
-				</Dropdown>
-				<Dropdown :options="moveToOptions">
-					<Button variant="ghost" :tooltip="__('Move To')">
-						<template #icon>
-							<FolderInput class="icon" />
 						</template>
 					</Button>
 				</Dropdown>
@@ -183,12 +183,6 @@ const threadActions = computed((): Action[] => [
 		condition: () => thread.every((m) => m.flagged),
 	},
 	{
-		label: __('Mark as Unread (U)'),
-		onClick: () => emit('setSeen', false),
-		icon: MailIcon,
-		condition: () => true,
-	},
-	{
 		label: __('Archive Thread (E)'),
 		onClick: () =>
 			emit(
@@ -224,6 +218,12 @@ const threadActions = computed((): Action[] => [
 		onClick: () => emit('deleteThread'),
 		icon: Trash2,
 		condition: () => threadMailboxes.value.includes(mailboxIds.trash),
+	},
+	{
+		label: __('Mark as Unread (U)'),
+		onClick: () => emit('setSeen', false),
+		icon: MailIcon,
+		condition: () => true,
 	},
 ])
 

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -140,6 +140,16 @@
 							</template>
 						</template>
 
+						<Dropdown
+							v-if="!!selections.length && !['search', 'starred'].includes(mailbox)"
+							:options="moveToOptions"
+						>
+							<Button variant="ghost" :tooltip="__('Move To')">
+								<template #icon>
+									<component :is="FolderInput" class="icon" />
+								</template>
+							</Button>
+						</Dropdown>
 						<Dropdown v-if="showAddTo" :options="addToOptions">
 							<Button variant="ghost" :tooltip="__('Add To')">
 								<template #icon>
@@ -151,16 +161,6 @@
 							<Button variant="ghost" :tooltip="__('Remove From')">
 								<template #icon>
 									<component :is="FolderMinus" class="icon" />
-								</template>
-							</Button>
-						</Dropdown>
-						<Dropdown
-							v-if="!!selections.length && !['search', 'starred'].includes(mailbox)"
-							:options="moveToOptions"
-						>
-							<Button variant="ghost" :tooltip="__('Move To')">
-								<template #icon>
-									<component :is="FolderInput" class="icon" />
 								</template>
 							</Button>
 						</Dropdown>
@@ -756,28 +756,6 @@ const selectActions = computed((): SelectAction[] => [
 			),
 	},
 	{
-		label: __('Mark as Read (Shift+U)'),
-		onClick: () => handleSetSeen({ 1: selections.value }),
-		icon: MailOpen,
-		condition: () =>
-			selections.value.some(
-				(threadID) =>
-					threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
-						?.seen === 0,
-			),
-	},
-	{
-		label: __('Mark as Unread (U)'),
-		onClick: () => handleSetSeen({ 0: selections.value }),
-		icon: MailIcon,
-		condition: () =>
-			selections.value.some(
-				(threadID) =>
-					threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
-						?.seen === 1,
-			),
-	},
-	{
 		label: __('Archive Threads (E)'),
 		onClick: () =>
 			mailbox === mailboxIds.sent
@@ -820,6 +798,28 @@ const selectActions = computed((): SelectAction[] => [
 		onClick: () => junkOrDeleteThreads(selections.value, false),
 		icon: Trash2,
 		condition: () => mailbox === mailboxIds.trash,
+	},
+	{
+		label: __('Mark as Read (Shift+U)'),
+		onClick: () => handleSetSeen({ 1: selections.value }),
+		icon: MailOpen,
+		condition: () =>
+			selections.value.some(
+				(threadID) =>
+					threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
+						?.seen === 0,
+			),
+	},
+	{
+		label: __('Mark as Unread (U)'),
+		onClick: () => handleSetSeen({ 0: selections.value }),
+		icon: MailIcon,
+		condition: () =>
+			selections.value.some(
+				(threadID) =>
+					threadsResource.value?.data?.find((t: Thread) => t.thread_id === threadID)
+						?.seen === 1,
+			),
 	},
 ])
 


### PR DESCRIPTION
Backport of #530 to v0.

Reorders thread and selection action items to mirror Gmail's ordering — Move To before Add To/Label, and Mark as Read/Unread moved to the end of the action list. Only the Vue changes are backported (the develop-only auto-generated type drift in `doctypes.ts` is omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)