### PR TITLE
feat: sign out and redirect on auth errors (backport #536 to v0)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,11 +10,31 @@ import router from '@/router'
 import { initSocket } from '@/socket'
 import translationPlugin from '@/translation'
 import dayjs from '@/utils/dayjs'
+import { sessionStore } from '@/stores/session'
 import { userStore } from '@/stores/user'
 
 import FrappePushNotification from '../public/frappe-push-notification'
 
-setConfig('resourceFetcher', frappeRequest)
+// Centralised auth handling: any request that comes back unauthenticated signs the user
+// out and redirects to login, so they can't keep composing/acting against a dead session.
+setConfig('resourceFetcher', async (options: Parameters<typeof frappeRequest>[0]) => {
+	try {
+		return await frappeRequest(options)
+	} catch (error) {
+		// A dead session surfaces as AuthenticationError or (for non-guest methods)
+		// PermissionError "Login to access". If the session is actually gone, swallow the
+		// error so the resource doesn't also toast it — we've shown "signed out" and are
+		// redirecting to login. A genuine PermissionError for a logged-in user re-throws and
+		// surfaces normally. Never-settling promise → the resource's onSuccess/onError won't fire.
+		const excType = (error as { exc_type?: string })?.exc_type
+		if (
+			(excType === 'AuthenticationError' || excType === 'PermissionError') &&
+			sessionStore().handleSessionExpired()
+		)
+			return new Promise<never>(() => {})
+		throw error
+	}
+})
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
 
 import router from '@/router'
+import { raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
 
 export const sessionStore = defineStore('mail-session', () => {
@@ -51,5 +52,26 @@ export const sessionStore = defineStore('mail-session', () => {
 		onSuccess: (data) => (document.querySelector("link[rel='icon']").href = data.favicon),
 	})
 
-	return { isLoggedIn, login, logout, branding }
+	// Called when a request fails with an auth/permission error. Returns true if the session
+	// is actually gone (so the caller can swallow the error and avoid a duplicate toast),
+	// false if the session is still alive — i.e. a genuine PermissionError that should surface
+	// normally. Frappe resets the user_id cookie to Guest on a dead session, so the cookie is
+	// the discriminator. Signs out + notifies + redirects once; later concurrent calls just
+	// report handled.
+	const handleSessionExpired = (): boolean => {
+		// Still logged in — this is a real permission error, not a logout.
+		if (sessionUser()) return false
+
+		if (user.value) {
+			user.value = null
+			userResource.reset()
+			mailboxes.reset()
+			raiseToast(__('You have been signed out. Please sign in again.'), 'error')
+			if (!router.currentRoute.value.meta?.isLogin) router.replace({ name: 'Login' })
+		}
+
+		return true
+	}
+
+	return { isLoggedIn, login, logout, branding, handleSessionExpired }
 })

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -2,8 +2,6 @@ import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
 
-import router from '@/router'
-
 import type { UserAccount, UserResource } from '@/types'
 
 export type MailboxRole = 'inbox' | 'sent' | 'drafts' | 'trash' | 'junk' | 'archive' | 'important'
@@ -51,9 +49,7 @@ export const userStore = defineStore('mail-user', () => {
 			if (data?.is_mail_admin) domains.fetch()
 			resolveAccount(data?.accounts)
 		},
-		onError: (error) => {
-			if (error && error.exc_type === 'AuthenticationError') router.push('/login')
-		},
+		// Auth errors are handled centrally by the resource fetcher (see main.ts).
 		auto: true,
 	})
 


### PR DESCRIPTION
Backport of #536 to `v0`.

Cherry-picked cleanly from develop (merge commit 7aaedc6).

---
### Problem
A user whose session has expired (timeout, logged out elsewhere, etc.) wasn't notified or redirected — they could keep composing/acting, and failed requests only surfaced raw error toasts.

### Fix
Centralised auth handling on the frappe-ui resource fetcher (`main.ts`): any request that returns an auth error signs the user out and redirects to login.