### PR TITLE
feat: move Outgoing settings from User Settings to Account Settings (v1 backport)

### DIFF
--- a/frontend/src/components/ComposeMailEditor.vue
+++ b/frontend/src/components/ComposeMailEditor.vue
@@ -317,10 +317,14 @@ const user = inject('$user') as UserResource
 
 const getDefaultFromEmail = () => {
 	const identityEmails = identities.data?.map((i: Identity) => i.email) ?? []
+	// The default outgoing email is now per-account; pick the active account's.
+	const defaultOutgoingEmail = user.data?.accounts?.find(
+		(a) => a.name === account,
+	)?.default_outgoing_email
 
 	return (
 		identityEmails.find((e) => e === mailDetails?.from_email) ??
-		identityEmails.find((e) => e === user.data.default_outgoing_email) ??
+		identityEmails.find((e) => e === defaultOutgoingEmail) ??
 		identityEmails[0] ??
 		user.data.name
 	)

--- a/frontend/src/components/ComposeMailEditor.vue
+++ b/frontend/src/components/ComposeMailEditor.vue
@@ -537,14 +537,27 @@ const openQuotedContent = () => {
 	mail.quoted_content = ''
 }
 
+const buildSignature = (email?: string) => {
+	const identity = getIdentity(email!)
+	return identity?.text_signature
+		? `<div><br></div><div><br></div>${identity.html_signature}`
+		: ''
+}
+
+const bodyText = (html: string) => {
+	const element = document.createElement('div')
+	element.innerHTML = html || ''
+	return element.textContent?.trim() ?? ''
+}
+
+// Swap the signature when the From identity changes — but only while the body is still the
+// auto-inserted signature (or empty), so a message the user has written isn't overwritten.
+// Compared by text so the editor's HTML normalization doesn't defeat the match.
 watch(
 	() => mail.from_email,
-	(val) => {
-		if (isBodyEmpty.value) {
-			const identity = getIdentity(val!)
-			mail.html_body = identity?.text_signature
-				? `<div><br></div><div><br></div>${identity.html_signature}`
-				: ''
+	(val, oldVal) => {
+		if (isBodyEmpty.value || bodyText(mail.html_body) === bodyText(buildSignature(oldVal))) {
+			mail.html_body = buildSignature(val)
 		}
 	},
 	{ immediate: true },

--- a/frontend/src/components/Settings/AccountSettings.vue
+++ b/frontend/src/components/Settings/AccountSettings.vue
@@ -1,8 +1,8 @@
 <template>
-	<template v-if="account.doc">
+	<template v-if="accountSettings.doc">
 		<h1>{{ __('Outgoing') }}</h1>
 		<FormControl
-			v-model="account.doc.default_outgoing_email"
+			v-model="accountSettings.doc.default_outgoing_email"
 			type="combobox"
 			:label="__('Default Outgoing Email')"
 			variant="outline"
@@ -32,24 +32,26 @@
 			class="!p-0"
 		/>
 
-		<h1>{{ __('Recovery') }}</h1>
-		<FormControl
-			v-model="account.doc.backup_email"
-			:label="__('Backup Email')"
-			:description="__(`We'll contact you here if there's an issue with your main account.`)"
-			variant="outline"
-		/>
-		<ErrorMessage :message="account.save.error" />
+		<template v-if="userSettings.doc">
+			<h1>{{ __('Recovery') }}</h1>
+			<FormControl
+				v-model="userSettings.doc.backup_email"
+				:label="__('Backup Email')"
+				:description="
+					__(`We'll contact you here if there's an issue with your main account.`)
+				"
+				variant="outline"
+			/>
+		</template>
+
+		<ErrorMessage :message="accountSettings.save.error || userSettings.save.error" />
 		<Button
 			:label="__('Save')"
 			variant="solid"
-			:disabled="
-				account.get.loading ||
-				JSON.stringify(account.doc) === JSON.stringify(account.originalDoc)
-			"
-			:loading="account.save.loading"
+			:disabled="loading || !isDirty"
+			:loading="saving"
 			class="min-h-7"
-			@click="() => account.save.submit()"
+			@click="save"
 		/>
 	</template>
 </template>
@@ -64,28 +66,56 @@ import { userStore } from '@/stores/user'
 import type { Identity } from '@/types'
 
 const user = inject('$user')
-const { identities } = userStore()
+const { account, identities } = userStore()
 
-const account = createDocumentResource({
+// Outgoing settings now live on the active account's Account Settings; backup_email
+// (Recovery) is still per-user on User Settings.
+const activeAccount = user.data?.accounts?.find((a) => a.name === account)
+
+const accountSettings = createDocumentResource({
+	doctype: 'Account Settings',
+	name: activeAccount?.account_settings,
+})
+
+const userSettings = createDocumentResource({
 	doctype: 'User Settings',
 	name: user.data?.user_settings,
-	setValue: {
-		onSuccess: () => raiseToast(__('Account updated.')),
-	},
 })
 
 const createContactsAfterEmailSubmit = computed({
-	get: () => !!account.doc.create_contacts_after_email_submit,
-	set: (val: boolean) => (account.doc.create_contacts_after_email_submit = val ? 1 : 0),
+	get: () => !!accountSettings.doc.create_contacts_after_email_submit,
+	set: (val: boolean) => (accountSettings.doc.create_contacts_after_email_submit = val ? 1 : 0),
 })
 
 const destroyEmailAfterSubmit = computed({
-	get: () => !!account.doc.destroy_email_after_submit,
-	set: (val: boolean) => (account.doc.destroy_email_after_submit = val ? 1 : 0),
+	get: () => !!accountSettings.doc.destroy_email_after_submit,
+	set: (val: boolean) => (accountSettings.doc.destroy_email_after_submit = val ? 1 : 0),
 })
 
 const destroyNewsletterAfterSubmit = computed({
-	get: () => !!account.doc.destroy_newsletter_after_submit,
-	set: (val: boolean) => (account.doc.destroy_newsletter_after_submit = val ? 1 : 0),
+	get: () => !!accountSettings.doc.destroy_newsletter_after_submit,
+	set: (val: boolean) => (accountSettings.doc.destroy_newsletter_after_submit = val ? 1 : 0),
 })
+
+const accountDirty = computed(
+	() => JSON.stringify(accountSettings.doc) !== JSON.stringify(accountSettings.originalDoc),
+)
+const userDirty = computed(
+	() => JSON.stringify(userSettings.doc) !== JSON.stringify(userSettings.originalDoc),
+)
+const isDirty = computed(() => accountDirty.value || userDirty.value)
+const loading = computed(() => accountSettings.get.loading || userSettings.get.loading)
+const saving = computed(() => accountSettings.save.loading || userSettings.save.loading)
+
+const save = async () => {
+	if (accountDirty.value) {
+		await accountSettings.save.submit()
+		// Sync the shared user data so compose picks up the new default without a page
+		// reload (ComposeMailEditor reads default_outgoing_email from user.data.accounts).
+		if (activeAccount)
+			activeAccount.default_outgoing_email = accountSettings.doc.default_outgoing_email
+	}
+	if (userDirty.value) await userSettings.save.submit()
+	raiseToast(__('Account updated.'))
+}
 </script>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,7 +14,6 @@ export interface User {
 	user_image: string | null
 	api_key: string | null
 	user_settings?: string
-	default_outgoing_email?: string
 	color_scheme?: COLOR_SCHEME
 	group_messages_by?: 'None' | 'Day' | 'Month'
 	show_reading_pane?: 0 | 1
@@ -25,7 +24,9 @@ export interface User {
 	is_jmap_configured: boolean
 
 	mailboxes: { id: string; name: string; role: string }[]
-	accounts: UserAccount[]
+	// `get_user_info` enriches each account with its per-account outgoing default and
+	// Account Settings doc name (the fields moved off User Settings).
+	accounts: (UserAccount & { default_outgoing_email?: string; account_settings?: string })[]
 }
 
 export interface UserResource {

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -135,7 +135,6 @@ def get_user_info() -> dict | None:
 			USER.user_type,
 			USER.username,
 			USER.api_key,
-			USER_SETTINGS.default_outgoing_email,
 			USER_SETTINGS.color_scheme,
 			USER_SETTINGS.group_messages_by,
 			USER_SETTINGS.show_reading_pane,
@@ -153,6 +152,23 @@ def get_user_info() -> dict | None:
 	data.is_system_manager = is_system_manager(user)
 	data.is_jmap_configured = is_jmap_configured(user)
 	data.accounts = frappe.get_all("User Account", filters={"user": user})
+
+	# Outgoing settings now live per-account on Account Settings; attach each account's
+	# default outgoing email (and its settings doc) so the compose UI can pick the
+	# default sender for the active account.
+	settings_by_account = {
+		s["account"]: s
+		for s in frappe.get_all(
+			"Account Settings",
+			filters={"user": user},
+			fields=["name", "account", "default_outgoing_email"],
+		)
+	}
+	for acc in data.accounts:
+		settings = settings_by_account.get(acc["name"])
+		acc["account_settings"] = settings["name"] if settings else None
+		acc["default_outgoing_email"] = settings["default_outgoing_email"] if settings else None
+
 	data.user_image = data.user_image or get_avatar_url(user)
 
 	return data

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -253,7 +253,7 @@ def create_mail_import(
 	doc.operation = "Import"
 	doc.import_format = format
 	doc.import_file = file
-	if format in ["eml", "maildir"] and mailbox:
+	if format in ["eml", "maildir", "mbox"] and mailbox:
 		doc.import_metadata = json.dumps({"mailboxIds": {mailbox: True}, "keywords": {"$seen": seen}})
 	doc.insert()
 	doc.submit()

--- a/mail/api/contacts.py
+++ b/mail/api/contacts.py
@@ -79,7 +79,7 @@ def create_contacts_if_not_exists(account: str, recipients: list[dict] | str) ->
 	"""Creates contacts for the given recipients if they do not exist."""
 
 	if not frappe.db.get_value(
-		"User Settings", {"user": frappe.session.user}, "create_contacts_after_email_submit"
+		"Account Settings", {"account": account}, "create_contacts_after_email_submit"
 	):
 		return
 

--- a/mail/client/doctype/account_settings/account_settings.json
+++ b/mail/client/doctype/account_settings/account_settings.json
@@ -14,6 +14,11 @@
   "email_current_state",
   "column_break_bkvs",
   "email_previous_state",
+  "outgoing_section",
+  "default_outgoing_email",
+  "create_contacts_after_email_submit",
+  "destroy_email_after_submit",
+  "destroy_newsletter_after_submit",
   "cache_section",
   "has_cached_jmap_identities",
   "has_cached_jmap_mailboxes",
@@ -85,6 +90,40 @@
    "options": "User",
    "search_index": 1,
    "set_only_once": 1
+  },
+  {
+   "depends_on": "eval: !doc.__islocal",
+   "fieldname": "outgoing_section",
+   "fieldtype": "Section Break",
+   "label": "Outgoing"
+  },
+  {
+   "description": "Default email address used as the sender when composing new messages.",
+   "fieldname": "default_outgoing_email",
+   "fieldtype": "Data",
+   "label": "Default Email",
+   "options": "Email"
+  },
+  {
+   "default": "0",
+   "description": "Automatically creates contact cards for new recipients after an email is sent.",
+   "fieldname": "create_contacts_after_email_submit",
+   "fieldtype": "Check",
+   "label": "Create Contacts After Email Submit"
+  },
+  {
+   "default": "0",
+   "description": "Automatically deletes the email from your mailbox after it is sent.",
+   "fieldname": "destroy_email_after_submit",
+   "fieldtype": "Check",
+   "label": "Destroy Email After Submit"
+  },
+  {
+   "default": "0",
+   "description": "Automatically delete newsletters after they are sent.",
+   "fieldname": "destroy_newsletter_after_submit",
+   "fieldtype": "Check",
+   "label": "Destroy Newsletter After Submit"
   },
   {
    "depends_on": "eval: !doc.__islocal",
@@ -186,6 +225,11 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All",
    "write": 1
   }
  ],

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -21,7 +21,7 @@ from mail.storage.data_store import Entity
 if TYPE_CHECKING:
 	from mail.jmap.services.core import CoreService
 
-from mail.utils.user import is_system_manager
+from mail.utils.user import get_account_emails, is_system_manager
 from mail.utils.validation import has_permission_for_user
 
 
@@ -101,6 +101,24 @@ class AccountSettings(Document):
 		user, account_id = parse_account(self.account)
 		store = get_data_store(user, account_id)
 		return store.count(Entity.CONTACT_CARD)
+
+	def validate(self) -> None:
+		self.validate_default_outgoing_email()
+
+	def validate_default_outgoing_email(self) -> None:
+		"""Keep the default outgoing email valid: fall back to the account's first identity
+		when the chosen one isn't one of the account's identities."""
+
+		if not self.default_outgoing_email or frappe.flags.in_migrate:
+			return
+
+		try:
+			emails = get_account_emails(self.account)
+		except Exception:
+			return
+
+		if emails and self.default_outgoing_email not in emails:
+			self.default_outgoing_email = emails[0]
 
 	def before_insert(self) -> None:
 		self.user = parse_account(self.account)[0]
@@ -200,7 +218,42 @@ def sync_account_settings(user: str, accounts: dict[str, dict]) -> None:
 		settings = frappe.new_doc("Account Settings")
 		settings.user = user
 		settings.account = account
+		# Default the outgoing sender to the account's first identity.
+		emails = get_account_emails(account)
+		if emails:
+			settings.default_outgoing_email = emails[0]
 		settings.save(ignore_permissions=True)
+
+
+def backfill_default_outgoing_emails() -> None:
+	"""Resolve each account's default outgoing email against its identities.
+
+	Run as a background job (e.g. after the Outgoing-settings migration), where JMAP is
+	reachable — unlike during `bench migrate`. Keeps an existing default if it's one of
+	the account's identities, otherwise uses the account's first identity.
+	"""
+
+	for settings in frappe.get_all("Account Settings", fields=["name", "account", "default_outgoing_email"]):
+		try:
+			emails = get_account_emails(settings["account"])
+		except Exception:
+			continue
+
+		if not emails:
+			continue
+
+		current = settings["default_outgoing_email"]
+		resolved = current if current in emails else emails[0]
+		if resolved != current:
+			frappe.db.set_value(
+				"Account Settings",
+				settings["name"],
+				"default_outgoing_email",
+				resolved,
+				update_modified=False,
+			)
+
+	frappe.db.commit()
 
 
 def get_permission_query_condition(user: str | None = None) -> str:

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -358,9 +358,11 @@ class MailQueue(Document):
 			return
 
 		if self.newsletter:
-			if frappe.db.get_value("User Settings", {"user": self.user}, "destroy_newsletter_after_submit"):
+			if frappe.db.get_value(
+				"Account Settings", {"account": self.account}, "destroy_newsletter_after_submit"
+			):
 				self.destroy_after_submit = 1
-		elif frappe.db.get_value("User Settings", {"user": self.user}, "destroy_email_after_submit"):
+		elif frappe.db.get_value("Account Settings", {"account": self.account}, "destroy_email_after_submit"):
 			self.destroy_after_submit = 1
 
 	def validate_delivery_mode(self) -> None:

--- a/mail/client/doctype/user_settings/user_settings.json
+++ b/mail/client/doctype/user_settings/user_settings.json
@@ -13,11 +13,6 @@
   "column_break_uxkb",
   "username",
   "app_password",
-  "outgoing_section",
-  "default_outgoing_email",
-  "column_break_scmb",
-  "destroy_email_after_submit",
-  "destroy_newsletter_after_submit",
   "inbound_section",
   "skip_schedule_fetch_changes",
   "column_break_nqwp",
@@ -31,9 +26,7 @@
   "color_scheme",
   "column_break_cxak",
   "group_messages_by",
-  "show_reading_pane",
-  "contacts_section",
-  "create_contacts_after_email_submit"
+  "show_reading_pane"
  ],
  "fields": [
   {
@@ -71,36 +64,9 @@
    "no_copy": 1
   },
   {
-   "default": "0",
-   "description": "Automatically deletes the email from your mailbox after it is sent.",
-   "fieldname": "destroy_email_after_submit",
-   "fieldtype": "Check",
-   "label": "Destroy Email After Submit"
-  },
-  {
-   "default": "0",
-   "description": "Automatically delete newsletters after they are sent.",
-   "fieldname": "destroy_newsletter_after_submit",
-   "fieldtype": "Check",
-   "label": "Destroy Newsletter After Submit"
-  },
-  {
    "fieldname": "jmap_credentials_section",
    "fieldtype": "Section Break",
    "label": "JMAP Credentials"
-  },
-  {
-   "description": "Default email address used as the sender when composing new messages.",
-   "fieldname": "default_outgoing_email",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Default Email",
-   "options": "Email"
-  },
-  {
-   "fieldname": "column_break_scmb",
-   "fieldtype": "Column Break"
   },
   {
    "description": "Secondary email address used for account recovery and important notifications.",
@@ -127,12 +93,6 @@
   {
    "fieldname": "column_break_klzk",
    "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval: doc.username",
-   "fieldname": "outgoing_section",
-   "fieldtype": "Section Break",
-   "label": "Outgoing"
   },
   {
    "fieldname": "ui_tab",
@@ -200,19 +160,6 @@
    "fieldtype": "Check",
    "label": "Skip Schedule Fetch Changes",
    "search_index": 1
-  },
-  {
-   "fieldname": "contacts_section",
-   "fieldtype": "Section Break",
-   "label": "Contacts"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.username",
-   "description": "Automatically creates contact cards for new recipients after an email is sent.",
-   "fieldname": "create_contacts_after_email_submit",
-   "fieldtype": "Check",
-   "label": "Create Contacts After Email Submit"
   },
   {
    "fieldname": "session_state",

--- a/mail/client/doctype/user_settings/user_settings.py
+++ b/mail/client/doctype/user_settings/user_settings.py
@@ -12,7 +12,6 @@ from frappe.model.document import Document
 from mail.client.doctype.account_settings.account_settings import sync_account_settings
 from mail.jmap import get_jmap_session_manager
 from mail.jmap.connection import JMAPConnection, JMAPConnectionInfo
-from mail.jmap.services.mail.identity import IdentityService
 from mail.utils import get_config
 from mail.utils.dt import timestamp_to_datetime
 from mail.utils.user import is_system_manager
@@ -84,7 +83,7 @@ class UserSettings(Document):
 			frappe.delete_doc("Account Settings", settings, ignore_permissions=True, delete_permanently=True)
 
 	def validate_jmap_settings(self) -> None:
-		"""Validate the JMAP settings by connecting to the JMAP server and verifying the default outgoing email."""
+		"""Validate the JMAP settings by connecting to the JMAP server."""
 
 		if not self.username or self.flags.skip_jmap_validation:
 			return
@@ -92,31 +91,12 @@ class UserSettings(Document):
 		if not self.get_password("app_password"):
 			frappe.throw(_("App Password is required to validate JMAP settings."))
 
-		connection = self.connection
-		if not connection:
+		if not self.connection:
 			frappe.throw(
 				_(
 					"Unable to connect to the JMAP server with the provided username and app password. Please check your settings."
 				)
 			)
-
-		if self.default_outgoing_email:
-			personal_account_id = next(
-				(account_id for account_id, details in connection.accounts.items() if details["isPersonal"]),
-				None,
-			)
-
-			if not personal_account_id:
-				frappe.throw(_("No personal account found for the user on the JMAP server."))
-
-			identity_service = IdentityService(f"{self.user}:{personal_account_id}", connection)
-
-			if not identity_service.get_identity_id_by_email(self.default_outgoing_email):
-				frappe.throw(
-					_(
-						"Default Outgoing Email {0} is not found in the identities of the JMAP account."
-					).format(frappe.bold(self.default_outgoing_email))
-				)
 
 	@frappe.whitelist()
 	def clear_jmap_session(self) -> None:

--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -1,7 +1,9 @@
 [pre_model_sync]
 execute:frappe.db.delete("Mail Cluster Store")
+mail.patches.capture_user_outgoing_settings
 
 [post_model_sync]
+mail.patches.migrate_outgoing_settings_to_account
 mail.patches.generate_ssh_keypair_for_cluster
 mail.patches.create_push_subscriptions
 mail.patches.rename_user_settings

--- a/mail/patches/capture_user_outgoing_settings.py
+++ b/mail/patches/capture_user_outgoing_settings.py
@@ -1,0 +1,30 @@
+import frappe
+
+CACHE_KEY = "migrate:user_outgoing_settings"
+
+
+def execute() -> None:
+	"""Capture the per-user Outgoing settings before they are dropped from User Settings.
+
+	The fields move to Account Settings (per-account). This patch runs pre_model_sync
+	(the User Settings columns still exist); the values are stashed in cache and applied
+	to Account Settings by migrate_outgoing_settings_to_account in post_model_sync (once
+	the new columns exist). The fields are already gone from the doctype meta but the
+	columns still exist in the table, so the query builder references them by column name.
+	"""
+
+	if not frappe.db.has_column("User Settings", "default_outgoing_email"):
+		return
+
+	US = frappe.qb.DocType("User Settings")
+	rows = (
+		frappe.qb.from_(US).select(
+			US.user,
+			US.default_outgoing_email,
+			US.create_contacts_after_email_submit,
+			US.destroy_email_after_submit,
+			US.destroy_newsletter_after_submit,
+		)
+	).run(as_dict=True)
+
+	frappe.cache.set_value(CACHE_KEY, frappe.as_json({r["user"]: r for r in rows}))

--- a/mail/patches/migrate_outgoing_settings_to_account.py
+++ b/mail/patches/migrate_outgoing_settings_to_account.py
@@ -1,0 +1,41 @@
+import frappe
+
+from mail.client.doctype.account_settings.account_settings import backfill_default_outgoing_emails
+from mail.patches.capture_user_outgoing_settings import CACHE_KEY
+
+
+def execute() -> None:
+	"""Apply the captured per-user Outgoing settings onto each Account Settings.
+
+	The three toggles and the old default_outgoing_email are copied verbatim to every
+	account the user owns (JMAP isn't reliably reachable during `bench migrate`, so we
+	can't resolve identities here). The per-account default is then finalised against
+	each account's identities by a background job once migrate is done.
+	"""
+
+	captured = frappe.cache.get_value(CACHE_KEY)
+	by_user = frappe.parse_json(captured) if captured else {}
+
+	for settings in frappe.get_all("Account Settings", fields=["name", "account", "user"]):
+		old = by_user.get(settings["user"])
+		if not old:
+			continue
+
+		frappe.db.set_value(
+			"Account Settings",
+			settings["name"],
+			{
+				"default_outgoing_email": old.get("default_outgoing_email"),
+				"create_contacts_after_email_submit": old.get("create_contacts_after_email_submit") or 0,
+				"destroy_email_after_submit": old.get("destroy_email_after_submit") or 0,
+				"destroy_newsletter_after_submit": old.get("destroy_newsletter_after_submit") or 0,
+			},
+			update_modified=False,
+		)
+
+	if captured:
+		frappe.cache.delete_value(CACHE_KEY)
+
+	# Resolve each account's default outgoing email against its identities once migrate
+	# is done — JMAP returns nothing while the migrate process is running.
+	frappe.enqueue(backfill_default_outgoing_emails, queue="long", enqueue_after_commit=True)


### PR DESCRIPTION
Backport of #534 to `v1`.

Moves the Outgoing settings (`default_outgoing_email` + the send-behaviour toggles) from per-user **User Settings** to per-account **Account Settings**, plus the two fixes bundled in #534 (compose signature on identity change; mbox import format). See #534 for details.

Cherry-picked cleanly onto `v1` (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
