### PR TITLE
fix: show Account settings tab for all JMAP accounts (backport to v1)

### DIFF
--- a/frontend/src/components/Modals/SettingsModal.vue
+++ b/frontend/src/components/Modals/SettingsModal.vue
@@ -55,7 +55,6 @@ import {
 } from 'lucide-vue-next'
 import { Button, Dialog } from 'frappe-ui'
 
-import { userStore } from '@/stores/user'
 import AccountSettings from '@/components/Settings/AccountSettings.vue'
 import AdvancedSettings from '@/components/Settings/AdvancedSettings.vue'
 import AppearanceSettings from '@/components/Settings/AppearanceSettings.vue'
@@ -71,7 +70,6 @@ import VacationResponseSettings from '@/components/Settings/VacationResponseSett
 
 const show = defineModel<boolean>()
 
-const store = userStore()
 const user = inject('$user')
 
 const tabs = computed(() => {
@@ -85,9 +83,7 @@ const tabs = computed(() => {
 			label: __('Account'),
 			icon: Mailbox,
 			component: markRaw(AccountSettings),
-			condition:
-				user.data.is_jmap_configured &&
-				store.account === user.data.accounts.find((a) => a.is_personal)?.name,
+			condition: user.data.is_jmap_configured,
 		},
 		{
 			label: __('Identity'),


### PR DESCRIPTION
Backport of #544 to v1.

Show the Account settings tab whenever JMAP is configured, instead of only when the selected account is the personal account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)