### PR TITLE
fix: surface auth errors and reload account data after re-login

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,23 +15,17 @@ import { userStore } from '@/stores/user'
 
 import FrappePushNotification from '../public/frappe-push-notification'
 
-// Centralised auth handling: any request that comes back unauthenticated signs the user
-// out and redirects to login, so they can't keep composing/acting against a dead session.
+// Centralised auth handling: when a request comes back unauthenticated, sign the user out and
+// redirect to login so they can't keep acting against a dead session. The error is always
+// re-thrown afterwards, so the originating resource still reports it normally (no swallowing,
+// which previously left resources hanging and hid errors like a wrong-password login).
 setConfig('resourceFetcher', async (options: Parameters<typeof frappeRequest>[0]) => {
 	try {
 		return await frappeRequest(options)
 	} catch (error) {
-		// A dead session surfaces as AuthenticationError or (for non-guest methods)
-		// PermissionError "Login to access". If the session is actually gone, swallow the
-		// error so the resource doesn't also toast it — we've shown "signed out" and are
-		// redirecting to login. A genuine PermissionError for a logged-in user re-throws and
-		// surfaces normally. Never-settling promise → the resource's onSuccess/onError won't fire.
 		const excType = (error as { exc_type?: string })?.exc_type
-		if (
-			(excType === 'AuthenticationError' || excType === 'PermissionError') &&
+		if (excType === 'AuthenticationError' || excType === 'PermissionError')
 			sessionStore().handleSessionExpired()
-		)
-			return new Promise<never>(() => {})
 		throw error
 	}
 })

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -7,7 +7,7 @@ import { raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
 
 export const sessionStore = defineStore('mail-session', () => {
-	const { userResource, mailboxes } = userStore()
+	const { userResource, reset } = userStore()
 
 	const sessionUser = () => {
 		const cookies = new URLSearchParams(document.cookie.split('; ').join('&'))
@@ -26,6 +26,10 @@ export const sessionStore = defineStore('mail-session', () => {
 			throw new Error('Invalid email or password')
 		},
 		onSuccess: () => {
+			// Start from a clean slate: a prior session's account/resources may still be in memory
+			// (e.g. cookies cleared without a page reload). Without this, resolveAccount() would
+			// skip setAccount() and the mailboxes/account resources wouldn't load until a reload.
+			reset()
 			userResource.reload()
 			user.value = sessionUser()
 			login.reset()
@@ -38,8 +42,7 @@ export const sessionStore = defineStore('mail-session', () => {
 	const logout = createResource({
 		url: 'logout',
 		onSuccess() {
-			userResource.reset()
-			mailboxes.reset()
+			reset()
 			user.value = null
 			window.location.reload()
 		},
@@ -52,25 +55,20 @@ export const sessionStore = defineStore('mail-session', () => {
 		onSuccess: (data) => (document.querySelector("link[rel='icon']").href = data.favicon),
 	})
 
-	// Called when a request fails with an auth/permission error. Returns true if the session
-	// is actually gone (so the caller can swallow the error and avoid a duplicate toast),
-	// false if the session is still alive — i.e. a genuine PermissionError that should surface
-	// normally. Frappe resets the user_id cookie to Guest on a dead session, so the cookie is
-	// the discriminator. Signs out + notifies + redirects once; later concurrent calls just
-	// report handled.
-	const handleSessionExpired = (): boolean => {
-		// Still logged in — this is a real permission error, not a logout.
-		if (sessionUser()) return false
+	// Called when a request fails with an auth/permission error: sign the user out (clear state,
+	// one toast, redirect to login) when their session is actually gone. No-op when still logged
+	// in (a genuine PermissionError that should surface) or when there was never a session in
+	// this tab (a failed login attempt — let the form show "wrong password"). Frappe resets the
+	// user_id cookie to Guest on a dead session, so the cookie is the discriminator. Idempotent:
+	// once user.value is cleared, concurrent calls return early, so the toast/redirect fire once.
+	const handleSessionExpired = (): void => {
+		if (sessionUser()) return
+		if (!user.value) return
 
-		if (user.value) {
-			user.value = null
-			userResource.reset()
-			mailboxes.reset()
-			raiseToast(__('You have been signed out. Please sign in again.'), 'error')
-			if (!router.currentRoute.value.meta?.isLogin) router.replace({ name: 'Login' })
-		}
-
-		return true
+		user.value = null
+		reset()
+		raiseToast(__('You have been signed out. Please sign in again.'), 'error')
+		if (!router.currentRoute.value.meta?.isLogin) router.replace({ name: 'Login' })
 	}
 
 	return { isLoggedIn, login, logout, branding, handleSessionExpired }

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -105,6 +105,21 @@ export const userStore = defineStore('mail-user', () => {
 
 	const domains = createResource({ url: 'mail.api.admin.get_enabled_domains' })
 
+	// Clear all user/account state so the next sign-in starts from a clean slate. Without
+	// resetting accountId, resolveAccount() would see the resolved account as unchanged and skip
+	// setAccount(), so the per-account resources (mailboxes, etc.) would never re-fetch until a
+	// full page reload.
+	const reset = () => {
+		accountId.value = ''
+		userResource.reset()
+		mailboxes.reset()
+		addressBooks.reset()
+		identities.reset()
+		blockedAddresses.reset()
+		sieveScripts.reset()
+		domains.reset()
+	}
+
 	return {
 		accountId,
 		account,
@@ -117,5 +132,6 @@ export const userStore = defineStore('mail-user', () => {
 		domains,
 		sieveScripts,
 		blockedAddresses,
+		reset,
 	}
 })


### PR DESCRIPTION
Follow-up to #536, which surfaced two regressions:

1. **Auth errors were swallowed** — #536 returned a never-settling promise on `AuthenticationError`/`PermissionError`, so genuine errors were hidden (e.g. a wrong-password login showed no message) and resources hung. Now we keep the sign-out toast + redirect on a real logout, but always re-throw so the originating resource still reports its error.
2. **Account data didn't reload after re-login** — clearing cookies and signing back in (without a page reload) left `accountId` stale in the store, so `resolveAccount()` skipped `setAccount()` and mailboxes/accounts never re-fetched. A new `userStore.reset()` clears that state on login (and logout/expiry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)