### PR TITLE
fix: reset user store on login so account data reloads (backport to v0)

### DIFF
--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -6,7 +6,7 @@ import router from '@/router'
 import { userStore } from '@/stores/user'
 
 export const sessionStore = defineStore('mail-session', () => {
-	const { userResource, mailboxes } = userStore()
+	const { userResource, reset } = userStore()
 
 	const sessionUser = () => {
 		const cookies = new URLSearchParams(document.cookie.split('; ').join('&'))
@@ -25,6 +25,10 @@ export const sessionStore = defineStore('mail-session', () => {
 			throw new Error('Invalid email or password')
 		},
 		onSuccess: () => {
+			// Start from a clean slate: a prior session's account/resources may still be in memory
+			// (e.g. cookies cleared without a page reload). Without this, resolveAccount() would
+			// skip setAccount() and the mailboxes/account resources wouldn't load until a reload.
+			reset()
 			userResource.reload()
 			user.value = sessionUser()
 			login.reset()
@@ -37,8 +41,7 @@ export const sessionStore = defineStore('mail-session', () => {
 	const logout = createResource({
 		url: 'logout',
 		onSuccess() {
-			userResource.reset()
-			mailboxes.reset()
+			reset()
 			user.value = null
 			window.location.reload()
 		},

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -109,6 +109,21 @@ export const userStore = defineStore('mail-user', () => {
 
 	const domains = createResource({ url: 'mail.api.admin.get_verified_domains' })
 
+	// Clear all user/account state so the next sign-in starts from a clean slate. Without
+	// resetting accountId, resolveAccount() would see the resolved account as unchanged and skip
+	// setAccount(), so the per-account resources (mailboxes, etc.) would never re-fetch until a
+	// full page reload.
+	const reset = () => {
+		accountId.value = ''
+		userResource.reset()
+		mailboxes.reset()
+		addressBooks.reset()
+		identities.reset()
+		blockedAddresses.reset()
+		sieveScripts.reset()
+		domains.reset()
+	}
+
 	return {
 		accountId,
 		account,
@@ -121,5 +136,6 @@ export const userStore = defineStore('mail-user', () => {
 		domains,
 		sieveScripts,
 		blockedAddresses,
+		reset,
 	}
 })


### PR DESCRIPTION
Login-reload portion of #547, backported to `v0`.

Clearing cookies and signing back in left `accountId` stale in the store, so `resolveAccount()` skipped `setAccount()` and mailboxes/accounts never re-fetched until a manual reload. A new `userStore.reset()` clears that state on login (and logout).

The auth-error handling in #547 is a follow-up to #536, which is not on this branch, so it is omitted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)