### PR TITLE
feat: use LMDB as DataStore (backport #548 to v1)

### DIFF
--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -14,3 +14,4 @@ mail.patches.create_archive_mailbox
 mail.patches.configure_mail_settings
 mail.patches.configure_mail_cluster
 mail.patches.configure_mail_server
+mail.patches.migrate_data_store_to_lmdb

--- a/mail/patches/migrate_data_store_to_lmdb.py
+++ b/mail/patches/migrate_data_store_to_lmdb.py
@@ -1,0 +1,129 @@
+import os
+from contextlib import suppress
+
+import frappe
+import lmdb
+
+from mail.storage import _get_data_base_path
+from mail.storage.base_store import BaseStore
+from mail.storage.data_store import DataStore, Entity, env_dirname
+
+SEPARATOR = BaseStore.SEPARATOR
+ENTITY_VALUES = {entity.value for entity in Entity}
+
+
+def execute() -> None:
+	"""Migrate the RocksDB-backed DataStore shards to per-account LMDB environments.
+
+	The previous DataStore stored every account under a hash-sharded RocksDB directory
+	(``shard-NN``), which only one process could open at a time. This copies every key into a
+	dedicated LMDB environment per ``user:account`` key, where LMDB handles concurrent
+	multi-process access natively.
+
+	Keys and msgpack-encoded values are copied verbatim, so sync tokens are preserved and the
+	next sync runs as an incremental delta (no full resync). The patch is idempotent and leaves
+	the original RocksDB shards in place so the migration can be verified before cleanup.
+	"""
+
+	base_path = _get_data_base_path()
+	if not os.path.isdir(base_path):
+		return
+
+	shard_dirs = sorted(
+		entry.path
+		for entry in os.scandir(base_path)
+		if entry.is_dir() and entry.name.startswith(BaseStore.SHARD_DIR_PREFIX)
+	)
+	if not shard_dirs:
+		return
+
+	total = 0
+	for shard_path in shard_dirs:
+		total += _migrate_shard(base_path, shard_path)
+
+	frappe.logger("mail.storage").info(
+		{"event": "data-store-lmdb-migration-complete", "shards": len(shard_dirs), "keys": total}
+	)
+
+
+def _migrate_shard(base_path: str, shard_path: str) -> int:
+	"""Copy every key from one RocksDB shard into its per-account LMDB environment."""
+
+	from rocksdict import AccessType, Rdict
+
+	try:
+		db = Rdict(shard_path, access_type=AccessType.read_only())
+	except Exception:
+		# Fall back to a read-write open (e.g. when no prior LOCK exists); migration runs with
+		# the site in maintenance mode, so an exclusive open is safe here.
+		db = Rdict(shard_path)
+
+	count = 0
+	current_store_key = None
+	env = None
+	txn = None
+
+	def close_current(commit: bool) -> None:
+		# Commit the current account's transaction on success, or abort it on error so a failed
+		# migration never leaves a partial account committed. Closing is best-effort and never
+		# masks an in-flight exception.
+		nonlocal env, txn, current_store_key
+		try:
+			if txn is not None:
+				if commit:
+					txn.commit()
+				else:
+					txn.abort()
+		finally:
+			if env is not None:
+				with suppress(Exception):
+					env.close()
+			env, txn, current_store_key = None, None, None
+
+	try:
+		# RocksDB iterates in sorted key order, so all keys for one account are contiguous.
+		for key, value in db.items():
+			key_str = key if isinstance(key, str) else bytes(key).decode()
+			store_key = _store_key_from(key_str)
+
+			if store_key != current_store_key:
+				close_current(commit=True)
+				current_store_key = store_key
+				env_path = os.path.join(base_path, env_dirname(store_key))
+				os.makedirs(env_path, exist_ok=True)
+				env = lmdb.open(
+					env_path,
+					map_size=DataStore.DEFAULT_MAP_SIZE,
+					subdir=True,
+					max_dbs=0,
+					writemap=False,
+				)
+				txn = env.begin(write=True)
+
+			txn.put(key_str.encode(), bytes(value))
+			count += 1
+
+		close_current(commit=True)
+	except Exception:
+		with suppress(Exception):
+			close_current(commit=False)
+		raise
+	finally:
+		db.close()
+
+	return count
+
+
+def _store_key_from(key: str) -> str:
+	"""Derive the ``user:account`` store key from a full stored key.
+
+	Stored keys are ``{user}:{account_id}:{entity}:{subkey}``. The second segment is the
+	account id unless it is a known entity value (a legacy ``account_id=None`` store, whose
+	keys are ``{user}:{entity}:{subkey}``).
+	"""
+
+	parts = key.split(SEPARATOR)
+	if len(parts) >= 2 and parts[1] not in ENTITY_VALUES:
+		return f"{parts[0]}{SEPARATOR}{parts[1]}"
+
+	return parts[0]

--- a/mail/storage/__init__.py
+++ b/mail/storage/__init__.py
@@ -26,17 +26,8 @@ def get_data_store(user: str, account_id: str | None = None) -> DataStore:
 
 	base_path = _get_data_base_path()
 	key = f"{user}{DataStore.SEPARATOR}{account_id}" if account_id else user
-	shard_count = get_config("storage_shard_count")
 
-	return DataStore(
-		base_path=base_path,
-		key=key,
-		acquire_timeout=10,
-		lock_timeout=60,
-		max_retries=3,
-		retry_delay=0.1,
-		shard_count=shard_count,
-	)
+	return DataStore(base_path=base_path, key=key)
 
 
 @frappe.whitelist()

--- a/mail/storage/data_store.py
+++ b/mail/storage/data_store.py
@@ -1,19 +1,16 @@
-import base64
-import hashlib
 import os
-import time
+from collections import OrderedDict
 from contextlib import contextmanager, suppress
 from enum import Enum
 from threading import RLock
-from typing import Any
+from typing import Any, ClassVar
+from urllib.parse import quote
 
 import frappe
+import lmdb
 import msgpack
-import psutil
-from rocksdict import BlockBasedOptions, Cache, DBCompressionType, Options, Rdict
 
 from mail.storage.base_store import BaseStore
-from mail.utils.lock import acquire_lock, release_lock
 
 
 class Entity(Enum):
@@ -33,171 +30,181 @@ class Entity(Enum):
 	CONTACT_CARD = "contact_card"
 
 
+def env_dirname(key: str) -> str:
+	"""Return the filesystem-safe directory name for a store key's LMDB environment."""
+
+	return quote(key, safe="")
+
+
+class _EnvEntry:
+	"""Tracks a cached LMDB environment and the number of in-flight transactions using it."""
+
+	__slots__ = ("env", "refcount")
+
+	def __init__(self, env: "lmdb.Environment") -> None:
+		self.env = env
+		self.refcount = 0
+
+
 class DataStore(BaseStore):
-	"""A simple key-value storage using RocksDB with write locking for concurrency control."""
+	"""A key-value store backed by LMDB, with one environment per ``user:account`` key.
+
+	LMDB natively supports concurrent multi-process access: many readers run lock-free via
+	MVCC snapshots while a single writer briefly serializes on a robust mutex (and waits
+	rather than failing). Environments are kept open and shared per process, so there is no
+	per-operation open cost and no external locking layer.
+	"""
 
 	MAX_MSGPACK_BYTES = 25 * 1024 * 1024
 	MAX_MSGPACK_COLLECTION_LEN = 2_00_000
+
+	# Virtual address-space ceiling per environment. It is sparse (not preallocated) on 64-bit
+	# systems, and grows automatically on MapFullError. Migration uses this same value.
+	DEFAULT_MAP_SIZE = 2 * 1024 * 1024 * 1024
+
+	# Best-effort per-process soft cap on simultaneously open environments. Before opening a
+	# new environment, idle ones (no in-flight transactions) are closed least-recently-used
+	# first. The cap may be temporarily exceeded under load when every cached environment is
+	# busy, since an in-use environment is never force-closed.
+	MAX_CACHED_ENVS = 128
+
+	_ENVS: ClassVar[OrderedDict[str, _EnvEntry]] = OrderedDict()
+	_ENVS_GUARD: ClassVar[RLock] = RLock()
 
 	def __init__(
 		self,
 		base_path: str,
 		key: str,
-		acquire_timeout: int = 10,
-		lock_timeout: int = 60,
-		max_retries: int = 3,
-		retry_delay: float = 0.1,
-		shard_count: int = 1,
+		map_size: int | None = None,
+		**_legacy: Any,
 	) -> None:
-		"""Initialize the storage with base path, key, and optional locking parameters."""
+		"""Initialize the store for the given base path and ``user:account`` key.
 
-		super().__init__(
-			base_path=base_path,
-			key=key,
-			shard_count=shard_count,
-		)
+		``**_legacy`` absorbs parameters from the previous RocksDB implementation
+		(acquire_timeout, lock_timeout, max_retries, retry_delay, shard_count) so existing
+		callers keep working; they no longer have any effect.
+		"""
+
+		super().__init__(base_path=base_path, key=key, shard_count=1)
 
 		self.logger_context["store"] = "data"
+		self.map_size = map_size or self.DEFAULT_MAP_SIZE
 
-		self.acquire_timeout = acquire_timeout
-		self.lock_timeout = lock_timeout
-		self.max_retries = max_retries
-		self.retry_delay = retry_delay
+	def _get_storage_path(self) -> str:
+		"""Return the per-account LMDB environment directory for this key (no sharding)."""
 
-		self.hash = base64.b32encode(hashlib.sha256(self.path.encode()).digest()).decode("ascii").lower()[:20]
-		self._lock_key = f"rocksdict-lock-{self.hash}"
+		return os.path.join(self.base_path, env_dirname(self.key))
+
+	def _open_env(self) -> "lmdb.Environment":
+		"""Open the LMDB environment for this store's path."""
+
+		self.logger.debug({**self.logger_context, "event": "opening-env", "path": self.path})
+
+		return lmdb.open(
+			self.path,
+			map_size=self.map_size,
+			subdir=True,
+			max_dbs=0,
+			readahead=False,
+			meminit=False,
+			writemap=False,
+		)
+
+	def _acquire_env(self) -> _EnvEntry:
+		"""Return the cached environment for this path, opening it if needed, and mark it in use."""
+
+		with self._ENVS_GUARD:
+			entry = self._ENVS.get(self.path)
+			if entry is None:
+				self._evict_idle_envs()
+				entry = _EnvEntry(self._open_env())
+				self._ENVS[self.path] = entry
+
+			entry.refcount += 1
+			self._ENVS.move_to_end(self.path)
+			return entry
+
+	def _release_env(self) -> None:
+		"""Mark this path's environment as no longer in use by the current operation."""
+
+		with self._ENVS_GUARD:
+			entry = self._ENVS.get(self.path)
+			if entry is not None and entry.refcount > 0:
+				entry.refcount -= 1
+
+	@classmethod
+	def close_all_envs(cls) -> None:
+		"""Close every cached LMDB environment in this process.
+
+		Intended for worker shutdown and tests. Must not be called while transactions are
+		in flight; LMDB forbids opening the same environment twice in a process, so a fresh
+		open afterwards is safe only once all handles are released.
+		"""
+
+		with cls._ENVS_GUARD:
+			for entry in cls._ENVS.values():
+				with suppress(Exception):
+					entry.env.close()
+
+			cls._ENVS.clear()
+
+	def _evict_idle_envs(self) -> None:
+		"""Close least-recently-used idle environments while over the cache cap."""
+
+		while len(self._ENVS) >= self.MAX_CACHED_ENVS:
+			victim_path = None
+			for path, entry in self._ENVS.items():
+				if entry.refcount == 0:
+					victim_path = path
+					break
+
+			if victim_path is None:
+				# Every cached environment is currently in use; nothing safe to evict.
+				return
+
+			entry = self._ENVS.pop(victim_path)
+			self.logger.debug({**self.logger_context, "event": "evicting-env", "path": victim_path})
+			with suppress(Exception):
+				entry.env.close()
+
+	def _grow_map(self) -> None:
+		"""Double the map size of this path's environment after a MapFullError."""
+
+		with self._ENVS_GUARD:
+			entry = self._ENVS.get(self.path)
+			if entry is None:
+				return
+
+			self.map_size = max(self.map_size * 2, self.DEFAULT_MAP_SIZE * 2)
+			self.logger.warning(
+				{**self.logger_context, "event": "growing-map", "path": self.path, "map_size": self.map_size}
+			)
+			entry.env.set_mapsize(self.map_size)
 
 	@contextmanager
-	def db_context(self) -> Any:
-		"""Context manager to handle serialized database access across threads and processes."""
+	def _txn(self, write: bool) -> Any:
+		"""Yield an LMDB transaction on this store's environment."""
 
-		process_lock = self._get_process_lock()
-		with process_lock:
-			identifier = self._acquire_global_lock()
-			db = None
+		entry = self._acquire_env()
+		try:
+			with entry.env.begin(write=write, buffers=False) as txn:
+				yield txn
+		finally:
+			self._release_env()
 
+	def _write(self, fn: Any) -> None:
+		"""Run a write callback in a transaction, growing the map and retrying on MapFullError."""
+
+		for _ in range(2):
 			try:
-				db = self._open_db()
-				yield db
+				with self._txn(write=True) as txn:
+					fn(txn)
+				return
+			except lmdb.MapFullError:
+				self._grow_map()
 
-			finally:
-				if db is not None:
-					self._close_db(db)
-
-				self._release_global_lock(identifier)
-
-	def _get_process_lock(self) -> RLock:
-		"""Return a process-local lock shared by all storage instances for the same path."""
-
-		return super()._get_process_lock()
-
-	def _acquire_global_lock(self) -> str:
-		"""Acquire the cross-process lock that guards RocksDB connection creation and use."""
-
-		identifier = None
-
-		for attempt in range(self.max_retries):
-			self.logger.debug(
-				{
-					**self.logger_context,
-					"event": "attempting-glock-acquire",
-					"lock_key": self._lock_key,
-					"attempt": attempt + 1,
-				}
-			)
-
-			identifier = acquire_lock(
-				self._lock_key, acquire_timeout=self.acquire_timeout, lock_timeout=self.lock_timeout
-			)
-			if identifier:
-				self.logger.debug(
-					{
-						**self.logger_context,
-						"event": "glock-acquired",
-						"lock_key": self._lock_key,
-						"identifier": identifier,
-					}
-				)
-
-				return identifier
-
-			self.logger.warning(
-				{
-					**self.logger_context,
-					"event": "glock-acquire-failed",
-					"lock_key": self._lock_key,
-					"attempt": attempt + 1,
-				}
-			)
-
-			time.sleep(self.retry_delay * (2**attempt))
-
-		raise TimeoutError(
-			f"Could not acquire lock '{self._lock_key}' after {self.acquire_timeout} seconds and {self.max_retries} attempts."
-		)
-
-	def _release_global_lock(self, identifier: str) -> None:
-		"""Release the cross-process lock that guards RocksDB connection creation and use."""
-
-		self.logger.debug(
-			{
-				**self.logger_context,
-				"event": "releasing-glock",
-				"lock_key": self._lock_key,
-				"identifier": identifier,
-			}
-		)
-
-		release_lock(self._lock_key, identifier)
-
-	def _open_db(self) -> Rdict:
-		"""Open a RocksDB handle for the current operation."""
-
-		self.logger.debug({**self.logger_context, "event": "opening-db", "path": self.path})
-
-		return Rdict(self.path, options=self._get_options())
-
-	def _close_db(self, db: Rdict) -> None:
-		"""Close the RocksDB handle, ensuring all resources are released."""
-
-		self.logger.debug({**self.logger_context, "event": "closing-db", "path": self.path})
-
-		with suppress(Exception):
-			db.close()
-
-	def _get_options(self) -> Options:
-		"""Configure RocksDB options for performance and reliability."""
-
-		opts = Options()
-		opts.create_if_missing(True)
-		opts.set_keep_log_file_num(5)
-
-		cpu_cores = os.cpu_count() or 2
-		parallelism = min(max(cpu_cores, 2), 16)
-		opts.increase_parallelism(parallelism)
-		opts.set_max_background_jobs(parallelism)
-
-		total_mem = psutil.virtual_memory().total or 4 * 1024 * 1024 * 1024
-		block_cache_size = int(total_mem * 0.1)
-		block_cache_size = max(64 * 1024 * 1024, min(block_cache_size, 2 * 1024 * 1024 * 1024))
-		write_buffer_size = int(total_mem * 0.05)
-		write_buffer_size = max(32 * 1024 * 1024, min(write_buffer_size, 256 * 1024 * 1024))
-
-		opts.set_max_open_files(-1)
-		opts.set_write_buffer_size(write_buffer_size)
-		opts.set_max_write_buffer_number(3)
-		opts.set_target_file_size_base(write_buffer_size)
-		opts.set_max_bytes_for_level_base(write_buffer_size * 4)
-		opts.set_compression_type(DBCompressionType.lz4())
-		opts.set_use_fsync(False)
-
-		table_opts = BlockBasedOptions()
-		table_opts.set_block_cache(Cache(block_cache_size))
-		table_opts.set_cache_index_and_filter_blocks(True)
-		table_opts.set_pin_l0_filter_and_index_blocks_in_cache(True)
-		opts.set_block_based_table_factory(table_opts)
-
-		return opts
+		with self._txn(write=True) as txn:
+			fn(txn)
 
 	def _serialize(self, value: Any) -> bytes:
 		"""Serialize a value to bytes using msgpack."""
@@ -220,36 +227,40 @@ class DataStore(BaseStore):
 			max_map_len=self.MAX_MSGPACK_COLLECTION_LEN,
 		)
 
-	def _make_key(self, entity: Entity, subkey: str) -> str:
-		"""Construct a full key by combining the entity type and subkey with the storage prefix."""
+	def _make_key(self, entity: Entity, subkey: str) -> bytes:
+		"""Construct a full key (with entity and storage prefix) as UTF-8 bytes."""
 
 		subkey = f"{entity.value}{self.SEPARATOR}{subkey}"
-		return super()._make_key(subkey)
+		return super()._make_key(subkey).encode()
 
 	def get(self, entity: Entity, subkey: str, default: Any | None = None) -> Any | None:
 		"""Retrieve a value by key, returning a default if the key does not exist."""
 
-		with self.db_context() as db:
-			value = db.get(self._make_key(entity, subkey))
-			return self._deserialize(value) if value is not None else default
+		key = self._make_key(entity, subkey)
+		with self._txn(write=False) as txn:
+			value = txn.get(key)
+
+		return self._deserialize(value) if value is not None else default
 
 	def set(self, entity: Entity, subkey: str, value: Any) -> None:
 		"""Store a value by key, serializing it before saving."""
 
-		with self.db_context() as db:
-			db.put(self._make_key(entity, subkey), self._serialize(value))
+		key = self._make_key(entity, subkey)
+		data = self._serialize(value)
+		self._write(lambda txn: txn.put(key, data))
 
 	def delete(self, entity: Entity, subkey: str) -> None:
 		"""Delete a value by key."""
 
-		with self.db_context() as db:
-			db.delete(self._make_key(entity, subkey))
+		key = self._make_key(entity, subkey)
+		self._write(lambda txn: txn.delete(key))
 
 	def exists(self, entity: Entity, subkey: str) -> bool:
 		"""Check if a key exists in the storage."""
 
-		with self.db_context() as db:
-			return db.get(self._make_key(entity, subkey)) is not None
+		key = self._make_key(entity, subkey)
+		with self._txn(write=False) as txn:
+			return txn.get(key) is not None
 
 	def get_many(self, entity: Entity, subkeys: list[str]) -> dict[str, Any | None]:
 		"""Retrieve multiple values by a list of keys, returning a dictionary of key-value pairs."""
@@ -257,16 +268,12 @@ class DataStore(BaseStore):
 		if not subkeys:
 			return {}
 
-		keys = [self._make_key(entity, subkey) for subkey in subkeys]
+		keys = [(subkey, self._make_key(entity, subkey)) for subkey in subkeys]
 
-		with self.db_context() as db:
-			values = [db.get(k) for k in keys]
+		with self._txn(write=False) as txn:
+			raw = [(subkey, txn.get(key)) for subkey, key in keys]
 
-			result = {}
-			for subkey, value in zip(subkeys, values, strict=False):
-				result[subkey] = self._deserialize(value) if value is not None else None
-
-			return result
+		return {subkey: self._deserialize(value) if value is not None else None for subkey, value in raw}
 
 	def set_many(self, entity: Entity, items: dict[str, Any]) -> None:
 		"""Store multiple key-value pairs at once, serializing values before saving."""
@@ -274,9 +281,15 @@ class DataStore(BaseStore):
 		if not items:
 			return
 
-		with self.db_context() as db:
-			for subkey, value in items.items():
-				db.put(self._make_key(entity, subkey), self._serialize(value))
+		encoded = [
+			(self._make_key(entity, subkey), self._serialize(value)) for subkey, value in items.items()
+		]
+
+		def _put_all(txn: Any) -> None:
+			for key, data in encoded:
+				txn.put(key, data)
+
+		self._write(_put_all)
 
 	def delete_many(self, entity: Entity, subkeys: list[str]) -> None:
 		"""Delete multiple keys from the storage at once."""
@@ -284,9 +297,13 @@ class DataStore(BaseStore):
 		if not subkeys:
 			return
 
-		with self.db_context() as db:
-			for key in subkeys:
-				db.delete(self._make_key(entity, key))
+		keys = [self._make_key(entity, subkey) for subkey in subkeys]
+
+		def _delete_all(txn: Any) -> None:
+			for key in keys:
+				txn.delete(key)
+
+		self._write(_delete_all)
 
 	def scan(self, entity: Entity, prefix: str = "") -> dict[str, Any]:
 		"""Scan for all key-value pairs that start with a given prefix, returning a dictionary of results."""
@@ -294,20 +311,15 @@ class DataStore(BaseStore):
 		full_prefix = self._make_key(entity, prefix)
 		result = {}
 
-		with self.db_context() as db:
-			it = db.iter()
-			it.seek(full_prefix)
+		with self._txn(write=False) as txn:
+			cursor = txn.cursor()
+			if cursor.set_range(full_prefix):
+				for key, value in cursor:
+					if not key.startswith(full_prefix):
+						break
 
-			while it.valid():
-				key = it.key()
-				if not key.startswith(full_prefix):
-					break
-
-				value = it.value()
-				subkey = self._normalize_scan_key(key)
-				result[subkey] = self._deserialize(value)
-
-				it.next()
+					subkey = self._normalize_scan_key(key.decode())
+					result[subkey] = self._deserialize(value)
 
 		return result
 
@@ -317,17 +329,14 @@ class DataStore(BaseStore):
 		full_prefix = self._make_key(entity, prefix)
 		count = 0
 
-		with self.db_context() as db:
-			it = db.iter()
-			it.seek(full_prefix)
+		with self._txn(write=False) as txn:
+			cursor = txn.cursor()
+			if cursor.set_range(full_prefix):
+				for key in cursor.iternext(keys=True, values=False):
+					if not key.startswith(full_prefix):
+						break
 
-			while it.valid():
-				key = it.key()
-				if not key.startswith(full_prefix):
-					break
-
-				count += 1
-				it.next()
+					count += 1
 
 		return count
 
@@ -343,15 +352,15 @@ class DataStore(BaseStore):
 			}
 		)
 
-		with self.db_context() as db:
-			it = db.iter()
-			prefix = self._make_key(entity, "")
-			it.seek(prefix)
+		full_prefix = self._make_key(entity, "")
 
-			while it.valid():
-				key = it.key()
-				if not key.startswith(prefix):
-					break
+		def _delete_prefix(txn: Any) -> None:
+			# Delete in place via the cursor (O(1) memory) instead of materializing every key.
+			# cursor.delete() removes the current entry and advances to the next one.
+			cursor = txn.cursor()
+			if cursor.set_range(full_prefix):
+				while cursor.key().startswith(full_prefix):
+					if not cursor.delete():
+						break
 
-				db.delete(key)
-				it.next()
+		self._write(_delete_prefix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "isodate~=0.7.2",
     "paramiko~=5.0.0",
     "dnspython~=2.4.2",
+    "lmdb~=1.5.1",
     "rocksdict~=0.3.29",
     "pydenticon~=0.3.1",
     "dns-lexicon~=3.20.1",


### PR DESCRIPTION
Backport of #548 to `v1`.

Replaces the RocksDB-backed `DataStore` with **LMDB** to fix `LOCK: Resource temporarily unavailable` crashes under concurrent multi-process access, and removes the Redis-lock / open-per-operation workaround. One LMDB environment per `user:account`; identical public API. Includes the idempotent migration patch that copies existing RocksDB shard data into the new per-account LMDB environments (verbatim keys + values, so sync tokens are preserved → next sync is an incremental delta).

See #548 for full details, benchmarks, and testing.

### Backport notes
- Cherry-picked cleanly onto `v1` with no conflicts and no adaptation — `v1` already has the `_get_data_base_path()` helper and the `configure_mail_*` patches, so the change applies verbatim.
