### PR TITLE
chore: log inbound and outbound APIs calls (backport #519 to v1)

### DIFF
--- a/mail/api/inbound.py
+++ b/mail/api/inbound.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _
-from frappe.utils import cint, convert_utc_to_system_timezone, create_batch, now
+from frappe.utils import cint, convert_utc_to_system_timezone, create_batch, now, random_string
 
 from mail.api.auth import validate_user
 from mail.client.doctype.mail_message.mail_message import fetch_blobs, fetch_messages
 from mail.client.doctype.mail_sync_history.mail_sync_history import get_mail_sync_history
 from mail.jmap import get_mailbox_id_by_role
-from mail.utils import get_config
+from mail.utils import get_config, get_inbound_logger
 from mail.utils.dt import convert_to_utc
 from mail.utils.rate_limiter import dynamic_rate_limit
 from mail.utils.user import get_user_personal_account
@@ -24,13 +24,30 @@ if TYPE_CHECKING:
 def fetch_blob(blob_id: str, as_bytes: bool = False) -> str | bytes:
 	"""Fetches the blob for the given blob_id."""
 
+	logger = get_inbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
+
+	logger.debug({**ctx, "event": "fetch-blob-started", "blob_id": blob_id})
+
 	validate_user()
-	account = get_user_personal_account(frappe.session.user, raise_exception=True)
 
-	from mail.client.doctype.mail_message.mail_message import fetch_blob as _fetch_blob
+	try:
+		account = get_user_personal_account(frappe.session.user, raise_exception=True)
 
-	blob = _fetch_blob(account, blob_id)
-	return blob if as_bytes else base64.b64encode(blob).decode("utf-8")
+		from mail.client.doctype.mail_message.mail_message import fetch_blob as _fetch_blob
+
+		blob = _fetch_blob(account, blob_id)
+		return blob if as_bytes else base64.b64encode(blob).decode("utf-8")
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "fetch-blob-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to fetch blob. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["GET"])
@@ -40,20 +57,44 @@ def pull(
 ) -> dict[str, list[dict] | str]:
 	"""Returns the emails for the given mailbox."""
 
+	logger = get_inbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
+
+	logger.debug(
+		{
+			**ctx,
+			"event": "pull-started",
+			"mailbox": mailbox,
+			"limit": limit,
+			"last_received_at": last_received_at,
+		}
+	)
+
 	validate_user()
 	validate_max_sync_limit(limit)
 
-	result = []
-	source = get_source()
-	mailbox = mailbox or "inbox"
-	last_received_at = convert_to_system_timezone(last_received_at)
-	account = get_user_personal_account(frappe.session.user, raise_exception=True)
-	sync_history = get_mail_sync_history(account, source)
-	result = get_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
-	update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
-	result["last_received_at"] = convert_to_utc(result["last_received_at"])
+	try:
+		result = []
+		source = get_source()
+		mailbox = mailbox or "inbox"
+		last_received_at = convert_to_system_timezone(last_received_at)
+		account = get_user_personal_account(frappe.session.user, raise_exception=True)
+		sync_history = get_mail_sync_history(account, source)
+		result = get_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
+		update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
+		result["last_received_at"] = convert_to_utc(result["last_received_at"])
 
-	return result
+		return result
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "pull-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to fetch emails. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["GET"])
@@ -63,20 +104,44 @@ def pull_raw(
 ) -> dict[str, list[str] | str]:
 	"""Returns the raw emails for the given mailbox."""
 
+	logger = get_inbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
+
+	logger.debug(
+		{
+			**ctx,
+			"event": "pull-raw-started",
+			"mailbox": mailbox,
+			"limit": limit,
+			"last_received_at": last_received_at,
+		}
+	)
+
 	validate_user()
 	validate_max_sync_limit(limit)
 
-	result = []
-	source = get_source()
-	mailbox = mailbox or "inbox"
-	last_received_at = convert_to_system_timezone(last_received_at)
-	account = get_user_personal_account(frappe.session.user, raise_exception=True)
-	sync_history = get_mail_sync_history(account, source)
-	result = get_raw_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
-	update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
-	result["last_received_at"] = convert_to_utc(result["last_received_at"])
+	try:
+		result = []
+		source = get_source()
+		mailbox = mailbox or "inbox"
+		last_received_at = convert_to_system_timezone(last_received_at)
+		account = get_user_personal_account(frappe.session.user, raise_exception=True)
+		sync_history = get_mail_sync_history(account, source)
+		result = get_raw_mails(account, mailbox, limit, last_received_at or sync_history.last_received_at)
+		update_mail_sync_history(sync_history, result["last_received_at"], result["last_received_mail"])
+		result["last_received_at"] = convert_to_utc(result["last_received_at"])
 
-	return result
+		return result
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "pull-raw-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to fetch raw emails. Please check the error logs for details."))
 
 
 def validate_max_sync_limit(limit: int) -> None:

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -20,7 +20,6 @@ def push_notification() -> dict:
 	"""Handle JMAP Push Notification."""
 
 	logger = get_push_logger()
-
 	ctx = {
 		"req_id": random_string(10),
 		"ip": frappe.request.remote_addr,

--- a/mail/api/outbound.py
+++ b/mail/api/outbound.py
@@ -3,14 +3,14 @@ from email.utils import parseaddr
 
 import frappe
 from frappe import _
-from frappe.utils import cint
+from frappe.utils import cint, random_string
 from frappe.utils.file_manager import save_file
 from werkzeug.datastructures.file_storage import FileStorage
 from werkzeug.utils import secure_filename
 
 from mail.api.auth import validate_user
 from mail.client.doctype.mail_queue.mail_queue import MailQueue
-from mail.utils import get_config, get_messages_directory
+from mail.utils import get_config, get_messages_directory, get_outbound_logger
 from mail.utils.rate_limiter import dynamic_rate_limit
 from mail.utils.user import get_user_personal_account
 
@@ -20,9 +20,16 @@ from mail.utils.user import get_user_personal_account
 def upload_attachment() -> dict:
 	"""Upload an attachment to the Frappe Mail folder."""
 
-	try:
-		validate_user()
+	logger = get_outbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
 
+	logger.debug({**ctx, "event": "upload-attachment-started"})
+	validate_user()
+
+	try:
 		if file := frappe.request.files.get("file"):
 			if not isinstance(file, FileStorage):
 				frappe.throw(_("Invalid file type."))
@@ -43,9 +50,13 @@ def upload_attachment() -> dict:
 				"file_size": doc.file_size,
 				"file_url": doc.file_url,
 			}
-	except Exception as e:
-		frappe.log_error(title=_("Error uploading attachment"), message=frappe.get_traceback())
-		frappe.throw(str(e))
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "upload-attachment-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to upload attachment. Please check the error logs for details."))
 
 	frappe.throw(_("No file found in the request."), frappe.MandatoryError)
 
@@ -69,29 +80,46 @@ def send(
 ) -> str:
 	"""Send Mail."""
 
+	logger = get_outbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
+
+	logger.debug(
+		{**ctx, "event": "send-started", "is_newsletter": is_newsletter, "save_as_draft": save_as_draft}
+	)
 	account = get_user_personal_account(frappe.session.user, raise_exception=True)
 
-	from_name, from_email = parseaddr(from_)
-	doc = MailQueue._create(
-		account=account,
-		from_name=from_name,
-		from_email=from_email,
-		subject=subject,
-		reply_to=format_reply_to(reply_to),
-		headers=headers,
-		recipients=format_recipients(to, cc, bcc),
-		attachments=attachments,
-		html_body=html,
-		text_body=text,
-		via_api=True,
-		newsletter=is_newsletter,
-		in_reply_to=in_reply_to,
-		save_as_draft=save_as_draft,
-		destroy_after_submit=False,
-		delivery_mode="Batch" if is_newsletter else "Enqueue",
-	)
+	try:
+		from_name, from_email = parseaddr(from_)
+		doc = MailQueue._create(
+			account=account,
+			from_name=from_name,
+			from_email=from_email,
+			subject=subject,
+			reply_to=format_reply_to(reply_to),
+			headers=headers,
+			recipients=format_recipients(to, cc, bcc),
+			attachments=attachments,
+			html_body=html,
+			text_body=text,
+			via_api=True,
+			newsletter=is_newsletter,
+			in_reply_to=in_reply_to,
+			save_as_draft=save_as_draft,
+			destroy_after_submit=False,
+			delivery_mode="Batch" if is_newsletter else "Enqueue",
+		)
 
-	return doc.name
+		return doc.name
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "send-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to send email. Please check the error logs for details."))
 
 
 @frappe.whitelist(methods=["POST"])
@@ -104,28 +132,51 @@ def send_raw(
 ) -> str:
 	"""Send raw email. Supports both single-shot and chunked upload."""
 
-	chunk_index = frappe.form_dict.get("chunk_index")
-	total_chunks = frappe.form_dict.get("total_chunk_count")
-	upload_session = frappe.form_dict.get("uuid")
+	logger = get_outbound_logger()
+	ctx = {
+		"req_id": random_string(10),
+		"ip": frappe.request.remote_addr,
+	}
 
-	if chunk_index is not None and total_chunks is not None and upload_session:
-		return _handle_chunked_upload(
-			from_, to, is_newsletter, int(chunk_index), int(total_chunks), str(upload_session)
-		)
+	logger.debug(
+		{
+			**ctx,
+			"event": "send-raw-started",
+			"is_newsletter": is_newsletter,
+			"has_raw_message": bool(raw_message),
+		}
+	)
 
-	raw_message = raw_message or get_message_from_files()
-	if not raw_message:
-		frappe.throw(_("The raw message is required."), frappe.MandatoryError)
+	try:
+		chunk_index = frappe.form_dict.get("chunk_index")
+		total_chunks = frappe.form_dict.get("total_chunk_count")
+		upload_session = frappe.form_dict.get("uuid")
 
-	max_message_size = _get_max_message_payload_size()
-	if len(raw_message.encode("utf-8")) > max_message_size:
-		frappe.throw(
-			_("The raw message exceeds the maximum allowed size of {0} MB.").format(
-				max_message_size // (1024 * 1024)
+		if chunk_index is not None and total_chunks is not None and upload_session:
+			return _handle_chunked_upload(
+				from_, to, is_newsletter, int(chunk_index), int(total_chunks), str(upload_session)
 			)
-		)
 
-	return _enqueue_mail(from_, to, raw_message, is_newsletter)
+		raw_message = raw_message or get_message_from_files()
+		if not raw_message:
+			frappe.throw(_("The raw message is required."), frappe.MandatoryError)
+
+		max_message_size = _get_max_message_payload_size()
+		if len(raw_message.encode("utf-8")) > max_message_size:
+			frappe.throw(
+				_("The raw message exceeds the maximum allowed size of {0} MB.").format(
+					max_message_size // (1024 * 1024)
+				)
+			)
+
+		return _enqueue_mail(from_, to, raw_message, is_newsletter)
+
+	except frappe.exceptions.ValidationError:
+		raise
+
+	except Exception:
+		logger.error({**ctx, "event": "send-raw-failed", "error": frappe.get_traceback()})
+		frappe.throw(_("Failed to send raw email. Please check the error logs for details."))
 
 
 def get_message_from_files() -> str | None:

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -1257,7 +1257,6 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 	"""Fetch changes from the server and remove MailMessage documents from the cache."""
 
 	ctx = ctx or {}
-
 	logger = get_push_logger()
 
 	current_state = get_sync_state(account, type="email")
@@ -1391,7 +1390,6 @@ def locked_fetch_changes(
 	"""Fetch changes for the specified account with a lock to prevent concurrent execution."""
 
 	ctx = ctx or {}
-
 	logger = get_push_logger()
 
 	try:
@@ -1406,7 +1404,6 @@ def enqueue_fetch_changes(account: str, email_state: str | None = None, ctx: dic
 	"""Enqueue the fetch_changes job for the specified account."""
 
 	ctx = ctx or {}
-
 	logger = get_push_logger()
 
 	logger.info({**ctx, "event": "enqueueing-fetch-changes"})

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -24,14 +24,6 @@
   "stalwart_version",
   "stalwart_cli_version",
   "storage_shard_count",
-  "logs_section",
-  "push_log_file_count",
-  "push_log_level",
-  "push_log_max_file_size",
-  "column_break_ztzv",
-  "storage_log_file_count",
-  "storage_log_level",
-  "storage_log_max_file_size",
   "limits_section",
   "exchange_max_export",
   "exchange_max_import",
@@ -43,6 +35,22 @@
   "column_break_cazi",
   "process_pending_emails_batch_size",
   "process_pending_emails_max_batch_size",
+  "logs_section",
+  "push_log_file_count",
+  "push_log_level",
+  "push_log_max_file_size",
+  "column_break_ztzv",
+  "storage_log_file_count",
+  "storage_log_level",
+  "storage_log_max_file_size",
+  "column_break_pvju",
+  "inbound_log_file_count",
+  "inbound_log_level",
+  "inbound_log_max_file_size",
+  "column_break_jdrp",
+  "outbound_log_file_count",
+  "outbound_log_level",
+  "outbound_log_max_file_size",
   "timeouts_seconds_section",
   "column_break_rtlq",
   "ansible_play_timeout",
@@ -607,12 +615,64 @@
    "fieldname": "limits_section",
    "fieldtype": "Section Break",
    "label": "Limits"
+  },
+  {
+   "fieldname": "column_break_jdrp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "10",
+   "fieldname": "outbound_log_file_count",
+   "fieldtype": "Int",
+   "label": "Outbound Log File Count",
+   "reqd": 1
+  },
+  {
+   "default": "INFO",
+   "fieldname": "outbound_log_level",
+   "fieldtype": "Select",
+   "label": "Outbound Log Level",
+   "options": "ERROR\nWARNING\nINFO\nDEBUG",
+   "reqd": 1
+  },
+  {
+   "default": "5000000",
+   "fieldname": "outbound_log_max_file_size",
+   "fieldtype": "Int",
+   "label": "Outbound Log Max File Size",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_pvju",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "10",
+   "fieldname": "inbound_log_file_count",
+   "fieldtype": "Int",
+   "label": "Inbound Log File Count",
+   "reqd": 1
+  },
+  {
+   "default": "INFO",
+   "fieldname": "inbound_log_level",
+   "fieldtype": "Select",
+   "label": "Inbound Log Level",
+   "options": "ERROR\nWARNING\nINFO\nDEBUG",
+   "reqd": 1
+  },
+  {
+   "default": "5000000",
+   "fieldname": "inbound_log_max_file_size",
+   "fieldtype": "Int",
+   "label": "Inbound Log Max File Size",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-08 22:01:00.877073",
+ "modified": "2026-06-15 15:27:49.779589",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Settings",

--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -15,3 +15,4 @@ mail.patches.configure_mail_settings
 mail.patches.configure_mail_cluster
 mail.patches.configure_mail_server
 mail.patches.migrate_data_store_to_lmdb
+mail.patches.configure_inbound_outbound_log

--- a/mail/patches/configure_inbound_outbound_log.py
+++ b/mail/patches/configure_inbound_outbound_log.py
@@ -1,0 +1,25 @@
+import frappe
+
+CONFIG_KEY_FIELD_MAP = {
+	# Inbound
+	"inbound_log_file_count": None,
+	"inbound_log_level": None,
+	"inbound_log_max_file_size": None,
+	# Outbound
+	"outbound_log_file_count": None,
+	"outbound_log_level": None,
+	"outbound_log_max_file_size": None,
+}
+
+
+def execute() -> None:
+	meta = frappe.get_meta("Mail Settings")
+	settings = frappe.get_doc("Mail Settings")
+
+	for key, field in CONFIG_KEY_FIELD_MAP.items():
+		value = meta.get_field(field or key).default
+		if value is not None:
+			setattr(settings, field or key, value)
+
+	settings.flags.ignore_mandatory = 1
+	settings.save()

--- a/mail/patches/configure_mail_settings.py
+++ b/mail/patches/configure_mail_settings.py
@@ -62,4 +62,5 @@ def execute() -> None:
 
 			setattr(settings, field or key, value)
 
+	settings.flags.ignore_mandatory = 1
 	settings.save()

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -63,6 +63,12 @@ CONFIG_KEYS = [
 	"storage_log_file_count",
 	"storage_log_level",
 	"storage_log_max_file_size",
+	"inbound_log_file_count",
+	"inbound_log_level",
+	"inbound_log_max_file_size",
+	"outbound_log_file_count",
+	"outbound_log_level",
+	"outbound_log_max_file_size",
 	# Limits
 	"exchange_max_export",
 	"exchange_max_import",
@@ -175,6 +181,36 @@ def get_push_logger() -> "Logger":
 	logger = frappe.logger("mail.push", allow_site=True, max_size=max_size, file_count=file_count)
 
 	log_level = config["push_log_level"].upper()
+	logger.setLevel(log_level)
+
+	return logger
+
+
+def get_outbound_logger() -> "Logger":
+	"""Returns a logger instance for outbound mail operations."""
+
+	config = get_config()
+
+	max_size = cint(config["outbound_log_max_file_size"])
+	file_count = cint(config["outbound_log_file_count"])
+	logger = frappe.logger("mail.outbound", allow_site=True, max_size=max_size, file_count=file_count)
+
+	log_level = config["outbound_log_level"].upper()
+	logger.setLevel(log_level)
+
+	return logger
+
+
+def get_inbound_logger() -> "Logger":
+	"""Returns a logger instance for inbound mail operations."""
+
+	config = get_config()
+
+	max_size = cint(config["inbound_log_max_file_size"])
+	file_count = cint(config["inbound_log_file_count"])
+	logger = frappe.logger("mail.inbound", allow_site=True, max_size=max_size, file_count=file_count)
+
+	log_level = config["inbound_log_level"].upper()
 	logger.setLevel(log_level)
 
 	return logger


### PR DESCRIPTION
Backport of #519 to `v1`.

Adds structured logging (with a per-request `req_id` and client IP) to the inbound (`fetch_blob`, `pull`, `pull_raw`) and outbound (`upload_attachment`, `send`, `send_raw`) APIs, plus consistent error handling that re-raises `ValidationError` (preserving user-facing messages) while logging unexpected failures.

`v1` shares the same config architecture as `develop`, so this is a near-verbatim port: new `inbound_log_*` / `outbound_log_*` fields on Mail Settings, `CONFIG_KEYS`, the `configure_inbound_outbound_log` patch, and the `get_inbound_logger` / `get_outbound_logger` helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)