### PR TITLE
perf(api): omit redundant text_body when html_body is present

### DIFF
--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -263,7 +263,6 @@ def serialize_mail(mail: dict) -> dict:
 		"from_email",
 		"subject",
 		"html_body",
-		"text_body",
 		"preview",
 		"received_at",
 		"draft",
@@ -275,8 +274,12 @@ def serialize_mail(mail: dict) -> dict:
 		"reply_to",
 	]
 
+	# text_body is only rendered as a fallback when html_body is empty (the UI renders
+	# `html_body || text_body`), so omit the redundant copy whenever there's HTML.
+	html = mail.get("html_body") or ""
 	return {
 		**{field: mail[field] for field in mail_fields},
+		"text_body": "" if html else mail.get("text_body", ""),
 		"attachments": serialize_attachments(mail.get("attachments", [])),
 	}
 


### PR DESCRIPTION
## Problem

`get_threads` returns every thread with all its messages nested, and `serialize_mail` ships **both** `html_body` and `text_body` for each message. The UI only ever renders `text_body` as a *fallback* when `html_body` is empty (`MailThread.vue`: `hasHtmlContent(html_body) ? html_body : (html_body || text_body)`). So for HTML mail — the vast majority — the `text_body` copy is downloaded and never rendered. It's pure dead weight in both `get_threads` (nested per-message) and `get_thread` payloads.

## Change

Send `text_body` only when there's no `html_body`:

```python
html = mail.get("html_body") or ""
"text_body": "" if html else mail.get("text_body", ""),
```

The `"" if html else ...` mirrors the frontend's `html_body || text_body` exactly, so it's **behavior-preserving** — plain-text-only mail (empty `html_body`) still gets its `text_body` and renders unchanged; HTML mail just stops shipping the redundant copy.

## Why not compression?

Transport-level gzip (already on in the standard bench nginx config, `application/json` included) handles wire compression. App-level compress/decompress would be redundant and add a base64 tax. Trimming the redundant field reduces the payload *before* gzip and also cuts client-side JSON parse cost.

## Verification

Exercised the real `serialize_mail` with both inputs:

| Input | `html_body` out | `text_body` out |
|---|---|---|
| Plain-text (`html_body=""`) | `""` | preserved ✓ |
| HTML (`html_body="<p>..</p>"`) | `"<p>..</p>"` | `""` (dropped) ✓ |

Confirmed the render path: `hasHtmlContent("")` is `false`, so plain-text mail takes the `<pre>` branch and renders `html_body || text_body` → the text body (non-blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)