### PR TITLE
perf(api): omit redundant text_body when html_body is present (backport #555 to v1)

### DIFF
--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -263,7 +263,6 @@ def serialize_mail(mail: dict) -> dict:
 		"from_email",
 		"subject",
 		"html_body",
-		"text_body",
 		"preview",
 		"received_at",
 		"draft",
@@ -275,8 +274,12 @@ def serialize_mail(mail: dict) -> dict:
 		"reply_to",
 	]
 
+	# text_body is only rendered as a fallback when html_body is empty (the UI renders
+	# `html_body || text_body`), so omit the redundant copy whenever there's HTML.
+	html = mail.get("html_body") or ""
 	return {
 		**{field: mail[field] for field in mail_fields},
+		"text_body": "" if html else mail.get("text_body", ""),
 		"attachments": serialize_attachments(mail.get("attachments", [])),
 	}
 


### PR DESCRIPTION
Backport of #555 to `v1`.

`serialize_mail` shipped both `html_body` and `text_body` for every message, but the UI only renders `text_body` as a fallback when `html_body` is empty (`html_body || text_body`). For HTML mail the `text_body` copy was downloaded and never rendered — dead weight in `get_threads`/`get_thread` payloads. This sends `text_body` only when there's no HTML, which is behavior-preserving (plain-text mail still renders).

Cherry-picked cleanly from develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)