### PR TITLE
feat: prompt to block sender after marking mail as junk

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -30,6 +30,7 @@ declare module 'vue' {
     AudioIcon: typeof import('./src/components/Icons/AudioIcon.vue')['default']
     AutomationSettings: typeof import('./src/components/Settings/AutomationSettings.vue')['default']
     BlockListSettings: typeof import('./src/components/Settings/BlockListSettings.vue')['default']
+    BlockSenderModal: typeof import('./src/components/Modals/BlockSenderModal.vue')['default']
     ChangePasswordModal: typeof import('./src/components/Modals/ChangePasswordModal.vue')['default']
     ComposeMailEditor: typeof import('./src/components/ComposeMailEditor.vue')['default']
     ComposeMailToolbar: typeof import('./src/components/ComposeMailToolbar.vue')['default']

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -61,6 +61,7 @@ declare module 'vue' {
     ImportSettings: typeof import('./src/components/Settings/ImportSettings.vue')['default']
     InformationField: typeof import('./src/components/InformationField.vue')['default']
     InstallPrompt: typeof import('./src/components/InstallPrompt.vue')['default']
+    LinkifiedText: typeof import('./src/components/LinkifiedText.vue')['default']
     ListCard: typeof import('./src/components/ListCard.vue')['default']
     LoginLayout: typeof import('./src/components/LoginLayout.vue')['default']
     MailActions: typeof import('./src/components/MailActions.vue')['default']

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -76,7 +76,7 @@ import { Avatar, Button, Dropdown, Sidebar, SidebarItem, createResource } from '
 
 import { FOLDER_ICON_COLOR_MAP } from '@/constants'
 import { getIcon, toTitleCase } from '@/utils'
-import { useScreenSize, useSidebar } from '@/utils/composables'
+import { useScreenSize, useSettings, useSidebar } from '@/utils/composables'
 import { sessionStore } from '@/stores/session'
 import { userStore } from '@/stores/user'
 import MailLogo from '@/components/Icons/MailLogo.vue'
@@ -121,7 +121,7 @@ const apps = createResource({
 	transform: (data) => data.filter((app) => app.name !== 'mail'),
 })
 
-const showSettings = ref(false)
+const { showSettings } = useSettings()
 const showFolderModal = ref(false)
 const selectedMailbox = ref()
 const showDeleteMailbox = ref(false)

--- a/frontend/src/components/LinkifiedText.vue
+++ b/frontend/src/components/LinkifiedText.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { isEmail } from '@/utils'
+
+// Matches URLs (http/https/www) and email addresses in plain text.
+const URL_OR_EMAIL_REGEX =
+	/(https?:\/\/[^\s<]+|www\.[^\s<]+|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/gi
+// Trailing punctuation unlikely to be part of the link.
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}'"]+$/
+
+interface Segment {
+	text: string
+	href?: string
+}
+
+const props = defineProps<{ text?: string | null }>()
+
+// Splits the text into plain runs and link runs. Rendered as <span>/<a> elements with the text in
+// {{ }} (auto-escaped), so the body can never be interpreted as markup — for rich HTML bodies use
+// <EmailContent> (DOMPurify) instead.
+const segments = computed<Segment[]>(() => {
+	const text = props.text ?? ''
+	const result: Segment[] = []
+	let lastIndex = 0
+
+	for (const match of text.matchAll(URL_OR_EMAIL_REGEX)) {
+		const token = match[0]
+		const start = match.index ?? 0
+
+		const before = text.slice(lastIndex, start)
+		if (before) result.push({ text: before })
+
+		const trailing = token.match(TRAILING_PUNCTUATION)?.[0] ?? ''
+		const link = token.slice(0, token.length - trailing.length)
+		const href = isEmail(link)
+			? `mailto:${link}`
+			: link.startsWith('www.')
+				? `https://${link}`
+				: link
+
+		result.push({ text: link, href })
+		if (trailing) result.push({ text: trailing })
+
+		lastIndex = start + token.length
+	}
+
+	const rest = text.slice(lastIndex)
+	if (rest) result.push({ text: rest })
+
+	return result
+})
+</script>
+
+<template>
+	<div class="whitespace-pre-wrap break-words pt-4 font-sans text-base !leading-5 sm:text-sm">
+		<template v-for="(segment, index) in segments" :key="index">
+			<a
+				v-if="segment.href"
+				:href="segment.href"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-ink-blue-2 hover:underline"
+				>{{ segment.text }}</a
+			>
+			<span v-else>{{ segment.text }}</span>
+		</template>
+	</div>
+</template>

--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -257,7 +257,8 @@ const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
 			reloadMails(isUndo)
 			// After marking as Junk, offer to block the sender (not when re-junking via an undo of
 			// Mark as Not Junk). Blocking then clears the undo set below.
-			if (spam && !isUndo) promptBlockSenders([mail.from_email])
+			if (spam && !isUndo)
+				promptBlockSenders([{ name: mail.from_name, email: mail.from_email }])
 		})
 	const successMessage = spam ? __('Mail marked as Junk.') : __('Mail marked as Not Junk.')
 

--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -43,7 +43,7 @@ import {
 import { Button, Dropdown, createResource, toast } from 'frappe-ui'
 
 import { downloadUrlAsFile, raisePromiseToast, raiseToast } from '@/utils'
-import { useScreenSize, useUndo } from '@/utils/composables'
+import { useBlockSender, useScreenSize, useUndo } from '@/utils/composables'
 import { userStore } from '@/stores/user'
 
 import type { ComposeMailData, Identity, Mail } from '@/types'
@@ -81,6 +81,7 @@ const route = useRoute()
 const router = useRouter()
 const { account, mailboxes, mailboxIds, identities, blockedAddresses } = userStore()
 const { setUndoAction, undo } = useUndo()
+const { promptBlockSenders } = useBlockSender()
 const user = inject('$user')
 
 const primaryActions = (mail: Mail): MailAction[] => [
@@ -251,7 +252,13 @@ const markAsSpam = createResource({
 })
 
 const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
-	const action = () => markAsSpam.submit({ spam }).then(() => reloadMails(isUndo))
+	const action = () =>
+		markAsSpam.submit({ spam }).then(() => {
+			reloadMails(isUndo)
+			// After marking as Junk, offer to block the sender (not when re-junking via an undo of
+			// Mark as Not Junk). Blocking then clears the undo set below.
+			if (spam && !isUndo) promptBlockSenders([mail.from_email])
+		})
 	const successMessage = spam ? __('Mail marked as Junk.') : __('Mail marked as Not Junk.')
 
 	if (isUndo) return raisePromiseToast(action, __('Undoing...'), successMessage)

--- a/frontend/src/components/MailListItem.vue
+++ b/frontend/src/components/MailListItem.vue
@@ -81,7 +81,7 @@
 			>
 				<h5
 					class="text-ink-gray-5 truncate text-sm !leading-[1.5]"
-					:class="{ italic: !mail.preview }"
+					:class="{ italic: !mail.preview, '!text-base': isFullWidth }"
 				>
 					{{ mail.preview || __('— No message body —') }}
 				</h5>
@@ -99,9 +99,14 @@
 				</div>
 			</div>
 			<div
-				v-if="attachments.length || mail.draft || ['starred', 'search'].includes(mailbox)"
+				v-if="
+					attachments.length ||
+					mail.draft ||
+					['starred', 'search'].includes(mailbox) ||
+					(isFullWidth && mailboxesToShow.length)
+				"
 				class="flex items-center"
-				:class="{ 'ml-auto min-w-fit': isFullWidth }"
+				:class="{ 'min-w-fit': isFullWidth }"
 			>
 				<Tooltip
 					v-for="(attachment, idx) in attachments.slice(0, 2)"

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -254,11 +254,11 @@
 										v-if="hasHtmlContent(mail.html_body)"
 										:content="mail.html_body"
 									/>
-									<pre
+
+									<LinkifiedText
 										v-else
-										class="whitespace-pre-wrap break-words pt-4 font-sans text-base !leading-5 sm:text-sm"
-										>{{ mail.html_body || mail.text_body }}</pre
-									>
+										:text="mail.html_body || mail.text_body"
+									/>
 
 									<div
 										v-if="filteredAttachments(mail).length"
@@ -368,6 +368,7 @@ import AttachmentViewer from '@/components/AttachmentViewer.vue'
 import ComposeMailEditor from '@/components/ComposeMailEditor.vue'
 import EmailContent from '@/components/EmailContent.vue'
 import NoMails from '@/components/Icons/NoMails.vue'
+import LinkifiedText from '@/components/LinkifiedText.vue'
 import MailActions from '@/components/MailActions.vue'
 import MailDate from '@/components/MailDate.vue'
 import MailDetails from '@/components/MailDetails.vue'

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -215,15 +215,29 @@
 									<Alert
 										v-if="blockedAddresses.data.includes(mail.from_email)"
 										:title="__('This sender is blocked')"
-										:description="
-											__(
-												`{0} is currently on your block list. You won't receive new messages from this source until you unblock them.`,
-												[mail.from_name || mail.from_email],
-											)
-										"
 										class="mb-4"
 										:dismissable="false"
 									>
+										<template #description>
+											<p class="text-ink-gray-6 prose-sm">
+												{{
+													__('{0} is currently on your', [
+														mail.from_name || mail.from_email,
+													])
+												}}
+												<button
+													type="button"
+													class="hover:text-ink-gray-8 underline"
+													@click="openSettings(__('Block List'))"
+												>
+													{{ __('block list') }}</button
+												>{{
+													__(
+														". You won't receive new messages from this source until you unblock them.",
+													)
+												}}
+											</p>
+										</template>
 										<template #footer>
 											<div class="col-span-full">
 												<Button
@@ -347,7 +361,7 @@ import {
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/utils'
-import { useScreenSize, useTheme } from '@/utils/composables'
+import { useScreenSize, useSettings, useTheme } from '@/utils/composables'
 import { userStore } from '@/stores/user'
 import AttachmentCapsule from '@/components/AttachmentCapsule.vue'
 import AttachmentViewer from '@/components/AttachmentViewer.vue'
@@ -389,6 +403,7 @@ const emit = defineEmits([
 ])
 
 const { isMobile } = useScreenSize()
+const { openSettings } = useSettings()
 const dayjs = inject('$dayjs')
 const user = inject('$user')
 const store = userStore()

--- a/frontend/src/components/Modals/BlockSenderModal.vue
+++ b/frontend/src/components/Modals/BlockSenderModal.vue
@@ -11,7 +11,6 @@
 						type="checkbox"
 						:model-value="allSelected"
 						class="pointer-events-none"
-						size="md"
 					/>
 					<span class="text-ink-gray-7 text-sm font-medium">
 						{{ allSelected ? __('Deselect all') : __('Select all') }}
@@ -35,7 +34,6 @@
 							type="checkbox"
 							:model-value="selected[sender.email]"
 							class="pointer-events-none"
-							size="md"
 						/>
 						<div class="min-w-0 flex-1 space-y-0.5">
 							<div class="text-ink-gray-8 truncate text-sm font-medium">

--- a/frontend/src/components/Modals/BlockSenderModal.vue
+++ b/frontend/src/components/Modals/BlockSenderModal.vue
@@ -1,14 +1,52 @@
 <template>
 	<Dialog v-model="showBlockSender" :options="options">
-		<template v-if="sendersToBlock.length > 1" #body-content>
-			<div class="flex flex-col gap-4">
-				<FormControl
-					v-for="email in sendersToBlock"
-					:key="email"
-					v-model="selected[email]"
-					type="checkbox"
-					:label="email"
-				/>
+		<template v-if="isMultiple" #body-content>
+			<div class="border-outline-gray-2 overflow-hidden rounded-md border">
+				<!-- Select all -->
+				<div
+					class="bg-surface-gray-1 flex cursor-pointer items-center gap-3 px-3.5 py-2.5"
+					@click="toggleAll"
+				>
+					<FormControl
+						type="checkbox"
+						:model-value="allSelected"
+						class="pointer-events-none"
+						size="md"
+					/>
+					<span class="text-ink-gray-7 text-sm font-medium">
+						{{ allSelected ? __('Deselect all') : __('Select all') }}
+					</span>
+					<span class="text-ink-gray-5 ml-auto text-sm">
+						{{ __('{0} of {1} selected', [selectedCount, sendersToBlock.length]) }}
+					</span>
+				</div>
+
+				<!-- Sender list -->
+				<div
+					class="divide-outline-gray-2 border-outline-gray-2 max-h-[290px] divide-y overflow-y-auto border-t"
+				>
+					<div
+						v-for="sender in sendersToBlock"
+						:key="sender.email"
+						class="hover:bg-surface-gray-1 flex cursor-pointer items-center gap-3 px-3.5 py-2.5 transition-colors"
+						@click="toggle(sender.email)"
+					>
+						<FormControl
+							type="checkbox"
+							:model-value="selected[sender.email]"
+							class="pointer-events-none"
+							size="md"
+						/>
+						<div class="min-w-0 flex-1 space-y-0.5">
+							<div class="text-ink-gray-8 truncate text-sm font-medium">
+								{{ sender.name || sender.email }}
+							</div>
+							<div v-if="sender.name" class="text-ink-gray-5 truncate text-xs">
+								{{ sender.email }}
+							</div>
+						</div>
+					</div>
+				</div>
 			</div>
 		</template>
 	</Dialog>
@@ -27,14 +65,27 @@ const { blockedAddresses } = store
 const { showBlockSender, sendersToBlock } = useBlockSender()
 const { setUndoAction } = useUndo()
 
-// Which of the listed senders are checked (only relevant when there's more than one). Reset to all
-// selected each time the prompt opens.
+const isMultiple = computed(() => sendersToBlock.value.length > 1)
+
+// Which senders are checked (multi-select only). Reset to all-selected each time the prompt opens.
 const selected = reactive<Record<string, boolean>>({})
 watch(showBlockSender, (open) => {
 	if (!open) return
 	Object.keys(selected).forEach((key) => delete selected[key])
-	sendersToBlock.value.forEach((email) => (selected[email] = true))
+	sendersToBlock.value.forEach((sender) => (selected[sender.email] = true))
 })
+
+const selectedCount = computed(
+	() => sendersToBlock.value.filter((sender) => selected[sender.email]).length,
+)
+const allSelected = computed(
+	() => sendersToBlock.value.length > 0 && selectedCount.value === sendersToBlock.value.length,
+)
+const toggle = (email: string) => (selected[email] = !selected[email])
+const toggleAll = () => {
+	const next = !allSelected.value
+	sendersToBlock.value.forEach((sender) => (selected[sender.email] = next))
+}
 
 const blockEmailAddresses = createResource({
 	url: 'mail.api.mail.block_email_addresses',
@@ -43,10 +94,11 @@ const blockEmailAddresses = createResource({
 })
 
 const handleBlock = () => {
-	const emails =
-		sendersToBlock.value.length === 1
-			? sendersToBlock.value
-			: sendersToBlock.value.filter((email) => selected[email])
+	const emails = (
+		isMultiple.value
+			? sendersToBlock.value.filter((sender) => selected[sender.email])
+			: sendersToBlock.value
+	).map((sender) => sender.email)
 	showBlockSender.value = false
 	if (!emails.length) return
 
@@ -59,24 +111,26 @@ const handleBlock = () => {
 	raisePromiseToast(action, __('Blocking...'), success)
 }
 
-const options = computed(() => ({
-	title: sendersToBlock.value.length > 1 ? __('Block Senders') : __('Block Sender'),
-	message:
-		sendersToBlock.value.length === 1
-			? __("Block {0}? You won't receive future messages from them.", [
-					sendersToBlock.value[0],
-				])
-			: __(
-					"Select the senders you want to block. You won't receive future messages from blocked senders.",
-				),
-	icon: { name: 'alert-triangle', appearance: 'warning' },
-	actions: [
-		{
-			label: __('Block'),
-			variant: 'solid',
-			autofocus: true,
-			onClick: handleBlock,
-		},
-	],
-}))
+const options = computed(() => {
+	const count = isMultiple.value ? selectedCount.value : 1
+	return {
+		title: __('Block {0}?', [count === 1 ? __('sender') : __('senders')]),
+		message: isMultiple.value
+			? __("You won't receive future messages from the selected senders.")
+			: __("You won't receive future messages from {0}.", [sendersToBlock.value[0]?.email]),
+		actions: [
+			{
+				label: __('Cancel'),
+				onClick: () => (showBlockSender.value = false),
+			},
+			{
+				label: __('Block'),
+				variant: 'solid',
+				autofocus: true,
+				disabled: isMultiple.value && count === 0,
+				onClick: handleBlock,
+			},
+		],
+	}
+})
 </script>

--- a/frontend/src/components/Modals/BlockSenderModal.vue
+++ b/frontend/src/components/Modals/BlockSenderModal.vue
@@ -1,0 +1,83 @@
+<template>
+	<Dialog v-model="showBlockSender" :options="options">
+		<template v-if="sendersToBlock.length > 1" #body-content>
+			<div class="flex flex-col gap-3">
+				<label
+					v-for="email in sendersToBlock"
+					:key="email"
+					class="flex cursor-pointer items-center gap-2"
+				>
+					<Checkbox v-model="selected[email]" />
+					<span class="text-ink-gray-7 truncate text-base">{{ email }}</span>
+				</label>
+			</div>
+		</template>
+	</Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue'
+import { Checkbox, Dialog, createResource } from 'frappe-ui'
+
+import { raisePromiseToast } from '@/utils'
+import { useBlockSender, useUndo } from '@/utils/composables'
+import { userStore } from '@/stores/user'
+
+const store = userStore()
+const { blockedAddresses } = store
+const { showBlockSender, sendersToBlock } = useBlockSender()
+const { setUndoAction } = useUndo()
+
+// Which of the listed senders are checked (only relevant when there's more than one). Reset to all
+// selected each time the prompt opens.
+const selected = reactive<Record<string, boolean>>({})
+watch(showBlockSender, (open) => {
+	if (!open) return
+	Object.keys(selected).forEach((key) => delete selected[key])
+	sendersToBlock.value.forEach((email) => (selected[email] = true))
+})
+
+const blockEmailAddresses = createResource({
+	url: 'mail.api.mail.block_email_addresses',
+	makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+	onSuccess: () => blockedAddresses.reload(),
+})
+
+const handleBlock = () => {
+	const emails =
+		sendersToBlock.value.length === 1
+			? sendersToBlock.value
+			: sendersToBlock.value.filter((email) => selected[email])
+	showBlockSender.value = false
+	if (!emails.length) return
+
+	// Blocking supersedes the junk action's undo — clear it so a following Ctrl+Z is a no-op (the
+	// junk toast's own Undo button is dismissed by raisePromiseToast's toast.removeAll()).
+	setUndoAction(undefined)
+
+	const action = () => blockEmailAddresses.submit({ emails })
+	const success = emails.length === 1 ? __('Sender blocked.') : __('Senders blocked.')
+	raisePromiseToast(action, __('Blocking...'), success)
+}
+
+const options = computed(() => ({
+	title: sendersToBlock.value.length > 1 ? __('Block Senders') : __('Block Sender'),
+	message:
+		sendersToBlock.value.length === 1
+			? __("Block {0}? You won't receive future messages from them.", [
+					sendersToBlock.value[0],
+				])
+			: __(
+					"Select the senders you want to block. You won't receive future messages from blocked senders.",
+				),
+	icon: { name: 'alert-triangle', appearance: 'warning' },
+	actions: [
+		{
+			label: __('Block'),
+			variant: 'solid',
+			autofocus: true,
+			onClick: handleBlock,
+		},
+	],
+}))
+</script>

--- a/frontend/src/components/Modals/BlockSenderModal.vue
+++ b/frontend/src/components/Modals/BlockSenderModal.vue
@@ -1,15 +1,14 @@
 <template>
 	<Dialog v-model="showBlockSender" :options="options">
 		<template v-if="sendersToBlock.length > 1" #body-content>
-			<div class="flex flex-col gap-3">
-				<label
+			<div class="flex flex-col gap-4">
+				<FormControl
 					v-for="email in sendersToBlock"
 					:key="email"
-					class="flex cursor-pointer items-center gap-2"
-				>
-					<Checkbox v-model="selected[email]" />
-					<span class="text-ink-gray-7 truncate text-base">{{ email }}</span>
-				</label>
+					v-model="selected[email]"
+					type="checkbox"
+					:label="email"
+				/>
 			</div>
 		</template>
 	</Dialog>
@@ -17,7 +16,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue'
-import { Checkbox, Dialog, createResource } from 'frappe-ui'
+import { Dialog, FormControl, createResource } from 'frappe-ui'
 
 import { raisePromiseToast } from '@/utils'
 import { useBlockSender, useUndo } from '@/utils/composables'

--- a/frontend/src/components/Modals/SettingsModal.vue
+++ b/frontend/src/components/Modals/SettingsModal.vue
@@ -38,7 +38,7 @@
 	</Dialog>
 </template>
 <script setup lang="ts">
-import { computed, inject, markRaw, ref } from 'vue'
+import { computed, inject, markRaw, ref, watch } from 'vue'
 import {
 	Ban,
 	Code,
@@ -55,6 +55,7 @@ import {
 } from 'lucide-vue-next'
 import { Button, Dialog } from 'frappe-ui'
 
+import { useSettings } from '@/utils/composables'
 import AccountSettings from '@/components/Settings/AccountSettings.vue'
 import AdvancedSettings from '@/components/Settings/AdvancedSettings.vue'
 import AppearanceSettings from '@/components/Settings/AppearanceSettings.vue'
@@ -69,6 +70,7 @@ import SignatureSettings from '@/components/Settings/SignatureSettings.vue'
 import VacationResponseSettings from '@/components/Settings/VacationResponseSettings.vue'
 
 const show = defineModel<boolean>()
+const { settingsTab } = useSettings()
 
 const user = inject('$user')
 
@@ -148,4 +150,12 @@ const tabs = computed(() => {
 	return allTabs.filter((tab) => tab.condition === undefined || tab.condition)
 })
 const activeTab = ref(tabs.value[0])
+
+// When opened via useSettings().openSettings('<label>'), jump to that tab.
+watch(show, (open) => {
+	if (!open || !settingsTab.value) return
+	const match = tabs.value.find((tab) => tab.label === settingsTab.value)
+	if (match) activeTab.value = match
+	settingsTab.value = ''
+})
 </script>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -348,6 +348,7 @@
 
 	<Dialog v-model="showEmptyMailbox" :options="emptyMailboxOptions" />
 	<Dialog v-model="showJunkOrDeleteThreads" :options="junkOrDeleteThreadsOptions" />
+	<BlockSenderModal />
 	<ShortcutsModal v-model="showShortcuts" />
 </template>
 <script setup lang="ts">
@@ -394,6 +395,7 @@ import HeaderActions from '@/components/HeaderActions.vue'
 import NoMails from '@/components/Icons/NoMails.vue'
 import MailListItem from '@/components/MailListItem.vue'
 import MailThread from '@/components/MailThread.vue'
+import BlockSenderModal from '@/components/Modals/BlockSenderModal.vue'
 import ShortcutsModal from '@/components/Modals/ShortcutsModal.vue'
 
 import type { COLOR_SCHEME, Thread, UserResource } from '@/types'

--- a/frontend/src/types/globals.d.ts
+++ b/frontend/src/types/globals.d.ts
@@ -1,6 +1,6 @@
 export {}
 
-type TranslateFunction = (message: string, variables?: string[]) => string
+type TranslateFunction = (message: string, variables?: (string | number)[]) => string
 declare global {
 	const __: TranslateFunction
 }

--- a/frontend/src/utils/composables.ts
+++ b/frontend/src/utils/composables.ts
@@ -94,25 +94,36 @@ export const useUndo = () => {
 
 // Shared state for the "Block sender?" prompt shown after marking/moving mail to Junk. A single
 // <BlockSenderModal> (rendered in MailboxView) reacts to this, so any view can open it.
+export interface BlockableSender {
+	name?: string
+	email: string
+}
+
 const showBlockSender = ref(false)
-const sendersToBlock = ref<string[]>([])
+const sendersToBlock = ref<BlockableSender[]>([])
 
 export const useBlockSender = () => {
 	const { identities, blockedAddresses } = userStore()
 
-	// Senders worth offering to block: drop the user's own identities and addresses already blocked.
-	const blockableSenders = (emails: (string | undefined)[]) => {
+	// Senders worth offering to block: drop the user's own identities and addresses already blocked,
+	// and de-duplicate by email (keeping the first occurrence's display name).
+	const blockableSenders = (senders: { name?: string; email?: string }[]) => {
 		const own = new Set((identities.data ?? []).map((i: Identity) => i.email))
 		const blocked = new Set<string>(blockedAddresses.data ?? [])
-		return [...new Set(emails)].filter(
-			(e): e is string => !!e && !own.has(e) && !blocked.has(e),
-		)
+		const seen = new Set<string>()
+		const result: BlockableSender[] = []
+		for (const { name, email } of senders) {
+			if (!email || own.has(email) || blocked.has(email) || seen.has(email)) continue
+			seen.add(email)
+			result.push({ name, email })
+		}
+		return result
 	}
 
-	const promptBlockSenders = (emails: (string | undefined)[]) => {
-		const senders = blockableSenders(emails)
-		if (!senders.length) return
-		sendersToBlock.value = senders
+	const promptBlockSenders = (senders: { name?: string; email?: string }[]) => {
+		const list = blockableSenders(senders)
+		if (!list.length) return
+		sendersToBlock.value = list
 		showBlockSender.value = true
 	}
 

--- a/frontend/src/utils/composables.ts
+++ b/frontend/src/utils/composables.ts
@@ -130,6 +130,21 @@ export const useBlockSender = () => {
 	return { showBlockSender, sendersToBlock, promptBlockSenders }
 }
 
+// Shared state for the Settings dialog, so any view can open it (optionally on a specific tab).
+// <SettingsModal> (rendered in AppSidebar) reacts to `showSettings`, and selects `settingsTab` by
+// label when it opens.
+const showSettings = ref(false)
+const settingsTab = ref('')
+
+export const useSettings = () => {
+	const openSettings = (tab = '') => {
+		settingsTab.value = tab
+		showSettings.value = true
+	}
+
+	return { showSettings, settingsTab, openSettings }
+}
+
 const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 const systemIsDark = ref(mediaQuery.matches)
 mediaQuery.addEventListener('change', () => (systemIsDark.value = mediaQuery.matches))

--- a/frontend/src/utils/composables.ts
+++ b/frontend/src/utils/composables.ts
@@ -2,6 +2,8 @@ import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
 
 import { userStore } from '@/stores/user'
 
+import type { Identity } from '@/types'
+
 export const useScreenSize = () => {
 	const size = reactive({ width: window.innerWidth, height: window.innerHeight })
 
@@ -88,6 +90,33 @@ export const useUndo = () => {
 	}
 
 	return { setUndoAction, undo }
+}
+
+// Shared state for the "Block sender?" prompt shown after marking/moving mail to Junk. A single
+// <BlockSenderModal> (rendered in MailboxView) reacts to this, so any view can open it.
+const showBlockSender = ref(false)
+const sendersToBlock = ref<string[]>([])
+
+export const useBlockSender = () => {
+	const { identities, blockedAddresses } = userStore()
+
+	// Senders worth offering to block: drop the user's own identities and addresses already blocked.
+	const blockableSenders = (emails: (string | undefined)[]) => {
+		const own = new Set((identities.data ?? []).map((i: Identity) => i.email))
+		const blocked = new Set<string>(blockedAddresses.data ?? [])
+		return [...new Set(emails)].filter(
+			(e): e is string => !!e && !own.has(e) && !blocked.has(e),
+		)
+	}
+
+	const promptBlockSenders = (emails: (string | undefined)[]) => {
+		const senders = blockableSenders(emails)
+		if (!senders.length) return
+		sendersToBlock.value = senders
+		showBlockSender.value = true
+	}
+
+	return { showBlockSender, sendersToBlock, promptBlockSenders }
 }
 
 const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')

--- a/frontend/src/utils/useThreadActions.ts
+++ b/frontend/src/utils/useThreadActions.ts
@@ -316,7 +316,6 @@ export function useThreadActions(deps: {
 	const junkOrDeleteThreadsOptions = computed(() => ({
 		title: junkOrDeleteTitle.value,
 		message: junkOrDeleteMessage.value,
-		icon: { name: 'alert-triangle', appearance: 'warning' },
 		actions: [
 			{
 				label: __('Confirm'),
@@ -527,14 +526,14 @@ export function useThreadActions(deps: {
 			mailbox_ids: m.mailboxes.map((mb) => mb.mailbox_id),
 			junk: m.junk,
 		}))
-		const senderEmails = mails.map((m) => m.from_email)
+		const senders = mails.map((m) => ({ name: m.from_name, email: m.from_email }))
 		const ids = snapshot.map((m) => m.id)
 		const action = async () => {
 			await setMailsSpam.submit({ ids, spam })
 			handleSuccessAndRemoveFromList(threadIDs)
 			// After marking as Junk, offer to block the sender(s). Blocking then clears the undo set
 			// below (undoing the junk once the sender is blocked would be inconsistent).
-			if (spam) promptBlockSenders(senderEmails)
+			if (spam) promptBlockSenders(senders)
 		}
 
 		setUndoAction(() => {

--- a/frontend/src/utils/useThreadActions.ts
+++ b/frontend/src/utils/useThreadActions.ts
@@ -4,7 +4,7 @@ import { createResource, toast } from 'frappe-ui'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/constants'
 import { getIcon, raisePromiseToast, raiseToast } from '@/utils'
-import { useUndo } from '@/utils/composables'
+import { useBlockSender, useUndo } from '@/utils/composables'
 import { userStore } from '@/stores/user'
 
 import type { Mail, Thread } from '@/types'
@@ -52,6 +52,7 @@ export function useThreadActions(deps: {
 	const store = userStore()
 	const { mailboxes, mailboxIds } = store
 	const { setUndoAction, undo } = useUndo()
+	const { promptBlockSenders } = useBlockSender()
 
 	const threadMails = (threadIds: string[]): Mail[] => {
 		const items = (threadsResource.value.data ?? []).filter((t: Thread) =>
@@ -422,6 +423,10 @@ export function useThreadActions(deps: {
 		const selectedThreads = Object.values(threadIDs).flat()
 		if (!selectedThreads.length) return
 
+		// Moving to Junk is the same as Mark as Junk: no undo, offer to block the sender instead.
+		if (Object.keys(threadIDs).length === 1 && Object.keys(threadIDs)[0] === mailboxIds.junk)
+			return handleSetSpamStatus({ 1: selectedThreads })
+
 		const originOf = (tid: string): string | undefined =>
 			threadsResource.value.data?.find((t: Thread) => t.thread_id === tid)?.mailboxes[0]
 				?.mailbox_id
@@ -514,17 +519,22 @@ export function useThreadActions(deps: {
 		if (JSON.stringify(originalState) === JSON.stringify(threadIDs)) return
 
 		const spam = Object.keys(threadIDs)[0] === '1'
+		const mails = threadMails(selectedThreads)
 		// Snapshot exact state now (threads leave the list on success) so undo restores the original
 		// mailbox + junk, rather than set_spam_status's blanket move to Inbox.
-		const snapshot = threadMails(selectedThreads).map((m) => ({
+		const snapshot = mails.map((m) => ({
 			id: m.id,
 			mailbox_ids: m.mailboxes.map((mb) => mb.mailbox_id),
 			junk: m.junk,
 		}))
+		const senderEmails = mails.map((m) => m.from_email)
 		const ids = snapshot.map((m) => m.id)
 		const action = async () => {
 			await setMailsSpam.submit({ ids, spam })
 			handleSuccessAndRemoveFromList(threadIDs)
+			// After marking as Junk, offer to block the sender(s). Blocking then clears the undo set
+			// below (undoing the junk once the sender is blocked would be inconsistent).
+			if (spam) promptBlockSenders(senderEmails)
 		}
 
 		setUndoAction(() => {

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -5,10 +5,11 @@ import frappe
 import pydenticon
 import requests
 from frappe import _
+from frappe.model.document import bulk_insert
 from frappe.utils import format_datetime, random_string
 
 from mail.api.contacts import create_contacts_if_not_exists
-from mail.api.sieve import update_sieve_script_for_mailbox
+from mail.api.sieve import update_sieve_script_for_blocked_emails, update_sieve_script_for_mailbox
 from mail.api.utils import get_avatar_url
 from mail.client.doctype.blocked_email_address.blocked_email_address import get_blocked_email_addresses
 from mail.client.doctype.mail_message.mail_message import (
@@ -747,6 +748,34 @@ def block_email_address(account: str, email: str) -> dict:
 
 	doc = frappe.get_doc({"doctype": "Blocked Email Address", "account": account, "email": email})
 	doc.insert()
+
+
+@frappe.whitelist()
+def block_email_addresses(account: str, emails: list[str]) -> None:
+	"""Blocks multiple email addresses for the given account in a single request.
+
+	Inserts in one batched query via `bulk_insert` (no per-document hooks) instead of looping over
+	`doc.insert()`. Addresses already blocked are skipped, `ignore_duplicates` guards against races,
+	and the sieve script is regenerated once at the end since it is rebuilt from the full list.
+	"""
+
+	user = parse_account(account)[0]
+	has_permission_for_user(user)
+
+	already_blocked = set(get_blocked_email_addresses(account))
+	docs = []
+	for email in dict.fromkeys(emails):  # de-duplicate while preserving order
+		if not email or email in already_blocked:
+			continue
+		doc = frappe.get_doc(
+			{"doctype": "Blocked Email Address", "account": account, "email": email, "user": user}
+		)
+		doc.set_new_name()
+		docs.append(doc)
+
+	if docs:
+		bulk_insert("Blocked Email Address", docs, ignore_duplicates=True)
+		update_sieve_script_for_blocked_emails(account)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

Prompt the user to block the sender after marking/moving mail to **Junk**, plus related mail-list and blocklist UX fixes.

### Block sender
- After a successful Junk action (single-mail, thread, and bulk/list views), a "Block N senders?" modal appears.
- Multi-select list with select-all and a running "N of M selected" count; skips the user's own identities and already-blocked addresses (not shown if none remain).
- The Junk action keeps its undo; **blocking** clears that undo (undoing the junk once the sender is blocked would be inconsistent).

### Blocked-sender banner
- The "block list" text in the blocked-sender alert is now an underlined link that opens **Settings → Block List** (shared `useSettings()` state; the settings modal jumps to that tab).

### Plaintext email bodies
- Linkify URLs/emails in plaintext bodies via a `LinkifiedText` component that renders auto-escaped text + real `<a>` nodes — no `v-html` and no manual HTML escaping.

### Full-width (reading-pane-off) list
- Show other-mailbox chips in the plain Inbox (previously only rendered for attachments/drafts/starred/search).
- Keep the subject/preview columns aligned when chips appear (dropped an `ml-auto` that fought the `flex-1` preview).
- Vertically level the subject and preview.

## Backend

Adds `mail.api.mail.block_email_addresses(account, emails)` — blocks multiple addresses in one request via `bulk_insert` (single batched query, no per-document hooks), skipping already-blocked addresses and regenerating the sieve script once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)