### PR TITLE
fix: surface auth errors after re-login (backport #547 to v0)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,23 +15,17 @@ import { userStore } from '@/stores/user'
 
 import FrappePushNotification from '../public/frappe-push-notification'
 
-// Centralised auth handling: any request that comes back unauthenticated signs the user
-// out and redirects to login, so they can't keep composing/acting against a dead session.
+// Centralised auth handling: when a request comes back unauthenticated, sign the user out and
+// redirect to login so they can't keep acting against a dead session. The error is always
+// re-thrown afterwards, so the originating resource still reports it normally (no swallowing,
+// which previously left resources hanging and hid errors like a wrong-password login).
 setConfig('resourceFetcher', async (options: Parameters<typeof frappeRequest>[0]) => {
 	try {
 		return await frappeRequest(options)
 	} catch (error) {
-		// A dead session surfaces as AuthenticationError or (for non-guest methods)
-		// PermissionError "Login to access". If the session is actually gone, swallow the
-		// error so the resource doesn't also toast it — we've shown "signed out" and are
-		// redirecting to login. A genuine PermissionError for a logged-in user re-throws and
-		// surfaces normally. Never-settling promise → the resource's onSuccess/onError won't fire.
 		const excType = (error as { exc_type?: string })?.exc_type
-		if (
-			(excType === 'AuthenticationError' || excType === 'PermissionError') &&
+		if (excType === 'AuthenticationError' || excType === 'PermissionError')
 			sessionStore().handleSessionExpired()
-		)
-			return new Promise<never>(() => {})
 		throw error
 	}
 })

--- a/frontend/src/stores/session.ts
+++ b/frontend/src/stores/session.ts
@@ -55,25 +55,20 @@ export const sessionStore = defineStore('mail-session', () => {
 		onSuccess: (data) => (document.querySelector("link[rel='icon']").href = data.favicon),
 	})
 
-	// Called when a request fails with an auth/permission error. Returns true if the session
-	// is actually gone (so the caller can swallow the error and avoid a duplicate toast),
-	// false if the session is still alive — i.e. a genuine PermissionError that should surface
-	// normally. Frappe resets the user_id cookie to Guest on a dead session, so the cookie is
-	// the discriminator. Signs out + notifies + redirects once; later concurrent calls just
-	// report handled.
-	const handleSessionExpired = (): boolean => {
-		// Still logged in — this is a real permission error, not a logout.
-		if (sessionUser()) return false
+	// Called when a request fails with an auth/permission error: sign the user out (clear state,
+	// one toast, redirect to login) when their session is actually gone. No-op when still logged
+	// in (a genuine PermissionError that should surface) or when there was never a session in
+	// this tab (a failed login attempt — let the form show "wrong password"). Frappe resets the
+	// user_id cookie to Guest on a dead session, so the cookie is the discriminator. Idempotent:
+	// once user.value is cleared, concurrent calls return early, so the toast/redirect fire once.
+	const handleSessionExpired = (): void => {
+		if (sessionUser()) return
+		if (!user.value) return
 
-		if (user.value) {
-			user.value = null
-			userResource.reset()
-			mailboxes.reset()
-			raiseToast(__('You have been signed out. Please sign in again.'), 'error')
-			if (!router.currentRoute.value.meta?.isLogin) router.replace({ name: 'Login' })
-		}
-
-		return true
+		user.value = null
+		reset()
+		raiseToast(__('You have been signed out. Please sign in again.'), 'error')
+		if (!router.currentRoute.value.meta?.isLogin) router.replace({ name: 'Login' })
 	}
 
 	return { isLoggedIn, login, logout, branding, handleSessionExpired }


### PR DESCRIPTION
Backport of #547 to the v0 release branch.

## What this fixes

#536 (already on this branch) routed auth/permission failures through a never-settling promise (`return new Promise<never>(() => {})`), which **swallowed genuine errors** — e.g. a wrong-password login showed no message — and left resources hanging. This keeps the sign-out toast + redirect on a real logout, but always re-throws so the originating resource still reports its error. `handleSessionExpired` no longer returns a swallow signal.

## Scope

Only the **auth-error-surfacing** portion of #547 is here. The re-login data-reload portion (`userStore.reset()`) was already backported separately (#549 / the v1 equivalent), so it is not repeated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)