### PR TITLE
fix(stalwart): delete DKIM signatures before deleting a domain (backport #567 to v1)

### DIFF
--- a/mail/stalwart/__init__.py
+++ b/mail/stalwart/__init__.py
@@ -15,7 +15,7 @@ from mail.stalwart.account import (
 	UserRoles,
 )
 from mail.stalwart.app_password import AppPassword, AppPasswordService
-from mail.stalwart.domain import Domain, DomainService
+from mail.stalwart.domain import DkimSignatureService, Domain, DomainService
 from mail.stalwart.role import RoleService
 from mail.utils import get_config, is_stalwart_configured
 from mail.utils.dt import utcnow
@@ -131,6 +131,13 @@ def create_domain(name: str, description: str | None = None) -> str:
 
 def delete_domain(domain_id: str) -> None:
 	"""Deletes a domain from the Stalwart server by ID."""
+
+	# Stalwart refuses to delete a domain while DKIM signatures are still linked to it,
+	# so the linked DKIM signatures must be removed first.
+	dkim_service = DkimSignatureService()
+	dkim_signature_ids = [signature["id"] for signature in dkim_service.get_all_by_domain(domain_id)]
+	if dkim_signature_ids:
+		dkim_service.delete(dkim_signature_ids)
 
 	DomainService().delete([domain_id])
 	get_domain_by_name.clear_cache()

--- a/mail/stalwart/domain.py
+++ b/mail/stalwart/domain.py
@@ -324,3 +324,55 @@ class DomainService(StalwartCLI):
 
 		if not response["success"]:
 			frappe.throw(title=_("Failed to delete domains"), msg=response["output"] or response["error"])
+
+
+class DkimSignatureService(StalwartCLI):
+	DEFAULT_FIELDS: ClassVar[list[str]] = ["id", "selector", "domainId", "stage"]
+
+	@classmethod
+	def _resolved_fields(cls, fields: list[str] | None) -> list[str]:
+		return fields if isinstance(fields, list) else cls.DEFAULT_FIELDS
+
+	@staticmethod
+	def _parse_query_output(output: str) -> list[dict]:
+		if not output:
+			return []
+
+		return [json.loads(signature) for signature in output.splitlines()]
+
+	def get_all_by_domain(self, domain_id: str, fields: list[str] | None = None) -> list[dict]:
+		"""Fetches all DKIM signatures associated with the given domain from the Stalwart server."""
+
+		fields = self._resolved_fields(fields)
+
+		commands = ["query", "DkimSignature", "--where", f"domainId={domain_id}"]
+
+		if fields:
+			commands.extend(["--fields", ",".join(fields)])
+
+		commands.append("--json")
+		response = self.run(commands)
+
+		if response["success"]:
+			return self._parse_query_output(response["output"])
+		else:
+			frappe.throw(
+				title=_("Failed to fetch DKIM signatures"), msg=response["output"] or response["error"]
+			)
+
+	def delete(self, ids: list[str]) -> None:
+		"""Deletes DKIM signatures with the specified IDs from the Stalwart server."""
+
+		if not ids:
+			frappe.throw(
+				title=_("No DKIM signature IDs provided"),
+				msg=_("No DKIM signature IDs provided for deletion."),
+			)
+
+		response = self.run(["delete", "DkimSignature", "--ids", ",".join(ids)])
+
+		if not response["success"]:
+			frappe.throw(
+				title=_("Failed to delete DKIM signatures"),
+				msg=response["output"] or response["error"],
+			)


### PR DESCRIPTION
Backport of #567 to `v1`.

### Problem

Deleting a domain from Stalwart fails when the domain still has DKIM signatures (DKIM keys) linked to it. Stalwart refuses to delete a `Domain` while linked `DkimSignature` objects reference it via `domainId`, so `delete_domain()` errors out.

### Fix

Before deleting the domain, query and delete its linked DKIM signatures. A new `DkimSignatureService` (in `mail/stalwart/domain.py`) wraps the Stalwart CLI for the `DkimSignature` datatype:

- `get_all_by_domain(domain_id)` — queries `DkimSignature --where domainId=<id>`
- `delete(ids)` — deletes `DkimSignature --ids <ids>`

`delete_domain()` (in `mail/stalwart/__init__.py`) now removes the linked DKIM signatures first, then deletes the domain.

### Notes

Clean cherry-pick of the develop commit — the affected files are identical on `v1` and `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)