### PR TITLE
fix: prefix Error Log titles with "[Mail]" (backport v1)

### DIFF
--- a/UPGRADING/v1.md
+++ b/UPGRADING/v1.md
@@ -147,6 +147,7 @@ Run this in bench console after Stalwart 0.16.x is fully up and credentials are 
 ```python
 import frappe
 from frappe import _
+from mail.utils import log_error
 from mail.stalwart import create_app_password
 from mail.utils.user import is_jmap_configured
 
@@ -174,7 +175,7 @@ for user_settings in settings:
         user_settings_doc.save(ignore_permissions=True)
 
     except Exception as error:
-        frappe.log_error(
+        log_error(
             title=_("Error updating app password for account {0}").format(
                 user_settings["name"]
             ),

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -21,6 +21,7 @@ from mail.storage.data_store import Entity
 if TYPE_CHECKING:
 	from mail.jmap.services.core import CoreService
 
+from mail.utils import log_error
 from mail.utils.user import get_account_emails, is_system_manager
 from mail.utils.validation import has_permission_for_user
 
@@ -292,7 +293,7 @@ def create_archive_mailbox(account: str) -> None:
 		get_mailbox_id_by_role(account, "archive", create_if_not_exists=True)
 
 	except Exception:
-		frappe.log_error(
+		log_error(
 			message=f"Failed to create archive mailbox for account {account}",
 			title="Archive Mailbox Creation Error",
 		)

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -294,6 +294,6 @@ def create_archive_mailbox(account: str) -> None:
 
 	except Exception:
 		log_error(
-			message=f"Failed to create archive mailbox for account {account}",
-			title="Archive Mailbox Creation Error",
+			"Archive Mailbox Creation Error",
+			f"Failed to create archive mailbox for account {account}",
 		)

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from uuid import uuid7
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
 
@@ -294,6 +295,6 @@ def create_archive_mailbox(account: str) -> None:
 
 	except Exception:
 		log_error(
-			"Archive Mailbox Creation Error",
-			f"Failed to create archive mailbox for account {account}",
+			_("Archive Mailbox Creation Error"),
+			_("Failed to create archive mailbox for account {0}").format(account),
 		)

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -34,6 +34,7 @@ from mail.utils import (
 	enqueue_job,
 	get_config,
 	get_push_logger,
+	log_error,
 	parse_filters,
 	user_context,
 )
@@ -785,7 +786,7 @@ def get_message_ids(
 			return [email["id"] for email in emails if not set(mailbox_id).isdisjoint(email["mailboxIds"])]
 
 	except Exception:
-		frappe.log_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
+		log_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
 		frappe.throw(_("Failed to fetch message IDs."))
 
 
@@ -802,7 +803,7 @@ def delete_messages(account: str, ids: list[str]) -> None:
 		service.delete(ids)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to delete mail(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -830,7 +831,7 @@ def empty_mailbox(account: str, mailbox_id: str) -> None:
 			service.delete(ids)
 			_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to empty mailbox"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -851,7 +852,7 @@ def move_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> N
 		service.update(emails, replace_mailboxes=True)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to move mail(s) to mailbox"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -881,7 +882,7 @@ def set_messages_mailboxes(account: str, mails: list[dict]) -> None:
 		service.update(emails, replace_keywords=False, replace_mailboxes=True)
 		_remove_cached_messages(account, [mail["id"] for mail in mails])
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to restore mailbox membership for mail(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -902,7 +903,7 @@ def add_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> No
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to add mail(s) to mailbox"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -923,7 +924,7 @@ def remove_messages_from_mailbox(account: str, ids: list[str], mailbox_id: str) 
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to remove mail(s) from mailbox"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -958,7 +959,7 @@ def set_seen_status(account: str, ids: list[str], seen: bool = True) -> None:
 			_cache_messages(account, messages_to_cache)
 
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to set seen status for mail(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -993,7 +994,7 @@ def set_flagged_status(account: str, ids: list[str], flagged: bool = True) -> No
 			_cache_messages(account, messages_to_cache)
 
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to set flagged status for mail(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -1025,7 +1026,7 @@ def set_spam_status(account: str, ids: list[str], spam: bool = True) -> None:
 
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to set spam status for mail(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -1076,7 +1077,7 @@ def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -
 
 		return result
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=_("Failed to fetch blob(s)"),
 			message=frappe.get_traceback(with_context=True),
 		)
@@ -1378,7 +1379,7 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 
 	except Exception:
 		logger.error({**ctx, "event": "fetch-changes-failed"})
-		frappe.log_error(
+		log_error(
 			title=_("Failed to fetch changes"),
 			message=frappe.get_traceback(with_context=True),
 		)

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -804,8 +804,8 @@ def delete_messages(account: str, ids: list[str]) -> None:
 		_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to delete mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to delete mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to delete mail(s)."))
 
@@ -832,8 +832,8 @@ def empty_mailbox(account: str, mailbox_id: str) -> None:
 			_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to empty mailbox"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to empty mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to empty mailbox."))
 
@@ -853,8 +853,8 @@ def move_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> N
 		_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to move mail(s) to mailbox"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to move mail(s) to mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to move mail(s) to mailbox."))
 
@@ -883,8 +883,8 @@ def set_messages_mailboxes(account: str, mails: list[dict]) -> None:
 		_remove_cached_messages(account, [mail["id"] for mail in mails])
 	except Exception:
 		log_error(
-			title=_("Failed to restore mailbox membership for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to restore mailbox membership for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to restore mailbox membership for mail(s)."))
 
@@ -904,8 +904,8 @@ def add_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> No
 		_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to add mail(s) to mailbox"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to add mail(s) to mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to add mail(s) to mailbox."))
 
@@ -925,8 +925,8 @@ def remove_messages_from_mailbox(account: str, ids: list[str], mailbox_id: str) 
 		_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to remove mail(s) from mailbox"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to remove mail(s) from mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to remove mail(s) from mailbox."))
 
@@ -960,8 +960,8 @@ def set_seen_status(account: str, ids: list[str], seen: bool = True) -> None:
 
 	except Exception:
 		log_error(
-			title=_("Failed to set seen status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to set seen status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set seen status for mail(s)."))
 
@@ -995,8 +995,8 @@ def set_flagged_status(account: str, ids: list[str], flagged: bool = True) -> No
 
 	except Exception:
 		log_error(
-			title=_("Failed to set flagged status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to set flagged status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set flagged status for mail(s)."))
 
@@ -1027,8 +1027,8 @@ def set_spam_status(account: str, ids: list[str], spam: bool = True) -> None:
 		_remove_cached_messages(account, ids)
 	except Exception:
 		log_error(
-			title=_("Failed to set spam status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to set spam status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set spam status for mail(s)."))
 
@@ -1078,8 +1078,8 @@ def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -
 		return result
 	except Exception:
 		log_error(
-			title=_("Failed to fetch blob(s)"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to fetch blob(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to fetch blob(s)."))
 
@@ -1380,8 +1380,8 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 	except Exception:
 		logger.error({**ctx, "event": "fetch-changes-failed"})
 		log_error(
-			title=_("Failed to fetch changes"),
-			message=frappe.get_traceback(with_context=True),
+			_("Failed to fetch changes"),
+			frappe.get_traceback(with_context=True),
 		)
 
 

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -861,7 +861,7 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 
 	except Exception:
 		log_error(
-			"Failed - Enqueue Process Pending Emails", frappe.get_traceback(with_context=True)
+			_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True)
 		)
 
 

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -861,7 +861,7 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 
 	except Exception:
 		log_error(
-			title="Failed - Enqueue Process Pending Emails", message=frappe.get_traceback(with_context=True)
+			"Failed - Enqueue Process Pending Emails", frappe.get_traceback(with_context=True)
 		)
 
 

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -33,7 +33,7 @@ from mail.jmap import get_email_service, get_identities, get_jmap_connection, pa
 from mail.jmap.models import EmailAddress, EmailAttachment, EmailCreateModel, EmailHeader, EmailRecipient
 from mail.jmap.services.mail.email import EmailService
 from mail.jmap.services.mail.mailbox import MailboxService
-from mail.utils import get_config
+from mail.utils import get_config, log_error
 from mail.utils.dt import parsedate_to_datetime
 from mail.utils.user import is_administrator
 from mail.utils.validation import has_permission_for_user
@@ -547,7 +547,7 @@ class MailQueue(Document):
 					self.in_reply_to_id = ids[0]
 			except Exception:
 				self.in_reply_to_id = None
-				frappe.log_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
+				log_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
 
 	@frappe.whitelist()
 	def retry(self) -> None:
@@ -860,7 +860,7 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 			enqueue_process_pending_emails(batch_size, max_batch_size)
 
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title="Failed - Enqueue Process Pending Emails", message=frappe.get_traceback(with_context=True)
 		)
 

--- a/mail/patches/create_push_subscriptions.py
+++ b/mail/patches/create_push_subscriptions.py
@@ -3,6 +3,7 @@ import time
 import frappe
 
 from mail.jmap import get_push_subscription_service
+from mail.utils import log_error
 
 
 def execute() -> None:
@@ -21,7 +22,7 @@ def execute() -> None:
 			ps.user = user
 			ps.insert(ignore_permissions=True)
 		except Exception as e:
-			frappe.log_error(
+			log_error(
 				title="Push Subscription Creation Failed",
 				message=f"Failed to create push subscription for user {user}: {e!s}",
 			)

--- a/mail/patches/create_push_subscriptions.py
+++ b/mail/patches/create_push_subscriptions.py
@@ -1,6 +1,7 @@
 import time
 
 import frappe
+from frappe import _
 
 from mail.jmap import get_push_subscription_service
 from mail.utils import log_error
@@ -23,8 +24,8 @@ def execute() -> None:
 			ps.insert(ignore_permissions=True)
 		except Exception as e:
 			log_error(
-				"Push Subscription Creation Failed",
-				f"Failed to create push subscription for user {user}: {e!s}",
+				_("Push Subscription Creation Failed"),
+				_("Failed to create push subscription for user {0}: {1}").format(user, str(e)),
 			)
 
 		time.sleep(0.1)

--- a/mail/patches/create_push_subscriptions.py
+++ b/mail/patches/create_push_subscriptions.py
@@ -23,8 +23,8 @@ def execute() -> None:
 			ps.insert(ignore_permissions=True)
 		except Exception as e:
 			log_error(
-				title="Push Subscription Creation Failed",
-				message=f"Failed to create push subscription for user {user}: {e!s}",
+				"Push Subscription Creation Failed",
+				f"Failed to create push subscription for user {user}: {e!s}",
 			)
 
 		time.sleep(0.1)

--- a/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -11,5 +11,5 @@ def execute() -> None:
 			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
 		except Exception:
 			log_error(
-				title=_("Failed to generate SSH keypair"), message=frappe.get_traceback(with_context=False)
+				_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False)
 			)

--- a/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe import _
 
+from mail.utils import log_error
+
 
 def execute() -> None:
 	clusters = frappe.db.get_all("Mail Cluster", {"ssh_public_key": ["in", ["", None]]}, pluck="name")
@@ -8,6 +10,6 @@ def execute() -> None:
 		try:
 			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
 		except Exception:
-			frappe.log_error(
+			log_error(
 				title=_("Failed to generate SSH keypair"), message=frappe.get_traceback(with_context=False)
 			)

--- a/mail/patches/set_user_account.py
+++ b/mail/patches/set_user_account.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.query_builder import Case
 
+from mail.utils import log_error
 from mail.utils.user import get_user_personal_account
 
 DOCTYPES = [
@@ -59,4 +60,4 @@ def execute() -> None:
 			).run()
 
 		except Exception as e:
-			frappe.log_error(message=str(e), title=f"Error while setting user account for {doctype}")
+			log_error(message=str(e), title=f"Error while setting user account for {doctype}")

--- a/mail/patches/set_user_account.py
+++ b/mail/patches/set_user_account.py
@@ -60,4 +60,4 @@ def execute() -> None:
 			).run()
 
 		except Exception as e:
-			log_error(message=str(e), title=f"Error while setting user account for {doctype}")
+			log_error(f"Error while setting user account for {doctype}", str(e))

--- a/mail/patches/set_user_account.py
+++ b/mail/patches/set_user_account.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.query_builder import Case
 
 from mail.utils import log_error
@@ -60,4 +61,7 @@ def execute() -> None:
 			).run()
 
 		except Exception as e:
-			log_error(f"Error while setting user account for {doctype}", str(e))
+			log_error(
+				_("Error while setting user account for {0}").format(doctype),
+				str(e),
+			)

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -403,8 +403,8 @@ def execute_with_logging(
 		return func(*args, **kwargs)
 	except Exception:
 		log_error(
-			title=title,
-			message=frappe.get_traceback(with_context=with_context),
+			title,
+			frappe.get_traceback(with_context=with_context),
 		)
 		if user_message:
 			frappe.throw(title=title, msg=user_message)

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -381,6 +381,19 @@ def reformat_pbkdf2_hash(passlib_hash: str, dklen: int | None = None) -> str:
 	return formatted_hash
 
 
+def log_error(title: str | None = None, message: str | None = None, **kwargs) -> None:
+	"""Logs an error, prefixing the title with "[Mail]" so Mail app errors can be filtered out.
+
+	Wraps `frappe.log_error` and should be used in place of it throughout the Mail app.
+	"""
+
+	prefix = "[Mail] "
+	if title and not title.startswith(prefix):
+		title = f"{prefix}{title}"
+
+	frappe.log_error(title=title, message=message, **kwargs)
+
+
 def execute_with_logging(
 	func: callable, title: str, user_message: str | None = None, with_context: bool = False, *args, **kwargs
 ) -> Any | None:
@@ -389,7 +402,7 @@ def execute_with_logging(
 	try:
 		return func(*args, **kwargs)
 	except Exception:
-		frappe.log_error(
+		log_error(
 			title=title,
 			message=frappe.get_traceback(with_context=with_context),
 		)


### PR DESCRIPTION
Backport of #572 to `v1`.

## Description

Error Log entries created by the Mail app now have their titles prefixed with `[Mail]`, so they can be filtered apart from other apps' errors when multiple apps share a bench/site.

## Changes

- Add a `log_error(title, message, **kwargs)` wrapper in `mail/utils/__init__.py` that prepends `"[Mail] "` to the title (idempotently) and forwards to `frappe.log_error`.
- Route all `frappe.log_error` callsites through the wrapper, calling it positionally as `log_error(title, message)`.
- Titles and human-readable literal messages are wrapped in `_()` for translation (traceback / exception-string messages are left as-is).

Cherry-picked cleanly from the develop PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)