### PR TITLE
fix: prefix Error Log titles with "[Mail]" (backport v0)

### DIFF
--- a/mail/backend.py
+++ b/mail/backend.py
@@ -7,7 +7,7 @@ import requests
 from frappe import _
 
 from mail.jmap.connection import raise_for_status
-from mail.utils import get_mail_config
+from mail.utils import get_mail_config, log_error
 from mail.utils.validation import validate_mail_config
 
 
@@ -89,8 +89,8 @@ class MailBackendAPI:
 
 			return response
 		except Exception:
-			frappe.log_error(
-				title=_("Mail Backend Request Failed"), message=frappe.get_traceback(with_context=False)
+			log_error(
+				_("Mail Backend Request Failed"), frappe.get_traceback(with_context=False)
 			)
 
 			if response:

--- a/mail/backend.py
+++ b/mail/backend.py
@@ -89,9 +89,7 @@ class MailBackendAPI:
 
 			return response
 		except Exception:
-			log_error(
-				_("Mail Backend Request Failed"), frappe.get_traceback(with_context=False)
-			)
+			log_error(_("Mail Backend Request Failed"), frappe.get_traceback(with_context=False))
 
 			if response:
 				frappe.throw(

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from uuid import uuid7
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cint
 
@@ -21,6 +22,7 @@ from mail.storage.data_store import Entity
 if TYPE_CHECKING:
 	from mail.jmap.services.core import CoreService
 
+from mail.utils import log_error
 from mail.utils.user import get_account_emails, is_system_manager
 from mail.utils.validation import has_permission_for_user
 
@@ -292,7 +294,7 @@ def create_archive_mailbox(account: str) -> None:
 		get_mailbox_id_by_role(account, "archive", create_if_not_exists=True)
 
 	except Exception:
-		frappe.log_error(
-			message=f"Failed to create archive mailbox for account {account}",
-			title="Archive Mailbox Creation Error",
+		log_error(
+			_("Archive Mailbox Creation Error"),
+			_("Failed to create archive mailbox for account {0}").format(account),
 		)

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -34,6 +34,7 @@ from mail.utils import (
 	enqueue_job,
 	get_mail_config,
 	get_push_logger,
+	log_error,
 	parse_filters,
 	user_context,
 )
@@ -785,7 +786,7 @@ def get_message_ids(
 			return [email["id"] for email in emails if not set(mailbox_id).isdisjoint(email["mailboxIds"])]
 
 	except Exception:
-		frappe.log_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
+		log_error(_("Failed to fetch message IDs."), frappe.get_traceback(with_context=True))
 		frappe.throw(_("Failed to fetch message IDs."))
 
 
@@ -802,9 +803,9 @@ def delete_messages(account: str, ids: list[str]) -> None:
 		service.delete(ids)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to delete mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to delete mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to delete mail(s)."))
 
@@ -830,9 +831,9 @@ def empty_mailbox(account: str, mailbox_id: str) -> None:
 			service.delete(ids)
 			_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to empty mailbox"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to empty mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to empty mailbox."))
 
@@ -851,9 +852,9 @@ def move_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> N
 		service.update(emails, replace_mailboxes=True)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to move mail(s) to mailbox"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to move mail(s) to mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to move mail(s) to mailbox."))
 
@@ -881,9 +882,9 @@ def set_messages_mailboxes(account: str, mails: list[dict]) -> None:
 		service.update(emails, replace_keywords=False, replace_mailboxes=True)
 		_remove_cached_messages(account, [mail["id"] for mail in mails])
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to restore mailbox membership for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to restore mailbox membership for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to restore mailbox membership for mail(s)."))
 
@@ -902,9 +903,9 @@ def add_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> No
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to add mail(s) to mailbox"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to add mail(s) to mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to add mail(s) to mailbox."))
 
@@ -923,9 +924,9 @@ def remove_messages_from_mailbox(account: str, ids: list[str], mailbox_id: str) 
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to remove mail(s) from mailbox"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to remove mail(s) from mailbox"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to remove mail(s) from mailbox."))
 
@@ -958,9 +959,9 @@ def set_seen_status(account: str, ids: list[str], seen: bool = True) -> None:
 			_cache_messages(account, messages_to_cache)
 
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to set seen status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to set seen status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set seen status for mail(s)."))
 
@@ -993,9 +994,9 @@ def set_flagged_status(account: str, ids: list[str], flagged: bool = True) -> No
 			_cache_messages(account, messages_to_cache)
 
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to set flagged status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to set flagged status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set flagged status for mail(s)."))
 
@@ -1025,9 +1026,9 @@ def set_spam_status(account: str, ids: list[str], spam: bool = True) -> None:
 
 		_remove_cached_messages(account, ids)
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to set spam status for mail(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to set spam status for mail(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to set spam status for mail(s)."))
 
@@ -1076,9 +1077,9 @@ def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -
 
 		return result
 	except Exception:
-		frappe.log_error(
-			title=_("Failed to fetch blob(s)"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to fetch blob(s)"),
+			frappe.get_traceback(with_context=True),
 		)
 		frappe.throw(_("Failed to fetch blob(s)."))
 
@@ -1378,9 +1379,9 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 
 	except Exception:
 		logger.error({**ctx, "event": "fetch-changes-failed"})
-		frappe.log_error(
-			title=_("Failed to fetch changes"),
-			message=frappe.get_traceback(with_context=True),
+		log_error(
+			_("Failed to fetch changes"),
+			frappe.get_traceback(with_context=True),
 		)
 
 

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -33,7 +33,7 @@ from mail.jmap import get_email_service, get_identities, get_jmap_connection, pa
 from mail.jmap.models import EmailAddress, EmailAttachment, EmailCreateModel, EmailHeader, EmailRecipient
 from mail.jmap.services.mail.email import EmailService
 from mail.jmap.services.mail.mailbox import MailboxService
-from mail.utils import get_mail_config
+from mail.utils import get_mail_config, log_error
 from mail.utils.dt import parsedate_to_datetime
 from mail.utils.user import is_administrator, is_local_user
 from mail.utils.validation import has_permission_for_user
@@ -563,7 +563,7 @@ class MailQueue(Document):
 					self.in_reply_to_id = ids[0]
 			except Exception:
 				self.in_reply_to_id = None
-				frappe.log_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
+				log_error(_("Failed to fetch In Reply To ID"), frappe.get_traceback(with_context=True))
 
 	@frappe.whitelist()
 	def retry(self) -> None:
@@ -876,8 +876,8 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 			enqueue_process_pending_emails(batch_size, max_batch_size)
 
 	except Exception:
-		frappe.log_error(
-			title="Failed - Enqueue Process Pending Emails", message=frappe.get_traceback(with_context=True)
+		log_error(
+			_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True)
 		)
 
 

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -876,9 +876,7 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 			enqueue_process_pending_emails(batch_size, max_batch_size)
 
 	except Exception:
-		log_error(
-			_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True)
-		)
+		log_error(_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True))
 
 
 def get_permission_query_condition(user: str | None = None) -> str:

--- a/mail/patches/create_push_subscriptions.py
+++ b/mail/patches/create_push_subscriptions.py
@@ -1,8 +1,10 @@
 import time
 
 import frappe
+from frappe import _
 
 from mail.jmap import get_push_subscription_service
+from mail.utils import log_error
 
 
 def execute() -> None:
@@ -21,9 +23,9 @@ def execute() -> None:
 			ps.user = user
 			ps.insert(ignore_permissions=True)
 		except Exception as e:
-			frappe.log_error(
-				title="Push Subscription Creation Failed",
-				message=f"Failed to create push subscription for user {user}: {e!s}",
+			log_error(
+				_("Push Subscription Creation Failed"),
+				_("Failed to create push subscription for user {0}: {1}").format(user, str(e)),
 			)
 
 		time.sleep(0.1)

--- a/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -10,6 +10,4 @@ def execute() -> None:
 		try:
 			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
 		except Exception:
-			log_error(
-				_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False)
-			)
+			log_error(_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False))

--- a/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -1,6 +1,8 @@
 import frappe
 from frappe import _
 
+from mail.utils import log_error
+
 
 def execute() -> None:
 	clusters = frappe.db.get_all("Mail Cluster", {"ssh_public_key": ["in", ["", None]]}, pluck="name")
@@ -8,6 +10,6 @@ def execute() -> None:
 		try:
 			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
 		except Exception:
-			frappe.log_error(
-				title=_("Failed to generate SSH keypair"), message=frappe.get_traceback(with_context=False)
+			log_error(
+				_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False)
 			)

--- a/mail/patches/set_user_account.py
+++ b/mail/patches/set_user_account.py
@@ -1,6 +1,8 @@
 import frappe
+from frappe import _
 from frappe.query_builder import Case
 
+from mail.utils import log_error
 from mail.utils.user import get_user_personal_account
 
 DOCTYPES = [
@@ -59,4 +61,7 @@ def execute() -> None:
 			).run()
 
 		except Exception as e:
-			frappe.log_error(message=str(e), title=f"Error while setting user account for {doctype}")
+			log_error(
+				_("Error while setting user account for {0}").format(doctype),
+				str(e),
+			)

--- a/mail/server/doctype/mail_data_exchange/mail_data_exchange.py
+++ b/mail/server/doctype/mail_data_exchange/mail_data_exchange.py
@@ -27,6 +27,7 @@ from mail.utils import (
 	get_mail_config,
 	get_mbox_files,
 	get_stalwart_cli_path,
+	log_error,
 	reconnect_on_failure,
 	sanitize_cli_output,
 )
@@ -207,8 +208,8 @@ class MailDataExchange(Document):
 			try:
 				output = clean_import_output(output)
 			except Exception:
-				frappe.log_error(
-					title=_("Failed to clean import output"), message=frappe.get_traceback(with_context=True)
+				log_error(
+					_("Failed to clean import output"), frappe.get_traceback(with_context=True)
 				)
 
 			clear_sync_state(self.user, type="email")

--- a/mail/server/doctype/mail_data_exchange/mail_data_exchange.py
+++ b/mail/server/doctype/mail_data_exchange/mail_data_exchange.py
@@ -208,9 +208,7 @@ class MailDataExchange(Document):
 			try:
 				output = clean_import_output(output)
 			except Exception:
-				log_error(
-					_("Failed to clean import output"), frappe.get_traceback(with_context=True)
-				)
+				log_error(_("Failed to clean import output"), frappe.get_traceback(with_context=True))
 
 			clear_sync_state(self.user, type="email")
 			kwargs.update({"status": "Completed", "output": output})

--- a/mail/server/doctype/principal/principal.py
+++ b/mail/server/doctype/principal/principal.py
@@ -23,6 +23,7 @@ from mail.utils import (
 	hash_password,
 	is_catch_all_address,
 	is_probable_hash,
+	log_error,
 	parse_filters,
 	parse_token,
 	snake_to_camel,
@@ -355,9 +356,9 @@ class Principal(Document):
 
 				backend.request("GET", RELOAD_ENDPOINT)
 			except Exception:
-				frappe.log_error(
-					title=f"Failed to create DKIM signature for domain {self.name}",
-					message=frappe.get_traceback(with_context=True),
+				log_error(
+					_("Failed to create DKIM signature for domain {0}").format(self.name),
+					frappe.get_traceback(with_context=True),
 				)
 
 	def _create_dkim_signature(
@@ -395,7 +396,7 @@ class Principal(Document):
 
 		if response.json().get("error"):
 			message = _("Failed to create DKIM signature for domain {0}").format(frappe.bold(self.name))
-			frappe.log_error(title=message, message=frappe.get_traceback(with_context=True))
+			log_error(message, frappe.get_traceback(with_context=True))
 
 			if raise_exception:
 				frappe.throw(message)
@@ -631,7 +632,7 @@ class Principal(Document):
 		response = backend.request("POST", SETTINGS_ENDPOINT, data=json.dumps(payload))
 		if response.json().get("error"):
 			message = _("Failed to delete DKIM signature for domain {0}").format(frappe.bold(self.name))
-			frappe.log_error(title=message, message=frappe.get_traceback(with_context=True))
+			log_error(message, frappe.get_traceback(with_context=True))
 
 			if raise_exception:
 				frappe.throw(message)

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -913,3 +913,16 @@ def get_stalwart_version() -> str:
 	"""Returns the Stalwart version from configuration or default."""
 
 	return get_mail_config("stalwart_version")
+
+
+def log_error(title: str | None = None, message: str | None = None, **kwargs) -> None:
+	"""Logs an error, prefixing the title with "[Mail]" so Mail app errors can be filtered out.
+
+	Wraps `frappe.log_error` and should be used in place of it throughout the Mail app.
+	"""
+
+	prefix = "[Mail] "
+	if title and not title.startswith(prefix):
+		title = f"{prefix}{title}"
+
+	frappe.log_error(title=title, message=message, **kwargs)


### PR DESCRIPTION
Backport of #572 to `v0`.

## Description

Error Log entries created by the Mail app now have their titles prefixed with `[Mail]`, so they can be filtered apart from other apps' errors when multiple apps share a bench/site.

## Changes

- Add a `log_error(title, message, **kwargs)` wrapper in `mail/utils/__init__.py` that prepends `"[Mail] "` to the title (idempotently) and forwards to `frappe.log_error`.
- Route all `frappe.log_error` callsites through the wrapper, calling it positionally as `log_error(title, message)`.
- Titles and human-readable literal messages are wrapped in `_()` for translation (traceback / exception-string messages are left as-is).

### Notes on this backport
- `v0` had no `execute_with_logging` helper, so this was reconstructed rather than cherry-picked.
- `v0` also has callsites not present on `develop` — `backend.py`, `server/doctype/principal/principal.py` (×3), and `server/doctype/mail_data_exchange/mail_data_exchange.py` — which are included here for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)