### PR TITLE
feat: show MIME Message on mobile and make its page responsive

### DIFF
--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -222,7 +222,7 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				label: __('See MIME Message'),
 				onClick: () => window.open(`/mail/mime-message/${mail.name}`, '_blank')?.focus(),
 				icon: Code,
-				condition: () => !mail.draft && !isMobile.value,
+				condition: () => !mail.draft,
 			},
 			{
 				label: __('View in Desk'),

--- a/frontend/src/pages/MimeMessageView.vue
+++ b/frontend/src/pages/MimeMessageView.vue
@@ -1,8 +1,10 @@
 <template>
-	<div class="sm:bg-surface-gray-1 min-h-screen py-12">
-		<div class="bg-surface-white mx-auto space-y-8 rounded-md border p-12 sm:w-[75rem]">
+	<div class="sm:bg-surface-gray-1 min-h-screen py-4 sm:py-12">
+		<div
+			class="bg-surface-white mx-auto max-w-full space-y-6 rounded-md border p-4 sm:w-[75rem] sm:space-y-8 sm:p-12"
+		>
 			<template v-if="mime.data">
-				<div class="flex items-center justify-between">
+				<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 					<h1 class="text-xl !font-medium">{{ __('MIME Message') }}</h1>
 					<Button
 						:label="__('Copy to Clipboard')"
@@ -11,19 +13,22 @@
 					/>
 				</div>
 				<div class="rounded-md border">
-					<div class="border-b px-6 py-4">
+					<div class="border-b px-4 py-4 sm:px-6">
 						<h2>{{ __('Message Information') }}</h2>
 					</div>
 					<div
 						v-for="[key, value] of Object.entries(mime.data)"
 						:key="key"
-						class="even:bg-surface-gray-1 flex items-center px-6 py-4 text-base last:rounded-b"
+						class="even:bg-surface-gray-1 flex flex-col gap-1 px-4 py-4 text-base last:rounded-b sm:flex-row sm:items-center sm:px-6"
 					>
-						<div class="text-ink-gray-5 w-1/4">{{ value.label }}</div>
-						<div class="flex w-3/4 items-center">{{ value.value }}</div>
+						<div class="text-ink-gray-5 w-full sm:w-1/4">{{ value.label }}</div>
+						<div class="flex w-full items-center break-words sm:w-3/4">{{ value.value }}</div>
 					</div>
 				</div>
-				<pre class="text-wrap break-words" style="font-size: 0.875rem">{{ message }}</pre>
+				<pre
+					class="overflow-x-auto whitespace-pre-wrap break-words"
+					style="font-size: 0.875rem"
+				>{{ message }}</pre>
 			</template>
 
 			<div v-else-if="mime.error" class="space-y-4 text-center">


### PR DESCRIPTION
## Summary
- Show the **See MIME Message** action on mobile/PWA as well (previously hidden via `!isMobile`); still hidden for drafts.
- Make the MIME Message page responsive:
  - Reduced padding on mobile while keeping the roomy desktop layout; added `max-w-full` so the card never overflows the viewport.
  - Header (title + "Copy to Clipboard") stacks vertically on mobile.
  - Message Information rows stack label/value on mobile instead of rigid 1/4 ÷ 3/4 columns, with `break-words` for long values (message IDs, DKIM, etc.).
  - Raw MIME `<pre>` now wraps and scrolls within its container instead of stretching the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)