### PR TITLE
feat: download attachment(s) as `.zip`

### DIFF
--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -260,24 +260,52 @@
 										:text="mail.html_body || mail.text_body"
 									/>
 
-									<div
-										v-if="filteredAttachments(mail).length"
-										class="mt-8 flex flex-wrap"
-									>
-										<AttachmentCapsule
-											v-for="(attachment, idx) in filteredAttachments(mail)"
-											:key="idx"
-											:file-name="attachment.filename"
-											:blob-i-d="attachment.blob_id"
-											:type="attachment.type"
-											class="mb-2 mr-2"
-											@click.stop.prevent="
-												openAttachment(
-													filteredAttachments(mail),
-													Number(idx),
-												)
-											"
-										/>
+									<div v-if="filteredAttachments(mail).length" class="mt-8">
+										<div
+											v-if="zippableAttachments(mail).length > 1"
+											class="mb-3 flex items-center justify-between"
+										>
+											<span class="text-ink-gray-5 text-sm">
+												{{
+													__('{0} attachments', [
+														String(
+															filteredAttachments(mail)
+																.length,
+														),
+													])
+												}}
+											</span>
+											<Button
+												variant="ghost"
+												:icon="Download"
+												:label="__('Download all')"
+												:tooltip="__('Download all')"
+												:loading="
+													downloadingZipMail === mail.name
+												"
+												@click.stop.prevent="
+													downloadAttachmentsAsZip(mail)
+												"
+											/>
+										</div>
+										<div class="flex flex-wrap">
+											<AttachmentCapsule
+												v-for="(attachment, idx) in filteredAttachments(
+													mail,
+												)"
+												:key="idx"
+												:file-name="attachment.filename"
+												:blob-i-d="attachment.blob_id"
+												:type="attachment.type"
+												class="mb-2 mr-2"
+												@click.stop.prevent="
+													openAttachment(
+														filteredAttachments(mail),
+														Number(idx),
+													)
+												"
+											/>
+										</div>
 									</div>
 								</div>
 							</template>
@@ -348,10 +376,11 @@ import {
 	watch,
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChevronDown, Forward, Reply, ReplyAll } from 'lucide-vue-next'
+import { ChevronDown, Download, Forward, Reply, ReplyAll } from 'lucide-vue-next'
 import { Alert, Avatar, Badge, Button, createResource } from 'frappe-ui'
 
 import {
+	downloadUrlAsFile,
 	extractQuotedContent,
 	getFirstAlphabet,
 	getFormattedDate,
@@ -361,6 +390,7 @@ import {
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/utils'
+import { getAttachmentsZipUrl } from '@/resources'
 import { useScreenSize, useSettings, useTheme } from '@/utils/composables'
 import { userStore } from '@/stores/user'
 import AttachmentCapsule from '@/components/AttachmentCapsule.vue'
@@ -716,6 +746,24 @@ const openAttachment = (mailAttachments: Attachment[], idx: number) => {
 	attachments.value = mailAttachments
 	attachmentIndex.value = idx
 	showAttachmentViewer.value = true
+}
+
+const zippableAttachments = (mail: Mail) =>
+	filteredAttachments(mail).filter((a: Attachment) => a.blob_id)
+
+const downloadingZipMail = ref<string | null>(null)
+
+const downloadAttachmentsAsZip = async (mail: Mail) => {
+	const mailAttachments = zippableAttachments(mail)
+	if (mailAttachments.length < 2) return
+
+	downloadingZipMail.value = mail.name
+	try {
+		const url = await getAttachmentsZipUrl(mailAttachments)
+		downloadUrlAsFile(url, `${mail.subject || 'attachments'}.zip`)
+	} finally {
+		downloadingZipMail.value = null
+	}
 }
 
 const isCollapsed = (mail: Mail) =>

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -268,10 +268,7 @@
 											<span class="text-ink-gray-5 text-sm">
 												{{
 													__('{0} attachments', [
-														String(
-															filteredAttachments(mail)
-																.length,
-														),
+														String(filteredAttachments(mail).length),
 													])
 												}}
 											</span>
@@ -280,9 +277,7 @@
 												:icon="Download"
 												:label="__('Download all')"
 												:tooltip="__('Download all')"
-												:loading="
-													downloadingZipMail === mail.name
-												"
+												:loading="downloadingZipMail === mail.name"
 												@click.stop.prevent="
 													downloadAttachmentsAsZip(mail)
 												"
@@ -379,6 +374,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { ChevronDown, Download, Forward, Reply, ReplyAll } from 'lucide-vue-next'
 import { Alert, Avatar, Badge, Button, createResource } from 'frappe-ui'
 
+import { getAttachmentsZipUrl } from '@/resources'
 import {
 	downloadUrlAsFile,
 	extractQuotedContent,
@@ -390,7 +386,6 @@ import {
 	raiseToast,
 	shouldIgnoreKeypress,
 } from '@/utils'
-import { getAttachmentsZipUrl } from '@/resources'
 import { useScreenSize, useSettings, useTheme } from '@/utils/composables'
 import { userStore } from '@/stores/user'
 import AttachmentCapsule from '@/components/AttachmentCapsule.vue'

--- a/frontend/src/pages/MimeMessageView.vue
+++ b/frontend/src/pages/MimeMessageView.vue
@@ -22,13 +22,16 @@
 						class="even:bg-surface-gray-1 flex flex-col gap-1 px-4 py-4 text-base last:rounded-b sm:flex-row sm:items-center sm:px-6"
 					>
 						<div class="text-ink-gray-5 w-full sm:w-1/4">{{ value.label }}</div>
-						<div class="flex w-full items-center break-words sm:w-3/4">{{ value.value }}</div>
+						<div class="flex w-full items-center break-words sm:w-3/4">
+							{{ value.value }}
+						</div>
 					</div>
 				</div>
 				<pre
 					class="overflow-x-auto whitespace-pre-wrap break-words"
 					style="font-size: 0.875rem"
-				>{{ message }}</pre>
+					>{{ message }}</pre
+				>
 			</template>
 
 			<div v-else-if="mime.error" class="space-y-4 text-center">

--- a/frontend/src/resources.ts
+++ b/frontend/src/resources.ts
@@ -2,6 +2,7 @@ import { createResource } from 'frappe-ui'
 
 import { raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
+
 import type { Attachment } from '@/types'
 
 const store = userStore()

--- a/frontend/src/resources.ts
+++ b/frontend/src/resources.ts
@@ -2,6 +2,7 @@ import { createResource } from 'frappe-ui'
 
 import { raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
+import type { Attachment } from '@/types'
 
 const store = userStore()
 
@@ -16,5 +17,23 @@ export const getAttachmentUrl = async (blobID: string, type?: string) => {
 	const attachment = await fetchAttachment.submit(blobID)
 	const byteArray = new Uint8Array(attachment)
 	const blob = new Blob([byteArray], { type })
+	return URL.createObjectURL(blob)
+}
+
+export const fetchAttachmentsAsZip = createResource({
+	url: 'mail.api.mail.fetch_attachments_as_zip',
+	makeParams: (attachments: Attachment[]) => ({
+		account: store.account,
+		attachments: JSON.stringify(
+			attachments.map((a) => ({ blob_id: a.blob_id, filename: a.filename })),
+		),
+	}),
+	onError: (error) => raiseToast(error.message, 'error'),
+})
+
+export const getAttachmentsZipUrl = async (attachments: Attachment[]) => {
+	const zip = await fetchAttachmentsAsZip.submit(attachments)
+	const byteArray = new Uint8Array(zip)
+	const blob = new Blob([byteArray], { type: 'application/zip' })
 	return URL.createObjectURL(blob)
 }

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -1,4 +1,7 @@
 import hashlib
+import io
+import os
+import zipfile
 from datetime import UTC, datetime
 
 import frappe
@@ -17,6 +20,7 @@ from mail.client.doctype.mail_message.mail_message import (
 	delete_messages,
 	empty_mailbox,
 	fetch_blob,
+	fetch_blobs,
 	fetch_thread,
 	fetch_threads,
 	move_messages_to_mailbox,
@@ -302,6 +306,46 @@ def fetch_attachment(account: str, blob_id: str) -> bytes:
 	"""Returns the content of an attachment."""
 
 	return fetch_blob(account, blob_id)
+
+
+@frappe.whitelist()
+def fetch_attachments_as_zip(account: str, attachments: list[dict] | str) -> bytes:
+	"""Returns the provided attachments bundled into a ZIP archive."""
+
+	if isinstance(attachments, str):
+		attachments = frappe.parse_json(attachments)
+
+	attachments = [a for a in (attachments or []) if a.get("blob_id")]
+	if not attachments:
+		frappe.throw(_("No attachments to download."))
+
+	blobs = [(a["blob_id"], a.get("filename")) for a in attachments]
+	contents = fetch_blobs(account, blobs)
+
+	buffer = io.BytesIO()
+	used_names = {}
+	with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+		for attachment in attachments:
+			content = contents.get(attachment["blob_id"])
+			if content is None:
+				continue
+
+			filename = _get_unique_filename(attachment.get("filename") or "attachment", used_names)
+			zf.writestr(filename, content)
+
+	return buffer.getvalue()
+
+
+def _get_unique_filename(filename: str, used_names: dict[str, int]) -> str:
+	"""Returns a unique filename, appending a counter to duplicates (e.g. "file (1).pdf")."""
+
+	if filename not in used_names:
+		used_names[filename] = 0
+		return filename
+
+	used_names[filename] += 1
+	name, ext = os.path.splitext(filename)
+	return f"{name} ({used_names[filename]}){ext}"
 
 
 @frappe.whitelist()

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -860,9 +860,7 @@ def enqueue_process_pending_emails(batch_size: int | None = None, max_batch_size
 			enqueue_process_pending_emails(batch_size, max_batch_size)
 
 	except Exception:
-		log_error(
-			_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True)
-		)
+		log_error(_("Failed - Enqueue Process Pending Emails"), frappe.get_traceback(with_context=True))
 
 
 def get_permission_query_condition(user: str | None = None) -> str:

--- a/mail/patches/generate_ssh_keypair_for_cluster.py
+++ b/mail/patches/generate_ssh_keypair_for_cluster.py
@@ -10,6 +10,4 @@ def execute() -> None:
 		try:
 			frappe.get_doc("Mail Cluster", cluster).generate_ssh_keypair(save=True)
 		except Exception:
-			log_error(
-				_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False)
-			)
+			log_error(_("Failed to generate SSH keypair"), frappe.get_traceback(with_context=False))


### PR DESCRIPTION
## Description

Adds a **Download all** action that bundles a mail's attachments into a single `.zip` archive when there is more than one attachment.

Closes #566

### Backend
- New whitelisted endpoint `mail.api.mail.fetch_attachments_as_zip(account, attachments)`. It reuses the existing concurrent `fetch_blobs` helper (which downloads and caches blobs), zips the contents in memory via `zipfile.ZipFile`, and returns the archive bytes — the same `bytes` return shape as `fetch_attachment`.
- Duplicate filenames within an archive are de-duplicated (e.g. `file.pdf`, `file (1).pdf`).

### Frontend
- New `fetchAttachmentsAsZip` resource + `getAttachmentsZipUrl()` helper, mirroring the existing `fetchAttachment` / `getAttachmentUrl` pattern.
- The attachments section now shows a small header (a count label on the left and a subtle icon-only **Download all** button with a tooltip on the right) when a mail has 2+ downloadable attachments. Single-attachment mails are unchanged.

## Screenshots
_To be added._

🤖 Generated with [Claude Code](https://claude.com/claude-code)