### PR TITLE
feat: download attachment(s) as `.zip` (backport)

### DIFF
--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -246,24 +246,47 @@
 										>{{ mail.html_body || mail.text_body }}</pre
 									>
 
-									<div
-										v-if="filteredAttachments(mail).length"
-										class="mt-8 flex flex-wrap"
-									>
-										<AttachmentCapsule
-											v-for="(attachment, idx) in filteredAttachments(mail)"
-											:key="idx"
-											:file-name="attachment.filename"
-											:blob-i-d="attachment.blob_id"
-											:type="attachment.type"
-											class="mb-2 mr-2"
-											@click.stop.prevent="
-												openAttachment(
-													filteredAttachments(mail),
-													Number(idx),
-												)
-											"
-										/>
+									<div v-if="filteredAttachments(mail).length" class="mt-8">
+										<div
+											v-if="zippableAttachments(mail).length > 1"
+											class="mb-3 flex items-center justify-between"
+										>
+											<span class="text-ink-gray-5 text-sm">
+												{{
+													__('{0} attachments', [
+														String(filteredAttachments(mail).length),
+													])
+												}}
+											</span>
+											<Button
+												variant="ghost"
+												:icon="Download"
+												:label="__('Download all')"
+												:tooltip="__('Download all')"
+												:loading="downloadingZipMail === mail.name"
+												@click.stop.prevent="
+													downloadAttachmentsAsZip(mail)
+												"
+											/>
+										</div>
+										<div class="flex flex-wrap">
+											<AttachmentCapsule
+												v-for="(attachment, idx) in filteredAttachments(
+													mail,
+												)"
+												:key="idx"
+												:file-name="attachment.filename"
+												:blob-i-d="attachment.blob_id"
+												:type="attachment.type"
+												class="mb-2 mr-2"
+												@click.stop.prevent="
+													openAttachment(
+														filteredAttachments(mail),
+														Number(idx),
+													)
+												"
+											/>
+										</div>
 									</div>
 								</div>
 							</template>
@@ -334,10 +357,12 @@ import {
 	watch,
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { ChevronDown, Forward, Reply, ReplyAll } from 'lucide-vue-next'
+import { ChevronDown, Download, Forward, Reply, ReplyAll } from 'lucide-vue-next'
 import { Alert, Avatar, Badge, Button, createResource } from 'frappe-ui'
 
+import { getAttachmentsZipUrl } from '@/resources'
 import {
+	downloadUrlAsFile,
 	extractQuotedContent,
 	getFirstAlphabet,
 	getFormattedDate,
@@ -700,6 +725,24 @@ const openAttachment = (mailAttachments: Attachment[], idx: number) => {
 	attachments.value = mailAttachments
 	attachmentIndex.value = idx
 	showAttachmentViewer.value = true
+}
+
+const zippableAttachments = (mail: Mail) =>
+	filteredAttachments(mail).filter((a: Attachment) => a.blob_id)
+
+const downloadingZipMail = ref<string | null>(null)
+
+const downloadAttachmentsAsZip = async (mail: Mail) => {
+	const mailAttachments = zippableAttachments(mail)
+	if (mailAttachments.length < 2) return
+
+	downloadingZipMail.value = mail.name
+	try {
+		const url = await getAttachmentsZipUrl(mailAttachments)
+		downloadUrlAsFile(url, `${mail.subject || 'attachments'}.zip`)
+	} finally {
+		downloadingZipMail.value = null
+	}
 }
 
 const isCollapsed = (mail: Mail) =>

--- a/frontend/src/resources.ts
+++ b/frontend/src/resources.ts
@@ -3,6 +3,8 @@ import { createResource } from 'frappe-ui'
 import { raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
 
+import type { Attachment } from '@/types'
+
 const store = userStore()
 
 export const fetchAttachment = createResource({
@@ -16,5 +18,23 @@ export const getAttachmentUrl = async (blobID: string, type?: string) => {
 	const attachment = await fetchAttachment.submit(blobID)
 	const byteArray = new Uint8Array(attachment)
 	const blob = new Blob([byteArray], { type })
+	return URL.createObjectURL(blob)
+}
+
+export const fetchAttachmentsAsZip = createResource({
+	url: 'mail.api.mail.fetch_attachments_as_zip',
+	makeParams: (attachments: Attachment[]) => ({
+		account: store.account,
+		attachments: JSON.stringify(
+			attachments.map((a) => ({ blob_id: a.blob_id, filename: a.filename })),
+		),
+	}),
+	onError: (error) => raiseToast(error.message, 'error'),
+})
+
+export const getAttachmentsZipUrl = async (attachments: Attachment[]) => {
+	const zip = await fetchAttachmentsAsZip.submit(attachments)
+	const byteArray = new Uint8Array(zip)
+	const blob = new Blob([byteArray], { type: 'application/zip' })
 	return URL.createObjectURL(blob)
 }

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -1,4 +1,7 @@
 import hashlib
+import io
+import os
+import zipfile
 from datetime import UTC, datetime
 
 import frappe
@@ -16,6 +19,7 @@ from mail.client.doctype.mail_message.mail_message import (
 	delete_messages,
 	empty_mailbox,
 	fetch_blob,
+	fetch_blobs,
 	fetch_thread,
 	fetch_threads,
 	move_messages_to_mailbox,
@@ -301,6 +305,46 @@ def fetch_attachment(account: str, blob_id: str) -> bytes:
 	"""Returns the content of an attachment."""
 
 	return fetch_blob(account, blob_id)
+
+
+@frappe.whitelist()
+def fetch_attachments_as_zip(account: str, attachments: list[dict] | str) -> bytes:
+	"""Returns the provided attachments bundled into a ZIP archive."""
+
+	if isinstance(attachments, str):
+		attachments = frappe.parse_json(attachments)
+
+	attachments = [a for a in (attachments or []) if a.get("blob_id")]
+	if not attachments:
+		frappe.throw(_("No attachments to download."))
+
+	blobs = [(a["blob_id"], a.get("filename")) for a in attachments]
+	contents = fetch_blobs(account, blobs)
+
+	buffer = io.BytesIO()
+	used_names = {}
+	with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+		for attachment in attachments:
+			content = contents.get(attachment["blob_id"])
+			if content is None:
+				continue
+
+			filename = _get_unique_filename(attachment.get("filename") or "attachment", used_names)
+			zf.writestr(filename, content)
+
+	return buffer.getvalue()
+
+
+def _get_unique_filename(filename: str, used_names: dict[str, int]) -> str:
+	"""Returns a unique filename, appending a counter to duplicates (e.g. "file (1).pdf")."""
+
+	if filename not in used_names:
+		used_names[filename] = 0
+		return filename
+
+	used_names[filename] += 1
+	name, ext = os.path.splitext(filename)
+	return f"{name} ({used_names[filename]}){ext}"
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Description

Backport of #581 to `v0`.

Adds a **Download all** action that bundles a mail's attachments into a single `.zip` archive when there is more than one attachment.

Closes #566

### Backend
- New whitelisted endpoint `mail.api.mail.fetch_attachments_as_zip(account, attachments)`. It reuses the existing concurrent `fetch_blobs` helper (which downloads and caches blobs), zips the contents in memory via `zipfile.ZipFile`, and returns the archive bytes — the same `bytes` return shape as `fetch_attachment`.
- Duplicate filenames within an archive are de-duplicated (e.g. `file.pdf`, `file (1).pdf`).

### Frontend
- New `fetchAttachmentsAsZip` resource + `getAttachmentsZipUrl()` helper, mirroring the existing `fetchAttachment` / `getAttachmentUrl` pattern.
- The attachments section now shows a small header (a count label on the left and a subtle icon-only **Download all** button with a tooltip on the right) when a mail has 2+ downloadable attachments. Single-attachment mails are unchanged.

> [!NOTE]
> The repo-wide `chore: linter` commit from the develop PR was **not** backported; only the equivalent formatting for the touched files was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)