### PR TITLE
refactor: structured event logger for "mail.push" (backport #584)

### DIFF
--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -19,25 +19,25 @@ from mail.utils import get_push_logger
 def push_notification() -> dict:
 	"""Handle JMAP Push Notification."""
 
-	logger = get_push_logger()
 	ctx = {
 		"req_id": random_string(10),
 		"ip": frappe.request.remote_addr,
 	}
+	logger = get_push_logger(ctx)
 
 	try:
-		logger.info({**ctx, "event": "received"})
+		logger.debug("push-received")
 
 		user = frappe.request.args.get("user") or frappe.request.args.get("account")
 		if not user:
-			logger.error({**ctx, "event": "missing-user"})
+			logger.warning("missing-user")
 			return {"status": "error", "message": _("Missing user query parameter.")}
 
 		user = unquote(user)
 		ctx["user"] = user
 
 		if is_jmap_push_notifications_frozen(user):
-			logger.warning({**ctx, "event": "frozen"})
+			logger.warning("push-frozen")
 			return {
 				"status": "frozen",
 				"message": _("Push notifications are currently frozen for this user."),
@@ -47,26 +47,27 @@ def push_notification() -> dict:
 		content_encoding = frappe.request.headers.get("Content-Encoding", "")
 
 		if keys:
-			logger.debug({**ctx, "event": "encrypted-payload-expected"})
+			logger.debug("encrypted-payload-expected")
 
 			if content_encoding != "aes128gcm":
-				logger.error({**ctx, "encoding": content_encoding, "event": "invalid-content-encoding"})
+				logger.warning("invalid-content-encoding", encoding=content_encoding)
 				return {
 					"status": "error",
 					"message": _("Invalid Content-Encoding. Expected 'aes128gcm'."),
 				}
 
-			logger.debug({**ctx, "event": "decrypting-payload"})
+			logger.debug("decrypting-payload")
 			request_data = decrypt_jmap_push_payload(frappe.request.get_data())
 		else:
-			logger.debug({**ctx, "event": "using-plain-json-payload"})
+			logger.debug("using-plain-json-payload")
 			request_data = frappe.request.get_json()
 
 		event_type = request_data.get("@type")
-		logger.debug({**ctx, "type": event_type, "event": "push-type-received"})
+		ctx["type"] = event_type
+		logger.debug("push-type-received")
 
 		if event_type == "PushVerification":
-			logger.info({**ctx, "type": event_type, "event": "verifying-subscription"})
+			logger.info("verifying-subscription")
 
 			verify_push_subscription(
 				user,
@@ -74,11 +75,11 @@ def push_notification() -> dict:
 				request_data["verificationCode"],
 			)
 
-			logger.info({**ctx, "type": event_type, "event": "subscription-verified"})
+			logger.info("subscription-verified")
 			return {"status": "verified"}
 
 		elif event_type == "StateChange":
-			logger.debug({**ctx, "type": event_type, "event": "state-change-received"})
+			logger.debug("state-change-received")
 
 			for account_id, changes in request_data.get("changed", {}).items():
 				account = f"{user}:{account_id}"
@@ -86,60 +87,29 @@ def push_notification() -> dict:
 
 				for entity, state in changes.items():
 					if entity == "Email":
-						logger.info(
-							{
-								**ctx,
-								"type": event_type,
-								"entity": entity,
-								"state": state,
-								"event": "queueing-email-sync",
-							}
-						)
+						logger.debug("queueing-email-sync", entity=entity, state=state)
 						enqueue_fetch_changes(account, state, ctx=ctx)
 
 					elif entity == "Mailbox":
-						logger.info(
-							{
-								**ctx,
-								"type": event_type,
-								"entity": entity,
-								"state": state,
-								"event": "invalidating-mailbox-cache",
-							}
-						)
+						logger.debug("invalidating-mailbox-cache", entity=entity, state=state)
 						invalidate_jmap_mailboxes_cache(account)
 
 					elif entity == "Identity":
-						logger.info(
-							{
-								**ctx,
-								"type": event_type,
-								"entity": entity,
-								"state": state,
-								"event": "invalidating-identity-cache",
-							}
-						)
+						logger.debug("invalidating-identity-cache", entity=entity, state=state)
 						invalidate_jmap_identities_cache(account)
 
 					else:
-						logger.warning(
-							{
-								**ctx,
-								"type": event_type,
-								"entity": entity,
-								"event": "unhandled-state-change-entity",
-							}
-						)
+						logger.warning("unhandled-state-change-entity", entity=entity)
 
 				return {"status": "processed"}
 
 		else:
-			logger.error({**ctx, "type": event_type, "event": "unknown-push-type"})
+			logger.warning("unknown-push-type")
 			return {
 				"status": "error",
 				"message": _("Invalid Push Notification @type = {0}").format(event_type),
 			}
 
 	except Exception:
-		logger.exception({**ctx, "event": "failed-to-process", "traceback": frappe.get_traceback()})
+		logger.exception("failed-to-process", traceback=frappe.get_traceback())
 		return {"status": "error", "message": _("Failed to handle JMAP Push Notification.")}

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -12,7 +12,7 @@ from mail.client.doctype.push_subscription.push_subscription import (
 	verify_push_subscription,
 )
 from mail.jmap import invalidate_jmap_identities_cache, invalidate_jmap_mailboxes_cache
-from mail.utils import get_push_logger
+from mail.utils.logger.push import get_push_logger
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -33,7 +33,6 @@ from mail.storage.data_store import Entity
 from mail.utils import (
 	enqueue_job,
 	get_mail_config,
-	get_push_logger,
 	log_error,
 	parse_filters,
 	user_context,
@@ -41,6 +40,7 @@ from mail.utils import (
 from mail.utils.dt import convert_to_utc, parse_iso_datetime, to_iso8601_z
 from mail.utils.email_parser import EmailParser
 from mail.utils.lock import acquire_lock, release_lock
+from mail.utils.logger.push import get_push_logger
 from mail.utils.user import get_account_emails, get_sync_state, update_sync_state
 from mail.utils.validation import has_permission_for_user
 

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -1258,7 +1258,7 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 	"""Fetch changes from the server and remove MailMessage documents from the cache."""
 
 	ctx = ctx or {}
-	logger = get_push_logger()
+	logger = get_push_logger(ctx)
 
 	current_state = get_sync_state(account, type="email")
 
@@ -1266,17 +1266,17 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 	ctx["email_state"] = email_state
 
 	if not current_state:
-		logger.info({**ctx, "event": "initializing-email-sync-state"})
+		logger.info("initializing-email-sync-state")
 		return update_sync_state(account, type="email", state=email_state)
 
 	elif email_state == current_state:
-		logger.info({**ctx, "event": "email-state-unchanged"})
+		logger.debug("email-state-unchanged")
 		return
 
 	user, account_id = parse_account(account)
 
 	try:
-		logger.info({**ctx, "event": "fetching-changes-from-server"})
+		logger.debug("fetching-changes-from-server")
 
 		connection = get_jmap_connection(user)
 		email_service = EmailService(account, connection)
@@ -1285,11 +1285,11 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 		result = email_service.changes(current_state)
 
 		if created_ids := result["created"]:
-			logger.info({**ctx, "event": "new-messages-created", "count": len(created_ids)})
+			logger.info("new-messages-created", count=len(created_ids))
 
 			if messages := get_messages(account, ids=created_ids):
 				subscribed_mailboxes = set([m["id"] for m in mailbox_service.mailboxes if m["isSubscribed"]])
-				logger.debug({**ctx, "subscribed_mailboxes": subscribed_mailboxes})
+				logger.debug("resolved-subscribed-mailboxes", subscribed_mailboxes=subscribed_mailboxes)
 
 				disabled_mailboxes = set(
 					frappe.db.get_all(
@@ -1302,7 +1302,7 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 					for m in mailbox_service.mailboxes
 					if m["role"] in ["sent", "drafts", "junk", "trash"]
 				}
-				logger.debug({**ctx, "disabled_mailboxes_for_notification": disabled_mailboxes})
+				logger.debug("resolved-disabled-mailboxes", disabled_mailboxes=disabled_mailboxes)
 
 				notify_candidates = []
 				mailboxes_to_reload = set()
@@ -1327,17 +1327,17 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 					if is_candidate:
 						notify_candidates.append((mailbox_id, message))
 
-				logger.debug({**ctx, "notify_candidates_count": len(notify_candidates)})
+				logger.debug("computed-notify-candidates", notify_candidates_count=len(notify_candidates))
 
 				max_push_notifications = cint(get_mail_config("max_push_notifications"))
 				recent_messages = notify_candidates[:max_push_notifications]
 
-				logger.debug({**ctx, "recent_notify_candidates_count": len(recent_messages)})
+				logger.debug("capped-notify-candidates", recent_notify_candidates_count=len(recent_messages))
 
 				pn = PushNotification("mail")
 
 				if pn.is_enabled():
-					logger.info({**ctx, "event": "sending-push-notifications", "count": len(recent_messages)})
+					logger.info("sending-push-notifications", count=len(recent_messages))
 
 					url = frappe.utils.get_url()
 					for mailbox_id, message in recent_messages:
@@ -1349,28 +1349,28 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 							f"{url}/assets/mail/frontend/manifest/manifest-icon-192.maskable.png",
 						)
 				else:
-					logger.info({**ctx, "event": "push-notifications-disabled"})
+					logger.debug("push-notifications-disabled")
 
 				if mailboxes_to_reload:
 					frappe.publish_realtime("new_mail_created", list(mailboxes_to_reload), user=user)
 
 		if updated_ids := result["updated"]:
-			logger.info({**ctx, "event": "messages-updated", "count": len(updated_ids)})
+			logger.info("messages-updated", count=len(updated_ids))
 			_remove_cached_messages(account, updated_ids)
 
 		if destroyed_ids := result["destroyed"]:
-			logger.info({**ctx, "event": "messages-deleted", "count": len(destroyed_ids)})
+			logger.info("messages-deleted", count=len(destroyed_ids))
 			_remove_cached_messages(account, destroyed_ids)
 
 		new_state = result["newState"]
 
 		ctx["new_state"] = new_state
-		logger.info({**ctx, "event": "updating-email-sync-state"})
+		logger.debug("updating-email-sync-state")
 
 		update_sync_state(account, type="email", state=new_state)
 
 		if result["hasMoreChanges"]:
-			logger.info({**ctx, "event": "more-changes-to-fetch"})
+			logger.debug("more-changes-to-fetch")
 			ctx.pop("current_state", None)
 			ctx.pop("email_state", None)
 			ctx.pop("new_state", None)
@@ -1378,7 +1378,7 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 			fetch_changes(account, ctx=ctx)
 
 	except Exception:
-		logger.error({**ctx, "event": "fetch-changes-failed"})
+		logger.error("fetch-changes-failed")
 		log_error(
 			_("Failed to fetch changes"),
 			frappe.get_traceback(with_context=True),
@@ -1391,13 +1391,13 @@ def locked_fetch_changes(
 	"""Fetch changes for the specified account with a lock to prevent concurrent execution."""
 
 	ctx = ctx or {}
-	logger = get_push_logger()
+	logger = get_push_logger(ctx)
 
 	try:
-		logger.info({**ctx, "event": "starting-fetch-changes"})
+		logger.debug("starting-fetch-changes")
 		fetch_changes(account, email_state, ctx=ctx)
 	finally:
-		logger.info({**ctx, "event": "releasing-fetch-changes-lock"})
+		logger.debug("releasing-fetch-changes-lock")
 		release_lock(f"fetch_changes:{account}", lock_id)
 
 
@@ -1405,22 +1405,22 @@ def enqueue_fetch_changes(account: str, email_state: str | None = None, ctx: dic
 	"""Enqueue the fetch_changes job for the specified account."""
 
 	ctx = ctx or {}
-	logger = get_push_logger()
+	logger = get_push_logger(ctx)
 
-	logger.info({**ctx, "event": "enqueueing-fetch-changes"})
+	logger.debug("enqueueing-fetch-changes")
 
 	lockname = f"fetch_changes:{account}"
 	fetch_lock_timeout = cint(get_mail_config("fetch_lock_timeout"))
 	identifier = acquire_lock(lockname, acquire_timeout=0, lock_timeout=fetch_lock_timeout)
 
 	if not identifier:
-		logger.info({**ctx, "event": "fetch-changes-lock-not-acquired"})
+		logger.debug("fetch-changes-lock-not-acquired")
 		return
 
 	ctx["lock_id"] = identifier
 
 	with user_context("Administrator"):
-		logger.debug({**ctx, "event": "fetch-changes-lock-acquired"})
+		logger.debug("fetch-changes-lock-acquired")
 		enqueue_job(
 			locked_fetch_changes,
 			account=account,
@@ -1465,15 +1465,9 @@ def schedule_fetch_changes() -> None:
 		return
 
 	req_id = random_string(10)
-	logger = get_push_logger()
+	logger = get_push_logger({"req_id": req_id})
 
-	logger.info(
-		{
-			"req_id": req_id,
-			"event": "scheduling-fetch-changes",
-			"account_count": len(accounts),
-		}
-	)
+	logger.info("scheduling-fetch-changes", account_count=len(accounts))
 
 	for idx, account in enumerate(accounts, start=1):
 		ctx = {"req_id": f"{req_id}-{idx}", "account": account}

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -151,19 +151,62 @@ def get_storage_logger() -> "Logger":
 	return logger
 
 
-def get_push_logger() -> "Logger":
-	"""Returns a logger instance for mail push notifications."""
+class PushLogger:
+	"""Structured event logger for mail push notifications ("mail.push").
 
-	config = get_mail_config()
+	Binds a context dict (shared by reference, so callers can keep mutating it)
+	and emits one structured record per event. Each log method takes the event
+	name as its first argument and any event-specific fields as keyword
+	arguments, keeping call sites free of repetitive `{**ctx, "event": ...}`
+	boilerplate. Pick the method that matches the event:
 
-	max_size = cint(config["push_log_max_size"])
-	file_count = cint(config["push_log_file_count"])
-	logger = frappe.logger("mail.push", allow_site=True, max_size=max_size, file_count=file_count)
+	- `debug`   — flow tracing and routine/no-op outcomes (entry points, cache
+	              invalidations, lock contention, unchanged state).
+	- `info`    — meaningful work that happened (messages synced, notifications
+	              sent, subscription verified, scheduled batches).
+	- `warning` — handled-but-unexpected situations (frozen user, bad client
+	              input, unknown push type or entity).
+	- `error`   — failures during our own processing.
+	- `exception` — same as `error` but also records the active traceback.
+	"""
 
-	log_level = config["push_log_level"].upper()
-	logger.setLevel(log_level)
+	def __init__(self, ctx: dict | None = None) -> None:
+		config = get_mail_config()
 
-	return logger
+		max_size = cint(config["push_log_max_size"])
+		file_count = cint(config["push_log_file_count"])
+		self.logger = frappe.logger("mail.push", allow_site=True, max_size=max_size, file_count=file_count)
+		self.logger.setLevel(config["push_log_level"].upper())
+
+		self.ctx = ctx if ctx is not None else {}
+
+	def _record(self, event: str, fields: dict) -> dict:
+		return {**self.ctx, **fields, "event": event}
+
+	def debug(self, event: str, **fields: Any) -> None:
+		self.logger.debug(self._record(event, fields))
+
+	def info(self, event: str, **fields: Any) -> None:
+		self.logger.info(self._record(event, fields))
+
+	def warning(self, event: str, **fields: Any) -> None:
+		self.logger.warning(self._record(event, fields))
+
+	def error(self, event: str, **fields: Any) -> None:
+		self.logger.error(self._record(event, fields))
+
+	def exception(self, event: str, **fields: Any) -> None:
+		self.logger.exception(self._record(event, fields))
+
+
+def get_push_logger(ctx: dict | None = None) -> PushLogger:
+	"""Returns a structured event logger for mail push notifications.
+
+	The returned `PushLogger` is bound to `ctx` (by reference); mutating that
+	same dict between log calls is reflected in subsequent records.
+	"""
+
+	return PushLogger(ctx)
 
 
 def get_outbound_logger() -> "Logger":

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -151,64 +151,6 @@ def get_storage_logger() -> "Logger":
 	return logger
 
 
-class PushLogger:
-	"""Structured event logger for mail push notifications ("mail.push").
-
-	Binds a context dict (shared by reference, so callers can keep mutating it)
-	and emits one structured record per event. Each log method takes the event
-	name as its first argument and any event-specific fields as keyword
-	arguments, keeping call sites free of repetitive `{**ctx, "event": ...}`
-	boilerplate. Pick the method that matches the event:
-
-	- `debug`   — flow tracing and routine/no-op outcomes (entry points, cache
-	              invalidations, lock contention, unchanged state).
-	- `info`    — meaningful work that happened (messages synced, notifications
-	              sent, subscription verified, scheduled batches).
-	- `warning` — handled-but-unexpected situations (frozen user, bad client
-	              input, unknown push type or entity).
-	- `error`   — failures during our own processing.
-	- `exception` — same as `error` but also records the active traceback.
-	"""
-
-	def __init__(self, ctx: dict | None = None) -> None:
-		config = get_mail_config()
-
-		max_size = cint(config["push_log_max_size"])
-		file_count = cint(config["push_log_file_count"])
-		self.logger = frappe.logger("mail.push", allow_site=True, max_size=max_size, file_count=file_count)
-		self.logger.setLevel(config["push_log_level"].upper())
-
-		self.ctx = ctx if ctx is not None else {}
-
-	def _record(self, event: str, fields: dict) -> dict:
-		return {**self.ctx, **fields, "event": event}
-
-	def debug(self, event: str, **fields: Any) -> None:
-		self.logger.debug(self._record(event, fields))
-
-	def info(self, event: str, **fields: Any) -> None:
-		self.logger.info(self._record(event, fields))
-
-	def warning(self, event: str, **fields: Any) -> None:
-		self.logger.warning(self._record(event, fields))
-
-	def error(self, event: str, **fields: Any) -> None:
-		self.logger.error(self._record(event, fields))
-
-	def exception(self, event: str, **fields: Any) -> None:
-		self.logger.exception(self._record(event, fields))
-
-
-def get_push_logger(ctx: dict | None = None) -> PushLogger:
-	"""Returns a structured event logger for mail push notifications.
-
-	The returned `PushLogger` is bound to `ctx` (by reference); mutating that
-	same dict between log calls is reflected in subsequent records.
-	"""
-
-	return PushLogger(ctx)
-
-
 def get_outbound_logger() -> "Logger":
 	"""Returns a logger instance for outbound mail operations."""
 

--- a/mail/utils/logger/push.py
+++ b/mail/utils/logger/push.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import frappe
+from frappe.utils import cint
+
+from mail.utils import get_mail_config
+
+
+class PushLogger:
+	"""Structured event logger for mail push notifications ("mail.push").
+
+	Binds a context dict (shared by reference, so callers can keep mutating it)
+	and emits one structured record per event. Each log method takes the event
+	name as its first argument and any event-specific fields as keyword
+	arguments, keeping call sites free of repetitive `{**ctx, "event": ...}`
+	boilerplate. Pick the method that matches the event:
+
+	- `debug`   — flow tracing and routine/no-op outcomes (entry points, cache
+	              invalidations, lock contention, unchanged state).
+	- `info`    — meaningful work that happened (messages synced, notifications
+	              sent, subscription verified, scheduled batches).
+	- `warning` — handled-but-unexpected situations (frozen user, bad client
+	              input, unknown push type or entity).
+	- `error`   — failures during our own processing.
+	- `exception` — same as `error` but also records the active traceback.
+	"""
+
+	def __init__(self, ctx: dict | None = None) -> None:
+		config = get_mail_config()
+
+		max_size = cint(config["push_log_max_size"])
+		file_count = cint(config["push_log_file_count"])
+		self.logger = frappe.logger("mail.push", allow_site=True, max_size=max_size, file_count=file_count)
+		self.logger.setLevel(config["push_log_level"].upper())
+
+		self.ctx = ctx if ctx is not None else {}
+
+	def _record(self, event: str, fields: dict) -> dict:
+		return {**self.ctx, **fields, "event": event}
+
+	def debug(self, event: str, **fields: Any) -> None:
+		self.logger.debug(self._record(event, fields))
+
+	def info(self, event: str, **fields: Any) -> None:
+		self.logger.info(self._record(event, fields))
+
+	def warning(self, event: str, **fields: Any) -> None:
+		self.logger.warning(self._record(event, fields))
+
+	def error(self, event: str, **fields: Any) -> None:
+		self.logger.error(self._record(event, fields))
+
+	def exception(self, event: str, **fields: Any) -> None:
+		self.logger.exception(self._record(event, fields))
+
+
+def get_push_logger(ctx: dict | None = None) -> PushLogger:
+	"""Returns a structured event logger for mail push notifications.
+
+	The returned `PushLogger` is bound to `ctx` (by reference); mutating that
+	same dict between log calls is reflected in subsequent records.
+	"""
+
+	return PushLogger(ctx)


### PR DESCRIPTION
Backport of #584 to `v0`.

## What

Refactors the `mail.push` event logger and reviews the log level of every push event.

- **`PushLogger` wrapper** (`mail/utils/logger/push.py`) binds the context dict by reference and exposes `debug/info/warning/error/exception(event, **fields)`, so the call sites in `api/jmap.py` and `mail_message.py` drop the repetitive `{**ctx, "event": ...}` boilerplate.
- **Log levels corrected per event** — bad client input (`missing-user`, `invalid-content-encoding`, `unknown-push-type`) is now `warning` rather than `error`; routine flow/cache/lock tracing is now `debug` rather than `info`; meaningful work (messages synced, notifications sent, subscription verified) stays at `info`.
- **Named the previously-unfilterable debug records** (`resolved-subscribed-mailboxes`, `resolved-disabled-mailboxes`, `computed-notify-candidates`, `capped-notify-candidates`).

## Backport notes

Adapted to `v0` conventions (no behavioral difference from the develop PR):
- `PushLogger` uses `get_mail_config()` / `push_log_max_size` instead of develop's `get_config()` / `push_log_max_file_size`.
- Error logging in `mail_message.py` keeps `v0`'s `frappe.log_error(title=, message=)` form.

`pre-commit` (ruff) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)