### PR TITLE
feat: make Gravatar opt-in via Mail Settings

### DIFF
--- a/frontend/src/types/doctypes.ts
+++ b/frontend/src/types/doctypes.ts
@@ -165,6 +165,8 @@ export interface MailSettings extends DocType {
   default_dns_ttl: number;
   /** Default Disk Quota (GB): Int */
   default_disk_quota_gb: number;
+  /** Enable Gravatar: Check */
+  enable_gravatar: 0 | 1;
   /** Default Gravatar: Select */
   default_gravatar: '404';
   /** Stalwart CLI Version: Data */

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -663,18 +663,19 @@ def get_avatar(email: str, size: int = 128, strict: bool = False) -> None:
 	avatar = frappe.cache.get_value(cache_key)
 
 	if not avatar:
-		# 2. Try Gravatar
-		default = get_config("default_gravatar")
-		try:
-			res = requests.get(
-				f"https://secure.gravatar.com/avatar/{email_hash}",
-				params={"d": default, "s": size},
-				timeout=3,
-			)
-			if res.ok:
-				avatar = res.content
-		except requests.RequestException:
-			pass
+		# 2. Try Gravatar (opt-in: avoids leaking emails to a third party when disabled)
+		if get_config("enable_gravatar"):
+			default = get_config("default_gravatar")
+			try:
+				res = requests.get(
+					f"https://secure.gravatar.com/avatar/{email_hash}",
+					params={"d": default, "s": size},
+					timeout=3,
+				)
+				if res.ok:
+					avatar = res.content
+			except requests.RequestException:
+				pass
 
 		# 3. Handle missing gravatar
 		if not avatar:

--- a/mail/api/utils.py
+++ b/mail/api/utils.py
@@ -1,4 +1,14 @@
-def get_avatar_url(email: str) -> str:
-	"""Returns the avatar URL for the given email."""
+from mail.utils import get_config
+
+
+def get_avatar_url(email: str) -> str | None:
+	"""Returns the Gravatar avatar URL for the given email, or None if Gravatar is disabled.
+
+	Gravatar is a third-party service, so the lookup is opt-in via the "Enable Gravatar" Mail
+	Setting. When disabled, callers fall back to showing initials instead.
+	"""
+
+	if not get_config("enable_gravatar"):
+		return None
 
 	return f"/api/method/mail.api.mail.get_avatar?email={email}"

--- a/mail/api/utils.py
+++ b/mail/api/utils.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from mail.utils import get_config
 
 
@@ -11,4 +13,4 @@ def get_avatar_url(email: str) -> str | None:
 	if not get_config("enable_gravatar"):
 		return None
 
-	return f"/api/method/mail.api.mail.get_avatar?email={email}"
+	return f"/api/method/mail.api.mail.get_avatar?email={quote(email, safe='')}"

--- a/mail/mail/doctype/mail_settings/mail_settings.json
+++ b/mail/mail/doctype/mail_settings/mail_settings.json
@@ -19,6 +19,7 @@
   "defaults_section",
   "default_dns_ttl",
   "default_disk_quota_gb",
+  "enable_gravatar",
   "default_gravatar",
   "column_break_cuxv",
   "stalwart_version",
@@ -410,7 +411,15 @@
    "reqd": 1
   },
   {
+   "default": "0",
+   "description": "Use Gravatar for default user images. Gravatar is a third-party service; enabling this shares users' email addresses (hashed) with it. When disabled, initials are shown instead.",
+   "fieldname": "enable_gravatar",
+   "fieldtype": "Check",
+   "label": "Enable Gravatar"
+  },
+  {
    "default": "404",
+   "depends_on": "eval: doc.enable_gravatar",
    "fieldname": "default_gravatar",
    "fieldtype": "Select",
    "label": "Default Gravatar",

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -49,6 +49,7 @@ CONFIG_KEYS = [
 	# Defaults
 	"default_dns_ttl",
 	"default_disk_quota_gb",
+	"enable_gravatar",
 	"default_gravatar",
 	"stalwart_version",
 	"stalwart_cli_version",


### PR DESCRIPTION
## Why

Gravatar is a third-party service. Looking up default user images by email (introduced in #398) shares users' email addresses (hashed) with it on every avatar request. For data-security reasons this should be **opt-in**, not the default.

## What

Adds an **Enable Gravatar** setting to Mail Settings → Config → Defaults, **disabled by default**.

- **Disabled (default):** no request is ever made to Gravatar; the UI falls back to **initials**, matching the pre-#398 behavior.
- **Enabled:** existing Gravatar behavior (admins who want it can simply turn it on).

## Changes

- **`mail_settings.json`** — new `enable_gravatar` Check (default `0`); the existing `default_gravatar` select now `depends_on` it.
- **`utils/__init__.py`** — register `enable_gravatar` in `CONFIG_KEYS`.
- **`api/utils.py`** — `get_avatar_url()` returns `None` when Gravatar is disabled. This is the single gate covering every call site (`mail.py`, `contacts.py`, `account.py`, `admin.py`), which all already do `user_image or get_avatar_url(...)` and thus fall back to initials.
- **`api/mail.py`** — `get_avatar` endpoint skips the Gravatar HTTP request when disabled, so the email hash is never sent to a third party even on a direct endpoint call (falls through to the local pydenticon generator).
- **`frontend/src/types/doctypes.ts`** — add `enable_gravatar` to the `MailSettings` type.

## Notes

- No data patch needed: for the Single doctype an absent value resolves to falsy = disabled, the intended default.
- All `Avatar` components consuming `user_image` already have an initials `:label` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)