### PR TITLE
feat: make Gravatar opt-in via mail config (v0 backport)

### DIFF
--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -663,18 +663,19 @@ def get_avatar(email: str, size: int = 128, strict: bool = False) -> None:
 	avatar = frappe.cache.get_value(cache_key)
 
 	if not avatar:
-		# 2. Try Gravatar
-		default = get_mail_config("gravatar_default_avatar")
-		try:
-			res = requests.get(
-				f"https://secure.gravatar.com/avatar/{email_hash}",
-				params={"d": default, "s": size},
-				timeout=3,
-			)
-			if res.ok:
-				avatar = res.content
-		except requests.RequestException:
-			pass
+		# 2. Try Gravatar (opt-in: avoids leaking emails to a third party when disabled)
+		if get_mail_config("enable_gravatar"):
+			default = get_mail_config("gravatar_default_avatar")
+			try:
+				res = requests.get(
+					f"https://secure.gravatar.com/avatar/{email_hash}",
+					params={"d": default, "s": size},
+					timeout=3,
+				)
+				if res.ok:
+					avatar = res.content
+			except requests.RequestException:
+				pass
 
 		# 3. Handle missing gravatar
 		if not avatar:

--- a/mail/api/utils.py
+++ b/mail/api/utils.py
@@ -1,4 +1,16 @@
-def get_avatar_url(email: str) -> str:
-	"""Returns the avatar URL for the given email."""
+from urllib.parse import quote
 
-	return f"/api/method/mail.api.mail.get_avatar?email={email}"
+from mail.utils import get_mail_config
+
+
+def get_avatar_url(email: str) -> str | None:
+	"""Returns the Gravatar avatar URL for the given email, or None if Gravatar is disabled.
+
+	Gravatar is a third-party service, so the lookup is opt-in via the `enable_gravatar` mail
+	config (site_config.json). When disabled, callers fall back to showing initials instead.
+	"""
+
+	if not get_mail_config("enable_gravatar"):
+		return None
+
+	return f"/api/method/mail.api.mail.get_avatar?email={quote(email, safe='')}"

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -72,6 +72,7 @@ def get_mail_config(key: str | None = None) -> dict[str, Any] | Any:
 		"default_dns_ttl": 3600,
 		"default_mail_quota": 1024**3,  # 1 GB
 		"enable_ed25519_dkim": False,
+		"enable_gravatar": False,
 		"exchange_export_batch_size": 500,
 		"exchange_export_timeout": 3600,
 		"exchange_import_timeout": 3600,


### PR DESCRIPTION
Backport of #591 to `v0`.

## Why

Gravatar is a third-party service. Looking up default user images by email shares users' email addresses (hashed) with it on every avatar request. For data-security reasons this should be **opt-in**, not the default.

## What

Adds an `enable_gravatar` mail config, **`False` by default**.

- **Disabled (default):** no request is ever made to Gravatar; the UI falls back to **initials**.
- **Enabled:** existing Gravatar behavior.

Enable it in `site_config.json`:

```json
{
  "mail": {
    "enable_gravatar": true
  }
}
```

## v0 adaptation notes

This is not a clean cherry-pick of #591 — `v0` differs from `develop`:

- On `develop`, gravatar config is part of `get_config`/`CONFIG_KEYS` and the toggle is a Mail Settings doctype field. On `v0`, gravatar config lives in `get_mail_config` (read from `frappe.conf.mail`, alongside the existing `gravatar_default_avatar`).
- So here the toggle is added to `get_mail_config`'s defaults and read via `get_mail_config("enable_gravatar")`, consistent with how `v0` handles gravatar config. `gravatar_default_avatar` is left untouched.

## Changes

- **`utils/__init__.py`** — add `enable_gravatar` (default `False`) to `get_mail_config`'s config defaults.
- **`api/utils.py`** — `get_avatar_url()` returns `None` when Gravatar is disabled. Single gate covering every call site (`mail.py`, `contacts.py`, `account.py`, `admin.py`), which all do `user_image or get_avatar_url(...)` and thus fall back to initials. Also URL-encodes the email so `+`/reserved characters survive the round-trip.
- **`api/mail.py`** — `get_avatar` endpoint skips the Gravatar HTTP request when disabled, so the email hash is never sent to a third party even on a direct endpoint call (falls through to the local pydenticon generator).

## Notes

- All `Avatar` components consuming `user_image` already have an initials `:label` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)