### PR TITLE
feat: configurable "on mark as junk" behaviour (junk or block sender) (backport to v0)

### DIFF
--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -81,7 +81,7 @@ const route = useRoute()
 const router = useRouter()
 const { account, mailboxes, mailboxIds, identities, blockedAddresses } = userStore()
 const { setUndoAction, undo } = useUndo()
-const { promptBlockSenders } = useBlockSender()
+const { promptBlockSenders, willJunkSenders } = useBlockSender()
 const user = inject('$user')
 
 const primaryActions = (mail: Mail): MailAction[] => [
@@ -255,12 +255,19 @@ const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
 	const action = () =>
 		markAsSpam.submit({ spam }).then(() => {
 			reloadMails(isUndo)
-			// After marking as Junk, offer to block the sender (not when re-junking via an undo of
-			// Mark as Not Junk). Blocking then clears the undo set below.
+			// After marking as Junk, apply the account's "on mark as junk" behaviour (silently junk the
+			// sender's future mail, or prompt to block). Not on the undo of Mark as Not Junk.
 			if (spam && !isUndo)
 				promptBlockSenders([{ name: mail.from_name, email: mail.from_email }])
 		})
-	const successMessage = spam ? __('Mail marked as Junk.') : __('Mail marked as Not Junk.')
+	// When the account auto-junks the sender, surface that as the single toast for the whole action.
+	const autoJunk =
+		spam && !isUndo && willJunkSenders([{ name: mail.from_name, email: mail.from_email }])
+	const successMessage = autoJunk
+		? __('Mails from sender will go to Junk.')
+		: spam
+			? __('Mail marked as Junk.')
+			: __('Mail marked as Not Junk.')
 
 	if (isUndo) return raisePromiseToast(action, __('Undoing...'), successMessage)
 
@@ -355,14 +362,14 @@ const handleBlockAddress = (block: boolean, isUndo = false) => {
 		(block ? blockEmailAddress : unblockEmailAddress)
 			.submit()
 			.then(() => blockedAddresses.reload())
-	const successMessage = block ? __('Email address blocked.') : __('Email address unblocked.')
+	const successMessage = block ? __('Sender blocked.') : __('Sender unblocked.')
 
 	if (isUndo) return raisePromiseToast(action, __('Undoing...'), successMessage)
 
 	setUndoAction(() => handleBlockAddress(!block, true))
 	raisePromiseToast(
 		action,
-		block ? __('Blocking email address...') : __('Unblocking email address...'),
+		block ? __('Blocking sender...') : __('Unblocking sender...'),
 		successMessage,
 		undo,
 	)

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -689,7 +689,7 @@ const unblockEmailAddress = createResource({
 	url: 'mail.api.mail.unblock_email_addresses',
 	makeParams: (email) => ({ account: store.account, emails: [email] }),
 	onSuccess: () => {
-		raiseToast(__('Email address unblocked.'))
+		raiseToast(__('Sender unblocked.'))
 		blockedAddresses.reload()
 	},
 })

--- a/frontend/src/components/Modals/BlockSenderModal.vue
+++ b/frontend/src/components/Modals/BlockSenderModal.vue
@@ -52,16 +52,11 @@
 
 <script setup lang="ts">
 import { computed, reactive, watch } from 'vue'
-import { Dialog, FormControl, createResource } from 'frappe-ui'
+import { Dialog, FormControl } from 'frappe-ui'
 
-import { raisePromiseToast } from '@/utils'
-import { useBlockSender, useUndo } from '@/utils/composables'
-import { userStore } from '@/stores/user'
+import { useBlockSender } from '@/utils/composables'
 
-const store = userStore()
-const { blockedAddresses } = store
-const { showBlockSender, sendersToBlock } = useBlockSender()
-const { setUndoAction } = useUndo()
+const { showBlockSender, sendersToBlock, blockSenders } = useBlockSender()
 
 const isMultiple = computed(() => sendersToBlock.value.length > 1)
 
@@ -85,28 +80,12 @@ const toggleAll = () => {
 	sendersToBlock.value.forEach((sender) => (selected[sender.email] = next))
 }
 
-const blockEmailAddresses = createResource({
-	url: 'mail.api.mail.block_email_addresses',
-	makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
-	onSuccess: () => blockedAddresses.reload(),
-})
-
 const handleBlock = () => {
-	const emails = (
-		isMultiple.value
-			? sendersToBlock.value.filter((sender) => selected[sender.email])
-			: sendersToBlock.value
-	).map((sender) => sender.email)
+	const toBlock = isMultiple.value
+		? sendersToBlock.value.filter((sender) => selected[sender.email])
+		: sendersToBlock.value
 	showBlockSender.value = false
-	if (!emails.length) return
-
-	// Blocking supersedes the junk action's undo — clear it so a following Ctrl+Z is a no-op (the
-	// junk toast's own Undo button is dismissed by raisePromiseToast's toast.removeAll()).
-	setUndoAction(undefined)
-
-	const action = () => blockEmailAddresses.submit({ emails })
-	const success = emails.length === 1 ? __('Sender blocked.') : __('Senders blocked.')
-	raisePromiseToast(action, __('Blocking...'), success)
+	blockSenders(toBlock)
 }
 
 const options = computed(() => {

--- a/frontend/src/components/Settings/AccountSettings.vue
+++ b/frontend/src/components/Settings/AccountSettings.vue
@@ -32,6 +32,15 @@
 			class="!p-0"
 		/>
 
+		<h1>{{ __('Incoming') }}</h1>
+		<FormControl
+			v-model="accountSettings.doc.on_mark_as_junk"
+			type="select"
+			:label="__('When Marking as Junk')"
+			variant="outline"
+			:options="ON_MARK_AS_JUNK_OPTIONS"
+		/>
+
 		<template v-if="userSettings.doc">
 			<h1>{{ __('Recovery') }}</h1>
 			<FormControl
@@ -97,6 +106,14 @@ const destroyNewsletterAfterSubmit = computed({
 	set: (val: boolean) => (accountSettings.doc.destroy_newsletter_after_submit = val ? 1 : 0),
 })
 
+const ON_MARK_AS_JUNK_OPTIONS = [
+	{
+		label: __("Move the sender's future mail to Junk automatically"),
+		value: "Junk Sender's Mail",
+	},
+	{ label: __('Ask whether to block the sender'), value: 'Ask to Block Sender' },
+]
+
 const accountDirty = computed(
 	() => JSON.stringify(accountSettings.doc) !== JSON.stringify(accountSettings.originalDoc),
 )
@@ -110,10 +127,12 @@ const saving = computed(() => accountSettings.save.loading || userSettings.save.
 const save = async () => {
 	if (accountDirty.value) {
 		await accountSettings.save.submit()
-		// Sync the shared user data so compose picks up the new default without a page
-		// reload (ComposeMailEditor reads default_outgoing_email from user.data.accounts).
-		if (activeAccount)
+		// Sync the shared user data so compose picks up the new default and the junk flow picks up
+		// the "on mark as junk" choice without a page reload (both read from user.data.accounts).
+		if (activeAccount) {
 			activeAccount.default_outgoing_email = accountSettings.doc.default_outgoing_email
+			activeAccount.on_mark_as_junk = accountSettings.doc.on_mark_as_junk
+		}
 	}
 	if (userDirty.value) await userSettings.save.submit()
 	raiseToast(__('Account updated.'))

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -1081,6 +1081,10 @@ const goToThread = (threadID: string) => {
 let pendingEdgeThread: { edge: 'first' | 'last'; action: 'open' | 'focus' } | null = null
 
 const crossPageByOffset = (offset: number, action: 'open' | 'focus') => {
+	// While a page transition is in flight (flag set until the new page loads), ignore further
+	// crossings — otherwise key auto-repeat at an edge keeps incrementing page.value and blows
+	// through many pages before the debounced reload fires.
+	if (pendingEdgeThread) return
 	if (offset > 0 && canGoNext.value) {
 		pendingEdgeThread = { edge: 'first', action }
 		goToPage(true)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,9 @@ export * from './doctypes'
 
 export type COLOR_SCHEME = 'System Default' | 'Light Mode' | 'Dark Mode'
 
+// What happens to a sender when one of their messages is marked as Junk (Account Settings).
+export type OnMarkAsJunk = "Junk Sender's Mail" | 'Ask to Block Sender'
+
 export interface User {
 	name: string
 	email: string
@@ -26,7 +29,11 @@ export interface User {
 	mailboxes: { id: string; name: string; role: string }[]
 	// `get_user_info` enriches each account with its per-account outgoing default and
 	// Account Settings doc name (the fields moved off User Settings).
-	accounts: (UserAccount & { default_outgoing_email?: string; account_settings?: string })[]
+	accounts: (UserAccount & {
+		default_outgoing_email?: string
+		account_settings?: string
+		on_mark_as_junk?: OnMarkAsJunk
+	})[]
 }
 
 export interface UserResource {

--- a/frontend/src/utils/composables.ts
+++ b/frontend/src/utils/composables.ts
@@ -1,5 +1,7 @@
 import { computed, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { createResource } from 'frappe-ui'
 
+import { raisePromiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
 
 import type { Identity } from '@/types'
@@ -89,7 +91,17 @@ export const useUndo = () => {
 		undoAction.value = undefined
 	}
 
-	return { setUndoAction, undo }
+	// Wrap the current undo so `step` runs first — lets a side effect (e.g. a junk-list entry) be
+	// reverted on top of the primary undo without replacing it.
+	const prependUndoAction = (step: () => void) => {
+		const prev = undoAction.value
+		undoAction.value = () => {
+			step()
+			prev?.()
+		}
+	}
+
+	return { setUndoAction, undo, prependUndoAction }
 }
 
 // Shared state for the "Block sender?" prompt shown after marking/moving mail to Junk. A single
@@ -103,7 +115,15 @@ const showBlockSender = ref(false)
 const sendersToBlock = ref<BlockableSender[]>([])
 
 export const useBlockSender = () => {
-	const { identities, blockedAddresses } = userStore()
+	const store = userStore()
+	const { userResource, identities, blockedAddresses } = store
+	const { setUndoAction, undo, prependUndoAction } = useUndo()
+
+	// Read account/accountId off the store at call time — destructuring would snapshot the unwrapped
+	// values and miss account switches while a component stays mounted.
+	const activeAccount = computed(() =>
+		userResource.data?.accounts?.find((a) => a.id === store.accountId),
+	)
 
 	// Senders worth offering to block: drop the user's own identities and addresses already blocked,
 	// and de-duplicate by email (keeping the first occurrence's display name).
@@ -120,14 +140,78 @@ export const useBlockSender = () => {
 		return result
 	}
 
+	const blockResource = createResource({
+		url: 'mail.api.mail.block_email_addresses',
+		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		onSuccess: () => blockedAddresses.reload(),
+	})
+
+	const junkResource = createResource({
+		url: 'mail.api.mail.junk_senders',
+		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+	})
+
+	const unjunkResource = createResource({
+		url: 'mail.api.mail.unjunk_senders',
+		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+	})
+
+	const unblockResource = createResource({
+		url: 'mail.api.mail.unblock_email_addresses',
+		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		onSuccess: () => blockedAddresses.reload(),
+	})
+
+	// Block the senders chosen in the prompt ('Ask to Block Sender' confirm). Blocking becomes the new
+	// undo action: Cmd+Z unblocks (it does not also reverse the junk move, which stays).
+	const blockSenders = (senders: BlockableSender[]) => {
+		const emails = senders.map((sender) => sender.email)
+		if (!emails.length) return
+
+		setUndoAction(() => {
+			const undoAction = () => unblockResource.submit({ emails })
+			const restored =
+				emails.length === 1 ? __('Sender unblocked.') : __('Senders unblocked.')
+			raisePromiseToast(undoAction, __('Undoing...'), restored)
+		})
+
+		const action = () => blockResource.submit({ emails })
+		const success = emails.length === 1 ? __('Sender blocked.') : __('Senders blocked.')
+		raisePromiseToast(action, __('Blocking...'), success, undo)
+	}
+
+	// File the senders' future mail into Junk (the default 'Junk Sender's Mail'). Side effect only — the
+	// caller renders the toast (see willJunkSenders) so the junk action shows a single toast, not two.
+	// Undoing the junk move also drops them from the junk list (composed onto that move's undo).
+	const junkSenders = (senders: BlockableSender[]) => {
+		const emails = senders.map((sender) => sender.email)
+		if (!emails.length) return
+
+		junkResource.submit({ emails })
+		prependUndoAction(() => unjunkResource.submit({ emails }))
+	}
+
+	// Whether marking these senders as junk will auto-file their future mail into Junk (vs prompting
+	// to block, or doing nothing when there's nothing blockable). Lets the caller show one accurate toast.
+	const willJunkSenders = (senders: { name?: string; email?: string }[]) =>
+		blockableSenders(senders).length > 0 &&
+		activeAccount.value?.on_mark_as_junk !== 'Ask to Block Sender'
+
+	// Apply the account's 'on mark as junk' behaviour to the senders of a just-junked message:
+	// 'Ask to Block Sender' opens the prompt; otherwise silently junk their future mail.
 	const promptBlockSenders = (senders: { name?: string; email?: string }[]) => {
 		const list = blockableSenders(senders)
 		if (!list.length) return
-		sendersToBlock.value = list
-		showBlockSender.value = true
+
+		if (activeAccount.value?.on_mark_as_junk === 'Ask to Block Sender') {
+			sendersToBlock.value = list
+			showBlockSender.value = true
+			return
+		}
+		junkSenders(list)
 	}
 
-	return { showBlockSender, sendersToBlock, promptBlockSenders }
+	return { showBlockSender, sendersToBlock, willJunkSenders, promptBlockSenders, blockSenders }
 }
 
 // Shared state for the Settings dialog, so any view can open it (optionally on a specific tab).

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -78,9 +78,11 @@ export const raisePromiseToast = (
 	if (undoAction)
 		return toast.promise(action(), {
 			loading,
-			success,
+			success: {
+				message: success,
+				action: { label: __('Undo'), onClick: () => undoAction() },
+			},
 			error,
-			successAction: { label: __('Undo'), onClick: () => undoAction() },
 		})
 
 	toast.promise(action(), { loading, success, error })

--- a/frontend/src/utils/useThreadActions.ts
+++ b/frontend/src/utils/useThreadActions.ts
@@ -52,7 +52,7 @@ export function useThreadActions(deps: {
 	const store = userStore()
 	const { mailboxes, mailboxIds } = store
 	const { setUndoAction, undo } = useUndo()
-	const { promptBlockSenders } = useBlockSender()
+	const { promptBlockSenders, willJunkSenders } = useBlockSender()
 
 	const threadMails = (threadIds: string[]): Mail[] => {
 		const items = (threadsResource.value.data ?? []).filter((t: Thread) =>
@@ -275,56 +275,45 @@ export function useThreadActions(deps: {
 	})
 
 	const showJunkOrDeleteThreads = ref(false)
-	const threadsToBeJunkedOrDeleted = ref<string[]>([])
-	const isJunkAction = ref(false)
+	const threadsToBeDeleted = ref<string[]>([])
 
+	// Marking as Junk is reversible (and may still prompt to block per the account setting), so it
+	// runs inline with no confirmation; only the destructive delete keeps a confirmation dialog.
 	const junkOrDeleteThreads = (threadIDs: string[], isJunk: boolean) => {
 		if (!threadIDs?.length) return
 
-		threadsToBeJunkedOrDeleted.value = threadIDs
-		isJunkAction.value = isJunk
+		if (isJunk) return handleSetSpamStatus({ 1: threadIDs })
+
+		threadsToBeDeleted.value = threadIDs
 		showJunkOrDeleteThreads.value = true
 	}
 
-	const junkOrDeleteThreadCount = computed(() => threadsToBeJunkedOrDeleted.value.length)
-
-	const junkOrDeleteTitle = computed(() => {
-		const count =
-			junkOrDeleteThreadCount.value === 1 ? '' : junkOrDeleteThreadCount.value.toString()
-		const noun = junkOrDeleteThreadCount.value > 1 ? __('Threads') : __('Thread')
-
-		return isJunkAction.value
-			? __('Mark {0} {1} as Junk', [count, noun])
-			: __('Delete {0} {1}', [count, noun])
-	})
-
-	const junkOrDeleteMessage = computed(() => {
-		const noun = junkOrDeleteThreadCount.value > 1 ? __('threads') : __('thread')
-
-		return isJunkAction.value
-			? __('Are you sure you want to mark the selected {0} as junk?', [noun])
-			: __('Are you sure you want to permanently delete the selected {0}?', [noun])
-	})
-
-	const handleJunkOrDelete = () => {
-		if (isJunkAction.value) handleSetSpamStatus({ 1: threadsToBeJunkedOrDeleted.value })
-		else handleDeleteThreads(threadsToBeJunkedOrDeleted.value)
-
+	const handleDeleteConfirmed = () => {
+		handleDeleteThreads(threadsToBeDeleted.value)
 		showJunkOrDeleteThreads.value = false
 	}
 
-	const junkOrDeleteThreadsOptions = computed(() => ({
-		title: junkOrDeleteTitle.value,
-		message: junkOrDeleteMessage.value,
-		actions: [
-			{
-				label: __('Confirm'),
-				variant: 'solid',
-				autofocus: true,
-				onClick: handleJunkOrDelete,
-			},
-		],
-	}))
+	const junkOrDeleteThreadsOptions = computed(() => {
+		const total = threadsToBeDeleted.value.length
+		const count = total === 1 ? '' : total.toString()
+		const noun = total > 1 ? __('Threads') : __('Thread')
+		const lowerNoun = total > 1 ? __('threads') : __('thread')
+
+		return {
+			title: __('Delete {0} {1}', [count, noun]),
+			message: __('Are you sure you want to permanently delete the selected {0}?', [
+				lowerNoun,
+			]),
+			actions: [
+				{
+					label: __('Confirm'),
+					variant: 'solid',
+					autofocus: true,
+					onClick: handleDeleteConfirmed,
+				},
+			],
+		}
+	})
 
 	const bulkDelete = createResource({
 		url: 'mail.client.doctype.mail_message.mail_message.bulk_delete',
@@ -531,8 +520,8 @@ export function useThreadActions(deps: {
 		const action = async () => {
 			await setMailsSpam.submit({ ids, spam })
 			handleSuccessAndRemoveFromList(threadIDs)
-			// After marking as Junk, offer to block the sender(s). Blocking then clears the undo set
-			// below (undoing the junk once the sender is blocked would be inconsistent).
+			// After marking as Junk, apply the account's "on mark as junk" behaviour (silently junk the
+			// sender's future mail, or prompt to block).
 			if (spam) promptBlockSenders(senders)
 		}
 
@@ -541,13 +530,21 @@ export function useThreadActions(deps: {
 				await setMailsMailboxes.submit({ mails: snapshot })
 				reloadThreads()
 			}
-			raisePromiseToast(undoAction, __('Undoing...'), __('Junk status restored.'))
+			// Undo flips the junk status back — name the resulting state, like the forward toast does.
+			const restored =
+				selectedThreads.length === 1
+					? __('Thread marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
+					: __('Threads marked as {0}.', [spam ? __('Not Junk') : __('Junk')])
+			raisePromiseToast(undoAction, __('Undoing...'), restored)
 		})
 		const loading = spam ? __('Marking as Junk...') : __('Marking as Not Junk...')
+		// When the account auto-junks the sender, surface that as the single toast for the whole action.
 		const success =
-			selectedThreads.length === 1
-				? __('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
-				: __('Threads marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
+			spam && willJunkSenders(senders)
+				? __('Mails from sender will go to Junk.')
+				: selectedThreads.length === 1
+					? __('Thread marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
+					: __('Threads marked as {0}.', [spam ? __('Junk') : __('Not Junk')])
 
 		raisePromiseToast(action, loading, success, undo)
 	}

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -165,13 +165,14 @@ def get_user_info() -> dict | None:
 		for s in frappe.get_all(
 			"Account Settings",
 			filters={"user": user},
-			fields=["name", "account", "default_outgoing_email"],
+			fields=["name", "account", "default_outgoing_email", "on_mark_as_junk"],
 		)
 	}
 	for acc in data.accounts:
 		settings = settings_by_account.get(acc["name"])
 		acc["account_settings"] = settings["name"] if settings else None
 		acc["default_outgoing_email"] = settings["default_outgoing_email"] if settings else None
+		acc["on_mark_as_junk"] = settings["on_mark_as_junk"] if settings else "Junk Sender's Mail"
 
 	data.user_image = data.user_image or get_avatar_url(user)
 

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -12,9 +12,14 @@ from frappe.model.document import bulk_insert
 from frappe.utils import format_datetime, random_string
 
 from mail.api.contacts import create_contacts_if_not_exists
-from mail.api.sieve import update_sieve_script_for_blocked_emails, update_sieve_script_for_mailbox
+from mail.api.sieve import (
+	update_sieve_script_for_blocked_emails,
+	update_sieve_script_for_junk_senders,
+	update_sieve_script_for_mailbox,
+)
 from mail.api.utils import get_avatar_url
 from mail.client.doctype.blocked_email_address.blocked_email_address import get_blocked_email_addresses
+from mail.client.doctype.junk_email_address.junk_email_address import get_junk_email_addresses
 from mail.client.doctype.mail_message.mail_message import (
 	add_messages_to_mailbox,
 	delete_messages,
@@ -822,13 +827,84 @@ def block_email_addresses(account: str, emails: list[str]) -> None:
 		bulk_insert("Blocked Email Address", docs, ignore_duplicates=True)
 		update_sieve_script_for_blocked_emails(account)
 
+	# A hard block supersedes a soft junk rule for the same sender — drop any junk entries so the two
+	# sieve blocks can't both target one address.
+	remove_junk_senders(account, [doc.email for doc in docs])
+
+
+@frappe.whitelist()
+def junk_senders(account: str, emails: list[str]) -> None:
+	"""Routes future mail from the given senders into Junk for the account, in a single request.
+
+	The soft counterpart to `block_email_addresses`: instead of discarding, the generated sieve block
+	files matching mail into the Junk folder. Already-junked addresses are skipped and the sieve
+	script is regenerated once at the end.
+	"""
+
+	user = parse_account(account)[0]
+	has_permission_for_user(user)
+
+	already_junked = set(get_junk_email_addresses(account))
+	docs = []
+	for email in dict.fromkeys(emails):  # de-duplicate while preserving order
+		if not email or email in already_junked:
+			continue
+		doc = frappe.get_doc(
+			{"doctype": "Junk Email Address", "account": account, "email": email, "user": user}
+		)
+		doc.set_new_name()
+		docs.append(doc)
+
+	if docs:
+		bulk_insert("Junk Email Address", docs, ignore_duplicates=True)
+		update_sieve_script_for_junk_senders(account)
+
+
+@frappe.whitelist()
+def unjunk_senders(account: str, emails: list[str]) -> None:
+	"""Removes senders from the account's junk list (e.g. when a junk action is undone)."""
+
+	has_permission_for_user(parse_account(account)[0])
+	remove_junk_senders(account, emails)
+
+
+def remove_junk_senders(account: str, emails: list[str]) -> None:
+	"""Deletes Junk Email Address records and regenerates the junk sieve block."""
+
+	if not emails:
+		return
+
+	deleted = frappe.db.get_all(
+		"Junk Email Address", filters={"account": account, "email": ["in", emails]}, pluck="name"
+	)
+	if not deleted:
+		return
+
+	frappe.db.delete("Junk Email Address", {"name": ["in", deleted]})
+	update_sieve_script_for_junk_senders(account)
+
 
 @frappe.whitelist()
 def unblock_email_addresses(account: str, emails: list[str]) -> None:
-	"""Unblocks email addresses by deleting Blocked Email Address records."""
+	"""Unblocks email addresses by deleting Blocked Email Address records and regenerating the sieve.
+
+	`frappe.db.delete` bypasses the doctype's `after_delete` hook, so the blocked-emails sieve block
+	is rebuilt explicitly here (mirrors `remove_junk_senders`).
+	"""
 
 	has_permission_for_user(parse_account(account)[0])
-	frappe.db.delete("Blocked Email Address", {"account": account, "email": ["in", emails]})
+
+	if not emails:
+		return
+
+	deleted = frappe.db.get_all(
+		"Blocked Email Address", filters={"account": account, "email": ["in", emails]}, pluck="name"
+	)
+	if not deleted:
+		return
+
+	frappe.db.delete("Blocked Email Address", {"name": ["in", deleted]})
+	update_sieve_script_for_blocked_emails(account)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])

--- a/mail/api/sieve.py
+++ b/mail/api/sieve.py
@@ -4,8 +4,14 @@ import frappe
 from frappe import _
 
 from mail.client.doctype.blocked_email_address.blocked_email_address import get_blocked_email_addresses
+from mail.client.doctype.junk_email_address.junk_email_address import get_junk_email_addresses
 from mail.client.doctype.sieve_script.sieve_script import SieveScript
-from mail.jmap import get_mailbox_id_by_name, get_mailbox_name_by_id, get_mailboxes
+from mail.jmap import (
+	get_mailbox_id_by_name,
+	get_mailbox_id_by_role,
+	get_mailbox_name_by_id,
+	get_mailboxes,
+)
 
 AUTOMATION_SCRIPT_NAME = "frappe_mail_automation"
 AUTOMATION_SCRIPT_REQUIRE = 'require ["fileinto", "imap4flags"];'
@@ -290,6 +296,69 @@ def update_sieve_script_for_blocked_emails(account: str) -> None:
 			f"# {block_name}",
 			condition_block,
 			"  discard;",
+			"  stop;",
+			"}",
+			"\n",
+		]
+	)
+
+	require_pattern = r"^(require\s+\[.*?\];\s*)+"
+	match = re.match(require_pattern, content, flags=re.DOTALL)
+
+	if match:
+		insert_pos = match.end()
+		content = content[:insert_pos] + "\n" + block_script + content[insert_pos:]
+	else:
+		content = block_script + content
+
+	doc.content = content.rstrip() + "\n"
+	doc.save()
+
+
+def get_junk_folder_path(account: str) -> str:
+	"""Return the folder path of the account's Junk mailbox (for sieve `fileinto`)."""
+
+	junk_id = get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True)
+	junk_name = get_mailbox_name_by_id(account, junk_id, raise_exception=True)
+	return get_mailbox_folder_path(account, junk_name, raise_exception=True)
+
+
+def update_sieve_script_for_junk_senders(account: str) -> None:
+	"""Update sieve script to file emails from the junk-sender list into the Junk folder.
+
+	Mirrors `update_sieve_script_for_blocked_emails` but files into Junk instead of discarding. A
+	sender is never in both lists at once (blocking removes the junk entry), so block/junk blocks
+	cannot both fire for the same sender.
+	"""
+
+	automation_script_name = get_automation_script_name(account)
+	doc = frappe.get_doc("Sieve Script", automation_script_name)
+	content = (doc.content or "").lstrip()
+
+	block_name = "Junk Senders"
+	content = remove_sieve_block(content, block_name)
+
+	junk_emails = get_junk_email_addresses(account)
+	conditions = [f'address :is "from" "{e.strip()}"' for e in junk_emails if e.strip()]
+
+	if not conditions:
+		doc.content = content.rstrip() + "\n"
+		doc.save()
+		return
+
+	junk_folder_path = get_junk_folder_path(account)
+
+	if len(conditions) == 1:
+		condition_block = f"if {conditions[0]} {{"
+	else:
+		joined = ",\n  ".join(conditions)
+		condition_block = f"if anyof (\n  {joined}\n) {{"
+
+	block_script = "\n".join(
+		[
+			f"# {block_name}",
+			condition_block,
+			f'  fileinto "{junk_folder_path}";',
 			"  stop;",
 			"}",
 			"\n",

--- a/mail/client/doctype/account_settings/account_settings.json
+++ b/mail/client/doctype/account_settings/account_settings.json
@@ -19,6 +19,8 @@
   "create_contacts_after_email_submit",
   "destroy_email_after_submit",
   "destroy_newsletter_after_submit",
+  "incoming_section",
+  "on_mark_as_junk",
   "cache_section",
   "has_cached_jmap_identities",
   "has_cached_jmap_mailboxes",
@@ -124,6 +126,19 @@
    "fieldname": "destroy_newsletter_after_submit",
    "fieldtype": "Check",
    "label": "Destroy Newsletter After Submit"
+  },
+  {
+   "fieldname": "incoming_section",
+   "fieldtype": "Section Break",
+   "label": "Incoming"
+  },
+  {
+   "default": "Junk Sender's Mail",
+   "description": "What to do with the sender when a message is marked as Junk. \"Junk Sender's Mail\" files their future mail into Junk; \"Ask to Block Sender\" prompts to block them outright.",
+   "fieldname": "on_mark_as_junk",
+   "fieldtype": "Select",
+   "label": "On Mark As Junk",
+   "options": "Junk Sender's Mail\nAsk to Block Sender"
   },
   {
    "depends_on": "eval: !doc.__islocal",

--- a/mail/client/doctype/junk_email_address/junk_email_address.js
+++ b/mail/client/doctype/junk_email_address/junk_email_address.js
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Junk Email Address', {
+	user(frm) {
+		if (frm.doc.user) {
+			frappe.call({
+				method: 'mail.jmap.get_user_accounts',
+				args: {
+					user: frm.doc.user,
+				},
+				callback: (r) => {
+					if (r.message) {
+						frm.set_df_property('account', 'options', r.message)
+						frm.refresh_field('account')
+					}
+				},
+			})
+		} else {
+			frm.set_df_property('account', 'options', [])
+			frm.refresh_field('account')
+		}
+	},
+})

--- a/mail/client/doctype/junk_email_address/junk_email_address.json
+++ b/mail/client/doctype/junk_email_address/junk_email_address.json
@@ -1,0 +1,90 @@
+{
+ "actions": [],
+ "creation": "2026-06-22 11:54:31.220491",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_gl6l",
+  "user",
+  "account",
+  "column_break_20of",
+  "email"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_gl6l",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "User",
+   "no_copy": 1,
+   "options": "User",
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "column_break_20of",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "no_copy": 1,
+   "options": "Email",
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "account",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account",
+   "no_copy": 1,
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-22 11:54:31.220491",
+ "modified_by": "Administrator",
+ "module": "Client",
+ "name": "Junk Email Address",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "All",
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/client/doctype/junk_email_address/junk_email_address.py
+++ b/mail/client/doctype/junk_email_address/junk_email_address.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from uuid import uuid7
+
+import frappe
+from frappe.model.document import Document
+
+from mail.jmap import parse_account
+
+
+class JunkEmailAddress(Document):
+	def autoname(self) -> None:
+		self.name = str(uuid7())
+
+	def before_insert(self) -> None:
+		self.user = parse_account(self.account)[0]
+
+	def validate(self) -> None:
+		self.validate_duplicate_email()
+
+	def after_insert(self) -> None:
+		from mail.api.sieve import update_sieve_script_for_junk_senders
+
+		update_sieve_script_for_junk_senders(self.account)
+
+	def after_delete(self) -> None:
+		from mail.api.sieve import update_sieve_script_for_junk_senders
+
+		update_sieve_script_for_junk_senders(self.account)
+
+	def validate_duplicate_email(self) -> None:
+		"""Validates that the same email address is not junked multiple times for the same account."""
+
+		if frappe.db.exists(
+			"Junk Email Address",
+			{"account": self.account, "email": self.email, "name": ["!=", self.name]},
+		):
+			frappe.throw(
+				frappe._("The email address {0} is already junked for account {1}.").format(
+					self.email, self.account
+				)
+			)
+
+
+def get_junk_email_addresses(account: str) -> list[str]:
+	"""Returns a list of junked email addresses for the given account."""
+
+	return frappe.db.get_all("Junk Email Address", filters={"account": account}, pluck="email")
+
+
+def on_doctype_update() -> None:
+	frappe.db.add_unique(
+		"Junk Email Address",
+		["account", "email"],
+		constraint_name="unique_account_junk_email",
+	)

--- a/mail/client/doctype/junk_email_address/junk_email_address_list.js
+++ b/mail/client/doctype/junk_email_address/junk_email_address_list.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings['Junk Email Address'] = {
+	refresh: (listview) => {
+		set_account_options(listview)
+	},
+}
+
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_accounts',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account
+			if (!account_field) return
+
+			const options = r.message
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}

--- a/mail/client/doctype/junk_email_address/test_junk_email_address.py
+++ b/mail/client/doctype/junk_email_address/test_junk_email_address.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestJunkEmailAddress(IntegrationTestCase):
+	"""
+	Integration tests for JunkEmailAddress.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -293,6 +293,7 @@ ignore_links_on_delete = [
 	"Mail Domain Request",
 	# Client
 	"Account Settings",
+	"Junk Email Address",
 	"Mail Exchange",
 	"Mail Queue",
 	"Mail Signature",


### PR DESCRIPTION
Backport of #594 to `v0`.

Adds a per-account **When Marking as Junk** setting:

- **Junk Sender's Mail** (default) — file the sender's future mail into Junk via a new `Junk Email Address` doctype + sieve `fileinto` rule.
- **Ask to Block Sender** — prompt to block the sender outright.

Block supersedes junk for the same sender; both actions are undoable (junk → unjunk on undo; block → unblock becomes the new undo). Also fixes `unblock_email_addresses` to regenerate the sieve after deletion.

> Requires `bench migrate` to create the `Junk Email Address` doctype and the `on_mark_as_junk` Account Settings field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)