### PR TITLE
fix: scope blocked-sender list to the shared account, not per user (backport #571 to v0)

### DIFF
--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -796,6 +796,7 @@ def get_blocked_addresses(account: str) -> list[dict]:
 def block_email_address(account: str, email: str) -> dict:
 	"""Blocks an email address for the given account."""
 
+	has_permission_for_user(parse_account(account)[0])
 	doc = frappe.get_doc({"doctype": "Blocked Email Address", "account": account, "email": email})
 	doc.insert()
 
@@ -809,7 +810,7 @@ def block_email_addresses(account: str, emails: list[str]) -> None:
 	and the sieve script is regenerated once at the end since it is rebuilt from the full list.
 	"""
 
-	user = parse_account(account)[0]
+	user, account_id = parse_account(account)
 	has_permission_for_user(user)
 
 	already_blocked = set(get_blocked_email_addresses(account))
@@ -817,8 +818,15 @@ def block_email_addresses(account: str, emails: list[str]) -> None:
 	for email in dict.fromkeys(emails):  # de-duplicate while preserving order
 		if not email or email in already_blocked:
 			continue
+		# bulk_insert bypasses before_insert, so set account_id (the shared key) explicitly.
 		doc = frappe.get_doc(
-			{"doctype": "Blocked Email Address", "account": account, "email": email, "user": user}
+			{
+				"doctype": "Blocked Email Address",
+				"account": account,
+				"account_id": account_id,
+				"email": email,
+				"user": user,
+			}
 		)
 		doc.set_new_name()
 		docs.append(doc)
@@ -888,8 +896,9 @@ def remove_junk_senders(account: str, emails: list[str]) -> None:
 def unblock_email_addresses(account: str, emails: list[str]) -> None:
 	"""Unblocks email addresses by deleting Blocked Email Address records and regenerating the sieve.
 
-	`frappe.db.delete` bypasses the doctype's `after_delete` hook, so the blocked-emails sieve block
-	is rebuilt explicitly here (mirrors `remove_junk_senders`).
+	Scoped to the shared account_id (not the per-user handle), so a block added by any user on a
+	shared account can be removed. `frappe.db.delete` bypasses the doctype's `after_delete` hook, so
+	the blocked-emails sieve block is rebuilt explicitly here (mirrors `remove_junk_senders`).
 	"""
 
 	has_permission_for_user(parse_account(account)[0])
@@ -897,8 +906,9 @@ def unblock_email_addresses(account: str, emails: list[str]) -> None:
 	if not emails:
 		return
 
+	account_id = parse_account(account)[1]
 	deleted = frappe.db.get_all(
-		"Blocked Email Address", filters={"account": account, "email": ["in", emails]}, pluck="name"
+		"Blocked Email Address", filters={"account_id": account_id, "email": ["in", emails]}, pluck="name"
 	)
 	if not deleted:
 		return

--- a/mail/client/doctype/blocked_email_address/blocked_email_address.json
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address.json
@@ -7,6 +7,7 @@
   "section_break_gl6l",
   "user",
   "account",
+  "account_id",
   "column_break_20of",
   "email"
  ],
@@ -49,6 +50,16 @@
    "label": "Account",
    "no_copy": 1,
    "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  },
+  {
+   "description": "The shared JMAP account id (without the user prefix). Blocks are scoped to this so a shared account's block list is the same for everyone with access.",
+   "fieldname": "account_id",
+   "fieldtype": "Data",
+   "label": "Account ID",
+   "no_copy": 1,
+   "read_only": 1,
    "search_index": 1,
    "set_only_once": 1
   }

--- a/mail/client/doctype/blocked_email_address/blocked_email_address.py
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address.py
@@ -14,7 +14,11 @@ class BlockedEmailAddress(Document):
 		self.name = str(uuid7())
 
 	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
+		# `account` is the "user:account_id" handle; `user` records who blocked, while `account_id`
+		# is the shared key so a group account's block list is the same for everyone with access.
+		user, account_id = parse_account(self.account)
+		self.user = user
+		self.account_id = account_id
 
 	def validate(self) -> None:
 		self.validate_duplicate_email()
@@ -30,28 +34,35 @@ class BlockedEmailAddress(Document):
 		update_sieve_script_for_blocked_emails(self.account)
 
 	def validate_duplicate_email(self) -> None:
-		"""Validates that the same email address is not blocked multiple times for the same account."""
+		"""Validates that the same email address is not blocked multiple times for the same account.
+
+		Scoped to `account_id` (not the per-user `account` handle) so a shared account can't have the
+		same address blocked twice by different users.
+		"""
 
 		if frappe.db.exists(
 			"Blocked Email Address",
-			{"account": self.account, "email": self.email, "name": ["!=", self.name]},
+			{"account_id": self.account_id, "email": self.email, "name": ["!=", self.name]},
 		):
 			frappe.throw(
-				frappe._("The email address {0} is already blocked for account {1}.").format(
-					self.email, self.account
-				)
+				frappe._("The email address {0} is already blocked for this account.").format(self.email)
 			)
 
 
 def get_blocked_email_addresses(account: str) -> list[str]:
-	"""Returns a list of blocked email addresses for the given account."""
+	"""Returns the blocked email addresses for the given account.
 
-	return frappe.db.get_all("Blocked Email Address", filters={"account": account}, pluck="email")
+	Keyed on `account_id` so every user with access to a shared account sees the same list.
+	"""
+
+	account_id = parse_account(account)[1]
+	return frappe.db.get_all("Blocked Email Address", filters={"account_id": account_id}, pluck="email")
 
 
 def on_doctype_update() -> None:
+	# Block list is shared per account_id, so uniqueness is on (account_id, email).
 	frappe.db.add_unique(
 		"Blocked Email Address",
-		["account", "email"],
-		constraint_name="unique_account_blocked_email",
+		["account_id", "email"],
+		constraint_name="unique_account_id_blocked_email",
 	)

--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -16,3 +16,4 @@ mail.patches.rename_account_to_user
 mail.patches.set_user_account
 mail.patches.create_archive_mailbox
 mail.patches.migrate_data_store_to_lmdb
+mail.patches.backfill_blocked_email_account_id

--- a/mail/patches/backfill_blocked_email_account_id.py
+++ b/mail/patches/backfill_blocked_email_account_id.py
@@ -1,0 +1,49 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Blocked Email Address.account_id` from the per-user "user:account_id" handle so the
+	block list is keyed on the shared account_id rather than per user.
+
+	The (account_id, email) unique index is added during model sync, when existing rows still have a
+	NULL account_id (NULLs are distinct, so the index applies cleanly). This patch then deduplicates
+	(account_id, email) and fills account_id in, and drops the now-redundant per-handle index.
+	"""
+
+	rows = frappe.get_all(
+		"Blocked Email Address",
+		fields=["name", "account", "email"],
+		order_by="creation asc",
+	)
+
+	seen: set[tuple[str, str]] = set()
+	duplicates: list[str] = []
+	updates: list[tuple[str, str]] = []
+
+	for row in rows:
+		try:
+			account_id = parse_account(row.account)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		key = (account_id, row.email)
+		if key in seen:
+			duplicates.append(row.name)
+		else:
+			seen.add(key)
+			updates.append((row.name, account_id))
+
+	# Drop redundant duplicate blocks first (same address blocked by multiple users on a shared
+	# account) so populating account_id can't violate the unique (account_id, email) index. The set
+	# of blocked addresses per account is unchanged, so the sieve scripts don't need regenerating.
+	if duplicates:
+		frappe.db.delete("Blocked Email Address", {"name": ["in", duplicates]})
+
+	for name, account_id in updates:
+		frappe.db.set_value("Blocked Email Address", name, "account_id", account_id, update_modified=False)
+
+	# The block list is keyed on account_id now; drop the stale per-handle unique index.
+	if frappe.db.has_index("tabBlocked Email Address", "unique_account_blocked_email"):
+		frappe.db.sql_ddl("ALTER TABLE `tabBlocked Email Address` DROP INDEX `unique_account_blocked_email`")


### PR DESCRIPTION
Backport of #571 to `v0`.

## Problem

The blocked-sender list was keyed by the per-user `"user:account_id"` handle. On a **shared (group) account**, each user therefore had a separate list, and regenerating the Stalwart sieve from one user's list **overrode** everyone else's blocks. Unblock had two further bugs: it matched on the per-user handle (so you couldn't remove a block another user added) and it never regenerated the sieve (so unblocking didn't take effect).

## Fix

Key the block list on the shared **`account_id`** (`parse_account(account)[1]`):

- `Blocked Email Address` gains an `account_id` field (the shared key); `user` records who blocked; uniqueness is now `(account_id, email)`.
- `get_blocked_email_addresses` / `block_email_addresses` / `unblock_email_addresses` are all scoped to `account_id`. Unblock now regenerates the sieve (the bulk delete bypasses the `after_delete` hook) and removes a block regardless of which user added it.
- Added the missing `has_permission_for_user` check to `block_email_address` (the read/unblock endpoints already had it).
- Patch backfills `account_id`, deduplicates `(account_id, email)`, and drops the old per-handle unique index.

Result: blocks/unblocks append/remove on the shared list, and every user with access sees the same per-account list. Frontend is unchanged (still passes the handle; the backend extracts `account_id`).

Note: existing shared-account sieves that are already stale from the old behaviour self-heal on the next block/unblock for that account (the migration can't reach JMAP).

## Backport notes

Cherry-picked cleanly except for `mail/patches.txt`, which on `v0` uses `[pre_model_sync]`/`[post_model_sync]` sections. The `backfill_blocked_email_account_id` patch was placed at the end of `[post_model_sync]`. The unrelated develop-only `configure_inbound_outbound_log` patch line was dropped (not present on `v0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)