### PR TITLE
refactor: share account-scoped data per JMAP account ID

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -135,7 +135,7 @@ const title = computed(() =>
 )
 
 const subtitle = computed(() => {
-	const currentAccount = user.data.accounts.find((a) => a.name === store.account)
+	const currentAccount = user.data.accounts.find((a) => a.id === store.accountId)
 	if (!currentAccount || currentAccount.is_personal) return toTitleCase(user.data.full_name)
 	return currentAccount._name
 })

--- a/frontend/src/components/ComposeMailEditor.vue
+++ b/frontend/src/components/ComposeMailEditor.vue
@@ -278,7 +278,7 @@ const emit = defineEmits(['discardMail', 'reply', 'replyAll', 'forward', 'popOut
 
 const router = useRouter()
 const store = userStore()
-const { account, identities } = store
+const { accountId, identities } = store
 
 const viewSentMessage = (threadID: string) =>
 	router.push({
@@ -328,7 +328,7 @@ const getDefaultFromEmail = () => {
 	const identityEmails = identities.data?.map((i: Identity) => i.email) ?? []
 	// The default outgoing email is now per-account; pick the active account's.
 	const defaultOutgoingEmail = user.data?.accounts?.find(
-		(a) => a.name === account,
+		(a) => a.id === accountId,
 	)?.default_outgoing_email
 
 	return (
@@ -453,7 +453,7 @@ const onMailUpdateSuccess = ({
 const createMail = createResource({
 	url: 'mail.api.mail.create_mail',
 	makeParams: ({ save_as_draft }: { save_as_draft: boolean }) => ({
-		account,
+		account_id: accountId,
 		...mail,
 		...processInlineImages(mail),
 		from_name: getIdentity(mail.from_email!)._name,
@@ -466,7 +466,7 @@ const createMail = createResource({
 const updateDraft = createResource({
 	url: 'mail.api.mail.update_draft_mail',
 	makeParams: ({ submit }: { submit: boolean }) => ({
-		account,
+		account_id: accountId,
 		...mail,
 		...processInlineImages(mail),
 		from_name: getIdentity(mail.from_email!)._name,
@@ -478,7 +478,7 @@ const updateDraft = createResource({
 
 const deleteMail = createResource({
 	url: 'mail.api.mail.delete_mail',
-	makeParams: () => ({ account, id: mail.id }),
+	makeParams: () => ({ account_id: accountId, id: mail.id }),
 	onSuccess: () => {
 		reloadMails()
 		raiseToast(__('Draft discarded.'))

--- a/frontend/src/components/Controls/RecipientInput.vue
+++ b/frontend/src/components/Controls/RecipientInput.vue
@@ -216,7 +216,7 @@ const mailContacts = createResource({
 	url: 'mail.api.contacts.get_contacts',
 	auto: false,
 	makeParams: (text: string) => ({
-		account: store.account,
+		account_id: store.accountId,
 		filter: { operator: 'OR', conditions: [{ text }, { email: text }] },
 	}),
 	transform: (data) =>

--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -79,7 +79,7 @@ const emit = defineEmits(['setFlagged', 'syncUnseen'])
 const { isMobile } = useScreenSize()
 const route = useRoute()
 const router = useRouter()
-const { account, mailboxes, mailboxIds, identities, blockedAddresses } = userStore()
+const { accountId, mailboxes, mailboxIds, identities, blockedAddresses } = userStore()
 const { setUndoAction, undo } = useUndo()
 const { promptBlockSenders, willJunkSenders } = useBlockSender()
 const user = inject('$user')
@@ -248,7 +248,7 @@ const downloadEmail = createResource({
 
 const markAsSpam = createResource({
 	url: 'mail.api.mail.set_mails_spam_status',
-	makeParams: ({ spam }: { spam: boolean }) => ({ account, ids: [mail.id], spam }),
+	makeParams: ({ spam }: { spam: boolean }) => ({ account_id: accountId, ids: [mail.id], spam }),
 })
 
 const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
@@ -283,7 +283,7 @@ const handleMarkAsSpam = (spam: boolean, isUndo = false) => {
 const moveMail = createResource({
 	url: 'mail.api.mail.move_mails',
 	makeParams: (mailbox: string) => ({
-		account,
+		account_id: accountId,
 		ids: [mail.id],
 		mailbox,
 		clear_junk: mail.junk === 1 && mailbox !== mailboxIds.junk,
@@ -325,7 +325,7 @@ const handleDeleteMail = () =>
 
 const setMailsSeen = createResource({
 	url: 'mail.api.mail.set_mails_seen',
-	makeParams: ({ ids }: { ids: string[] }) => ({ account, ids, seen: false }),
+	makeParams: ({ ids }: { ids: string[] }) => ({ account_id: accountId, ids, seen: false }),
 	onSuccess: (ids: string[]) => {
 		raiseToast(__('{0} marked as unread.', [ids.length === 1 ? __('Mail') : __('Mails')]))
 		router.push({
@@ -349,12 +349,12 @@ const handleMarkUnreadFromHere = () => {
 
 const blockEmailAddress = createResource({
 	url: 'mail.api.mail.block_email_address',
-	makeParams: () => ({ account, email: mail.from_email }),
+	makeParams: () => ({ account_id: accountId, email: mail.from_email }),
 })
 
 const unblockEmailAddress = createResource({
 	url: 'mail.api.mail.unblock_email_addresses',
-	makeParams: () => ({ account, emails: [mail.from_email] }),
+	makeParams: () => ({ account_id: accountId, emails: [mail.from_email] }),
 })
 
 const handleBlockAddress = (block: boolean, isUndo = false) => {

--- a/frontend/src/components/MailThread.vue
+++ b/frontend/src/components/MailThread.vue
@@ -499,7 +499,7 @@ const thread = ref<Mail[]>([])
 
 const threadFallback = createResource({
 	url: 'mail.api.mail.get_thread',
-	makeParams: () => ({ account: store.account, thread_id: threadID }),
+	makeParams: () => ({ account_id: store.accountId, thread_id: threadID }),
 	onSuccess: (mails: Mail[]) => {
 		// Thread no longer exists (e.g. deleted) — bail to the mailbox instead of a blank page.
 		if (!mails?.length) {
@@ -687,7 +687,7 @@ onMounted(() => loadThread())
 
 const unblockEmailAddress = createResource({
 	url: 'mail.api.mail.unblock_email_addresses',
-	makeParams: (email) => ({ account: store.account, emails: [email] }),
+	makeParams: (email) => ({ account_id: store.accountId, emails: [email] }),
 	onSuccess: () => {
 		raiseToast(__('Sender unblocked.'))
 		blockedAddresses.reload()

--- a/frontend/src/components/Modals/AddAddressBookContactsModal.vue
+++ b/frontend/src/components/Modals/AddAddressBookContactsModal.vue
@@ -67,7 +67,7 @@ const contacts = createResource({
 	url: 'mail.api.contacts.get_contact_cards',
 	auto: true,
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		filter: { text: search.value },
 		limit: limit.value,
 	}),

--- a/frontend/src/components/Modals/AddAddressBookModal.vue
+++ b/frontend/src/components/Modals/AddAddressBookModal.vue
@@ -50,7 +50,7 @@ const store = userStore()
 const router = useRouter()
 
 const defaultAddressBook = {
-	account: store.account,
+	account_id: store.accountId,
 	name: '',
 	description: '',
 	default: false,

--- a/frontend/src/components/Modals/AddContactModal.vue
+++ b/frontend/src/components/Modals/AddContactModal.vue
@@ -63,7 +63,7 @@ const router = useRouter()
 const defaultAddressBook = store.addressBooks.data.find((ab) => ab.default)?.id
 
 const defaultContact = {
-	account: store.account,
+	account_id: store.accountId,
 	address_book_ids: defaultAddressBook ? [defaultAddressBook] : [],
 	full_name: '',
 	kind: 'Individual',

--- a/frontend/src/components/Modals/ContactsModal.vue
+++ b/frontend/src/components/Modals/ContactsModal.vue
@@ -50,7 +50,7 @@ const show = defineModel<boolean>()
 
 const emit = defineEmits(['insert'])
 
-const { addressBooks, account } = userStore()
+const { addressBooks, accountId } = userStore()
 
 const listView = useTemplateRef('listView')
 
@@ -102,7 +102,7 @@ const contacts = createResource({
 					? filters[0]
 					: { operator: 'AND', conditions: filters }
 
-		return { account, filter, limit: limit.value }
+		return { account_id: accountId, filter, limit: limit.value }
 	},
 	transform: (data) =>
 		data.map((c) => ({ ...c, full_name: c.full_name || extractNameFromEmail(c.email) })),

--- a/frontend/src/components/Modals/DeleteFolderModal.vue
+++ b/frontend/src/components/Modals/DeleteFolderModal.vue
@@ -29,7 +29,7 @@ const store = userStore()
 
 const deleteFolder = createResource({
 	url: 'mail.api.mail.delete_mailbox',
-	makeParams: () => ({ account: store.account, id: mailbox.id, name: mailbox._name }),
+	makeParams: () => ({ account_id: store.accountId, id: mailbox.id, name: mailbox._name }),
 	onSuccess: () => {
 		raiseToast(__('Folder deleted.'))
 		show.value = false

--- a/frontend/src/components/Modals/DeleteSieveScriptModal.vue
+++ b/frontend/src/components/Modals/DeleteSieveScriptModal.vue
@@ -27,7 +27,7 @@ const store = userStore()
 
 const deleteScript = createResource({
 	url: 'mail.api.sieve.delete_sieve_script',
-	makeParams: () => ({ account: store.account, id: script.id }),
+	makeParams: () => ({ account_id: store.accountId, id: script.id }),
 	onSuccess: () => {
 		raiseToast(__('Sieve script deleted.'))
 		store.sieveScripts.reload()

--- a/frontend/src/components/Modals/FolderModal.vue
+++ b/frontend/src/components/Modals/FolderModal.vue
@@ -225,7 +225,7 @@ const isNotDirty = computed(() => {
 const createFolder = createResource({
 	url: 'mail.api.mail.create_mailbox',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		...folder,
 		automation_rules: isDefaultAutomation.value ? null : automationRules,
 	}),
@@ -241,7 +241,7 @@ const createFolder = createResource({
 const updateFolder = createResource({
 	url: 'mail.api.mail.update_mailbox',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		...folder,
 		old_name: original.name,
 		automation_rules: isDefaultAutomation.value ? null : automationRules,
@@ -257,7 +257,7 @@ const updateFolder = createResource({
 
 const createAutomationScript = createResource({
 	url: 'mail.api.sieve.create_automation_script',
-	makeParams: () => ({ account: store.account, active: true }),
+	makeParams: () => ({ account_id: store.accountId, active: true }),
 	onSuccess: () => {
 		raiseToast(__('Folder Automation enabled.'))
 		sieveScripts.reload()

--- a/frontend/src/components/Modals/SearchModal.vue
+++ b/frontend/src/components/Modals/SearchModal.vue
@@ -173,7 +173,7 @@ import type { Recipient } from '@/types'
 
 const show = defineModel<boolean>()
 
-const { account, mailboxes } = userStore()
+const { accountId, mailboxes } = userStore()
 
 const route = useRoute()
 const { isMobile } = useScreenSize()
@@ -224,7 +224,7 @@ const mailboxOptions = computed(() =>
 
 const results = createResource({
 	url: 'mail.api.mail.search_mails',
-	makeParams: () => ({ account, filter: filteredFilter.value }),
+	makeParams: () => ({ account_id: accountId, filter: filteredFilter.value }),
 })
 
 const noOfAttachments = (result) =>

--- a/frontend/src/components/Modals/SieveScriptModal.vue
+++ b/frontend/src/components/Modals/SieveScriptModal.vue
@@ -91,7 +91,7 @@ const isNotDirty = computed(
 
 const createScript = createResource({
 	url: 'mail.api.sieve.create_sieve_script',
-	makeParams: () => ({ account: store.account, ...script }),
+	makeParams: () => ({ account_id: store.accountId, ...script }),
 	onSuccess: () => {
 		raiseToast(__('Sieve script created.'))
 		store.sieveScripts.reload()
@@ -102,7 +102,7 @@ const createScript = createResource({
 
 const updateScript = createResource({
 	url: 'mail.api.sieve.update_sieve_script',
-	makeParams: () => ({ account: store.account, id: selectedScript!.id, ...script }),
+	makeParams: () => ({ account_id: store.accountId, id: selectedScript!.id, ...script }),
 	onSuccess: () => {
 		raiseToast(__('Sieve script updated.'))
 		store.sieveScripts.reload()

--- a/frontend/src/components/QuotaBar.vue
+++ b/frontend/src/components/QuotaBar.vue
@@ -36,12 +36,12 @@ const store = userStore()
 const quota = createResource({
 	url: 'mail.api.account.get_quota',
 	auto: true,
-	makeParams: () => ({ account: store.account }),
-	cache: ['quota', store.account],
+	makeParams: () => ({ account_id: store.accountId }),
+	cache: ['quota', store.accountId],
 })
 
 watch(
-	() => store.account,
+	() => store.accountId,
 	() => quota.reload(),
 )
 

--- a/frontend/src/components/Settings/AccountSettings.vue
+++ b/frontend/src/components/Settings/AccountSettings.vue
@@ -75,11 +75,11 @@ import { userStore } from '@/stores/user'
 import type { Identity } from '@/types'
 
 const user = inject('$user')
-const { account, identities } = userStore()
+const { accountId, identities } = userStore()
 
 // Outgoing settings now live on the active account's Account Settings; backup_email
 // (Recovery) is still per-user on User Settings.
-const activeAccount = user.data?.accounts?.find((a) => a.name === account)
+const activeAccount = user.data?.accounts?.find((a) => a.id === accountId)
 
 const accountSettings = createDocumentResource({
 	doctype: 'Account Settings',

--- a/frontend/src/components/Settings/BlockListSettings.vue
+++ b/frontend/src/components/Settings/BlockListSettings.vue
@@ -69,7 +69,7 @@ const rows = computed(() => blockedAddresses.data.map((address: string) => ({ na
 
 const blockEmailAddress = createResource({
 	url: 'mail.api.mail.block_email_address',
-	makeParams: () => ({ account: store.account, email: email.value }),
+	makeParams: () => ({ account_id: store.accountId, email: email.value }),
 	onSuccess: () => {
 		raiseToast(__('Email address blocked.'))
 		email.value = ''
@@ -80,7 +80,7 @@ const blockEmailAddress = createResource({
 const unblockEmailAddresses = createResource({
 	url: 'mail.api.mail.unblock_email_addresses',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		emails: Array.from(listViewRef.value?.selections),
 	}),
 	onSuccess: () => {

--- a/frontend/src/components/Settings/ExportSettings.vue
+++ b/frontend/src/components/Settings/ExportSettings.vue
@@ -94,7 +94,7 @@ import { Button, ErrorMessage, FormControl, Switch, createResource } from 'frapp
 import { getAttachmentOptions, getReadStatusOptions } from '@/constants'
 import { userStore } from '@/stores/user'
 
-const { account, mailboxes } = userStore()
+const { accountId, mailboxes } = userStore()
 
 const user = inject('$user')
 const socket = inject('$socket')
@@ -138,7 +138,7 @@ const createMailExport = createResource({
 				.map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
 				.filter(([, v]) => Boolean(v)),
 		)
-		return { account, ...mailExport, filter: cleanedFilter }
+		return { account_id: accountId, ...mailExport, filter: cleanedFilter }
 	},
 	onSuccess: () => ongoingExport.reload(),
 })

--- a/frontend/src/components/Settings/ImportSettings.vue
+++ b/frontend/src/components/Settings/ImportSettings.vue
@@ -64,7 +64,7 @@ import { raiseToast } from '@/utils'
 import { useChunkedUpload } from '@/utils/useChunkedUpload'
 import { userStore } from '@/stores/user'
 
-const { account, mailboxes } = userStore()
+const { accountId, mailboxes } = userStore()
 
 const user = inject('$user')
 const socket = inject('$socket')
@@ -126,7 +126,7 @@ watch(
 
 const createMailImport = createResource({
 	url: 'mail.api.account.create_mail_import',
-	makeParams: () => ({ account, ...mailImport }),
+	makeParams: () => ({ account_id: accountId, ...mailImport }),
 	onSuccess: () => ongoingImport.reload(),
 })
 

--- a/frontend/src/components/Settings/VacationResponseSettings.vue
+++ b/frontend/src/components/Settings/VacationResponseSettings.vue
@@ -85,7 +85,7 @@ const original = reactive({})
 
 const vacationResponse = createResource({
 	url: 'mail.client.doctype.vacation_response.vacation_response.get_vacation_response',
-	makeParams: () => ({ account: store.account }),
+	makeParams: () => ({ account_id: store.accountId }),
 	auto: true,
 	transform: (doc: VacationResponse) => {
 		doc['enabled'] = !!doc['enabled']
@@ -99,7 +99,7 @@ const vacationResponse = createResource({
 const updateVacationResponse = createResource({
 	url: 'mail.client.doctype.vacation_response.vacation_response.update_vacation_response',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		enabled: vacationResponse.data.enabled,
 		from_date: vacationResponse.data.from_date,
 		to_date: vacationResponse.data.to_date,

--- a/frontend/src/pages/AddressBookView.vue
+++ b/frontend/src/pages/AddressBookView.vue
@@ -133,7 +133,7 @@ const showRemoveContacts = ref(false)
 
 const addressBook = createDocumentResource({
 	doctype: 'Address Book',
-	name: `${store.account}|${addressBookName}`,
+	name: `${store.user}:${store.accountId}|${addressBookName}`,
 	onError: () => router.replace({ name: 'AddressBooks', params: { accountId } }),
 	setValue: {
 		onSuccess: () => {
@@ -154,7 +154,7 @@ const contacts = createResource({
 	url: 'mail.api.contacts.get_contact_cards',
 	auto: true,
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		filter: { inAddressBook: addressBookName, text: search.value },
 		limit: limit.value,
 	}),
@@ -175,7 +175,7 @@ const contacts = createResource({
 const totalContacts = createResource({
 	url: 'mail.api.contacts.get_address_book_contact_count',
 	auto: true,
-	makeParams: () => ({ account: store.account, address_book: addressBookName }),
+	makeParams: () => ({ account_id: store.accountId, address_book: addressBookName }),
 	cache: ['addressBookContactCount', addressBookName],
 })
 
@@ -204,7 +204,7 @@ const breadcrumbs = computed(() => [
 
 const deleteAddressBook = createResource({
 	url: 'mail.client.doctype.address_book.address_book.delete_address_books',
-	makeParams: () => ({ account: store.account, ids: [addressBookName] }),
+	makeParams: () => ({ account_id: store.accountId, ids: [addressBookName] }),
 	onSuccess: () => {
 		showDeleteAddressBook.value = false
 		raiseToast(__('Address book deleted.'))
@@ -221,7 +221,7 @@ const listView = useTemplateRef('listView')
 
 const addContacts = createResource({
 	url: 'mail.client.doctype.contact_card.contact_card.contact_card_add_to_address_book',
-	makeParams: (ids) => ({ account: store.account, ids, address_book_id: addressBookName }),
+	makeParams: (ids) => ({ account_id: store.accountId, ids, address_book_id: addressBookName }),
 	onSuccess: () => {
 		raiseToast(__('Contacts added.'))
 		contacts.reload()
@@ -233,7 +233,7 @@ const addContacts = createResource({
 const removeContacts = createResource({
 	url: 'mail.client.doctype.contact_card.contact_card.contact_card_remove_from_address_book',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		ids: Array.from(listView.value?.selections),
 		address_book_id: addressBookName,
 	}),

--- a/frontend/src/pages/ContactView.vue
+++ b/frontend/src/pages/ContactView.vue
@@ -259,7 +259,7 @@ const store = userStore()
 
 const contact = createDocumentResource({
 	doctype: 'Contact Card',
-	name: `${store.account}|${contactName}`,
+	name: `${store.user}:${store.accountId}|${contactName}`,
 	onError: () => router.replace({ name: 'Contacts', params: { accountId } }),
 	setValue: {
 		onSuccess: () => raiseToast(__('Contact updated.')),

--- a/frontend/src/pages/ContactsView.vue
+++ b/frontend/src/pages/ContactsView.vue
@@ -77,7 +77,7 @@ const contacts = createResource({
 	url: 'mail.api.contacts.get_contact_cards',
 	auto: true,
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		filter: { text: search.value },
 		limit: limit.value,
 	}),
@@ -95,7 +95,7 @@ const contacts = createResource({
 })
 
 watch(
-	() => store.account,
+	() => store.accountId,
 	() => contacts.reload(),
 )
 
@@ -115,7 +115,10 @@ const loadMoreContacts = useDebounceFn((e) => {
 
 const deleteContacts = createResource({
 	url: 'mail.client.doctype.contact_card.contact_card.delete_contact_cards',
-	makeParams: () => ({ account: store.account, ids: Array.from(listView.value?.selections) }),
+	makeParams: () => ({
+		account_id: store.accountId,
+		ids: Array.from(listView.value?.selections),
+	}),
 	onSuccess: () => {
 		contacts.reload()
 		showDeleteContacts.value = false

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -853,7 +853,7 @@ const syncDisplayedPage = () => {
 const searchResults = createResource({
 	url: 'mail.api.mail.search_mails',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		filter: route.query,
 		limit: PAGE_LENGTH,
 		start: page.value * PAGE_LENGTH,
@@ -890,7 +890,7 @@ const isMailboxLoaded = ref(false)
 const threads = createResource({
 	url: 'mail.api.mail.get_threads',
 	makeParams: () => ({
-		account: store.account,
+		account_id: store.accountId,
 		mailbox,
 		limit: PAGE_LENGTH + 1,
 		start: page.value * PAGE_LENGTH,
@@ -1175,7 +1175,7 @@ const showEmptyMailbox = ref(false)
 
 const emptyMailbox = createResource({
 	url: 'mail.api.mail.empty_user_mailbox',
-	makeParams: () => ({ account: store.account, mailbox }),
+	makeParams: () => ({ account_id: store.accountId, mailbox }),
 	onSuccess: () => {
 		threadsResource.value.data = []
 		raiseToast(__('{0} emptied.', [mailboxName.value]))

--- a/frontend/src/resources.ts
+++ b/frontend/src/resources.ts
@@ -9,7 +9,7 @@ const store = userStore()
 
 export const fetchAttachment = createResource({
 	url: 'mail.api.mail.fetch_attachment',
-	makeParams: (blobID: string) => ({ account: store.account, blob_id: blobID }),
+	makeParams: (blobID: string) => ({ account_id: store.accountId, blob_id: blobID }),
 	onError: (error) => raiseToast(error.message, 'error'),
 	cache: ['attachment'],
 })
@@ -24,7 +24,7 @@ export const getAttachmentUrl = async (blobID: string, type?: string) => {
 export const fetchAttachmentsAsZip = createResource({
 	url: 'mail.api.mail.fetch_attachments_as_zip',
 	makeParams: (attachments: Attachment[]) => ({
-		account: store.account,
+		account_id: store.accountId,
 		attachments: JSON.stringify(
 			attachments.map((a) => ({ blob_id: a.blob_id, filename: a.filename })),
 		),

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -53,13 +53,13 @@ export const userStore = defineStore('mail-user', () => {
 		auto: true,
 	})
 
-	const account = computed(
-		() => userResource.data?.accounts?.find((a) => a.id === accountId.value)?.name,
-	)
+	// The logged-in user (the user component of every account handle is always the session user).
+	// Exposed so callers can rebuild a `user:account_id` virtual-doctype document name when needed.
+	const user = computed(() => userResource.data?.name)
 
 	const mailboxes = createResource({
 		url: 'mail.api.mail.get_mailboxes',
-		makeParams: () => ({ account: account.value }),
+		makeParams: () => ({ account_id: accountId.value }),
 		cache: ['mailboxes', accountId.value],
 	})
 
@@ -81,25 +81,25 @@ export const userStore = defineStore('mail-user', () => {
 
 	const addressBooks = createResource({
 		url: 'mail.api.contacts.get_address_books',
-		makeParams: () => ({ account: account.value }),
+		makeParams: () => ({ account_id: accountId.value }),
 		cache: ['addressBooks', accountId.value],
 	})
 
 	const identities = createResource({
 		url: 'mail.api.account.get_identities',
-		makeParams: () => ({ account: account.value }),
+		makeParams: () => ({ account_id: accountId.value }),
 		cache: ['identities', accountId.value],
 	})
 
 	const blockedAddresses = createResource({
 		url: 'mail.api.mail.get_blocked_addresses',
-		makeParams: () => ({ account: account.value }),
+		makeParams: () => ({ account_id: accountId.value }),
 		cache: ['blockedAddresses', accountId.value],
 	})
 
 	const sieveScripts = createResource({
 		url: 'mail.api.sieve.get_sieve_scripts',
-		makeParams: () => ({ account: account.value }),
+		makeParams: () => ({ account_id: accountId.value }),
 		cache: ['sieveScripts', accountId.value],
 	})
 
@@ -122,7 +122,7 @@ export const userStore = defineStore('mail-user', () => {
 
 	return {
 		accountId,
-		account,
+		user,
 		resolveAccount,
 		userResource,
 		mailboxes,

--- a/frontend/src/utils/composables.ts
+++ b/frontend/src/utils/composables.ts
@@ -142,23 +142,35 @@ export const useBlockSender = () => {
 
 	const blockResource = createResource({
 		url: 'mail.api.mail.block_email_addresses',
-		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		makeParams: ({ emails }: { emails: string[] }) => ({
+			account_id: store.accountId,
+			emails,
+		}),
 		onSuccess: () => blockedAddresses.reload(),
 	})
 
 	const junkResource = createResource({
 		url: 'mail.api.mail.junk_senders',
-		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		makeParams: ({ emails }: { emails: string[] }) => ({
+			account_id: store.accountId,
+			emails,
+		}),
 	})
 
 	const unjunkResource = createResource({
 		url: 'mail.api.mail.unjunk_senders',
-		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		makeParams: ({ emails }: { emails: string[] }) => ({
+			account_id: store.accountId,
+			emails,
+		}),
 	})
 
 	const unblockResource = createResource({
 		url: 'mail.api.mail.unblock_email_addresses',
-		makeParams: ({ emails }: { emails: string[] }) => ({ account: store.account, emails }),
+		makeParams: ({ emails }: { emails: string[] }) => ({
+			account_id: store.accountId,
+			emails,
+		}),
 		onSuccess: () => blockedAddresses.reload(),
 	})
 

--- a/frontend/src/utils/useThreadActions.ts
+++ b/frontend/src/utils/useThreadActions.ts
@@ -82,7 +82,7 @@ export function useThreadActions(deps: {
 	const setSeen = createResource({
 		url: 'mail.api.mail.set_mails_seen',
 		makeParams: ({ ids, seen }: { ids: string[]; seen: boolean }) => ({
-			account: store.account,
+			account_id: store.accountId,
 			ids,
 			seen,
 		}),
@@ -92,7 +92,7 @@ export function useThreadActions(deps: {
 	const setFlagged = createResource({
 		url: 'mail.api.mail.set_flagged',
 		makeParams: ({ ids, flagged }: { ids: string[]; flagged: boolean }) => ({
-			account: store.account,
+			account_id: store.accountId,
 			ids,
 			flagged,
 		}),
@@ -116,7 +116,7 @@ export function useThreadActions(deps: {
 			ids: string[]
 			mailbox: string
 			clear_junk?: boolean
-		}) => ({ account: store.account, ids, mailbox: target, clear_junk }),
+		}) => ({ account_id: store.accountId, ids, mailbox: target, clear_junk }),
 	})
 
 	const moveToOptions = computed(() =>
@@ -132,7 +132,7 @@ export function useThreadActions(deps: {
 	const addMails = createResource({
 		url: 'mail.api.mail.add_mails_to_mailbox',
 		makeParams: ({ ids, mailbox_id }: { ids: string[]; mailbox_id: string }) => ({
-			account: store.account,
+			account_id: store.accountId,
 			ids,
 			mailbox_id,
 		}),
@@ -141,7 +141,7 @@ export function useThreadActions(deps: {
 	const removeMails = createResource({
 		url: 'mail.api.mail.remove_mails_from_mailbox',
 		makeParams: ({ ids, mailbox_id }: { ids: string[]; mailbox_id: string }) => ({
-			account: store.account,
+			account_id: store.accountId,
 			ids,
 			mailbox_id,
 		}),
@@ -151,7 +151,10 @@ export function useThreadActions(deps: {
 	type MailSnapshot = { id: string; mailbox_ids: string[]; junk: 0 | 1 }
 	const setMailsMailboxes = createResource({
 		url: 'mail.api.mail.set_mails_mailboxes',
-		makeParams: ({ mails }: { mails: MailSnapshot[] }) => ({ account: store.account, mails }),
+		makeParams: ({ mails }: { mails: MailSnapshot[] }) => ({
+			account_id: store.accountId,
+			mails,
+		}),
 	})
 
 	const showAddTo = computed(
@@ -268,7 +271,7 @@ export function useThreadActions(deps: {
 	const setMailsSpam = createResource({
 		url: 'mail.api.mail.set_mails_spam_status',
 		makeParams: ({ ids, spam }: { ids: string[]; spam: boolean }) => ({
-			account: store.account,
+			account_id: store.accountId,
 			ids,
 			spam,
 		}),

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -14,7 +14,13 @@ from mail.server.doctype.mail_account_request.mail_account_request import create
 from mail.utils import convert_html_to_text, user_context
 from mail.utils.cache import get_signup_domains
 from mail.utils.rate_limiter import dynamic_rate_limit
-from mail.utils.user import has_user_settings, is_jmap_configured, is_mail_admin, is_system_manager
+from mail.utils.user import (
+	get_session_account,
+	has_user_settings,
+	is_jmap_configured,
+	is_mail_admin,
+	is_system_manager,
+)
 from mail.utils.validation import is_email_assigned
 
 
@@ -157,19 +163,20 @@ def get_user_info() -> dict | None:
 	data.is_jmap_configured = is_jmap_configured(user)
 	data.accounts = frappe.get_all("User Account", filters={"user": user})
 
-	# Outgoing settings now live per-account on Account Settings; attach each account's
-	# default outgoing email (and its settings doc) so the compose UI can pick the
-	# default sender for the active account.
+	# Outgoing settings now live per-account on Account Settings (shared across the users
+	# of an account and named by the account ID); attach each account's default outgoing
+	# email (and its settings doc) so the compose UI can pick the default sender.
+	account_ids = [acc["id"] for acc in data.accounts]
 	settings_by_account = {
-		s["account"]: s
+		s["name"]: s
 		for s in frappe.get_all(
 			"Account Settings",
-			filters={"user": user},
-			fields=["name", "account", "default_outgoing_email", "on_mark_as_junk"],
+			filters={"name": ["in", account_ids]},
+			fields=["name", "default_outgoing_email", "on_mark_as_junk"],
 		)
 	}
 	for acc in data.accounts:
-		settings = settings_by_account.get(acc["name"])
+		settings = settings_by_account.get(acc["id"])
 		acc["account_settings"] = settings["name"] if settings else None
 		acc["default_outgoing_email"] = settings["default_outgoing_email"] if settings else None
 		acc["on_mark_as_junk"] = settings["on_mark_as_junk"] if settings else "Junk Sender's Mail"
@@ -244,7 +251,7 @@ def get_user_for_reset_password_key(key: str) -> str:
 
 @frappe.whitelist()
 def create_mail_import(
-	account: str,
+	account_id: str,
 	format: Literal["eml", "jmap", "mbox", "maildir", "maildir-nested"],
 	file: str,
 	mailbox: str | None = None,
@@ -254,7 +261,7 @@ def create_mail_import(
 
 	doc = frappe.new_doc("Mail Exchange")
 	doc.user = frappe.session.user
-	doc.account = account
+	doc.account_id = account_id
 	doc.operation = "Import"
 	doc.import_format = format
 	doc.import_file = file
@@ -266,7 +273,7 @@ def create_mail_import(
 
 @frappe.whitelist()
 def create_mail_export(
-	account: str,
+	account_id: str,
 	format: Literal["jmap", "mbox", "maildir", "maildir-nested"],
 	archive_type: Literal[".zip", ".tgz", ".tar.gz"],
 	sort: Literal["Received At (ASC)", "Received At (DESC)"],
@@ -277,7 +284,7 @@ def create_mail_export(
 
 	doc = frappe.new_doc("Mail Exchange")
 	doc.user = frappe.session.user
-	doc.account = account
+	doc.account_id = account_id
 	doc.operation = "Export"
 	doc.export_format = format
 	doc.export_archive_type = archive_type
@@ -297,8 +304,10 @@ def is_push_notification_relay_enabled() -> bool:
 
 
 @frappe.whitelist()
-def get_quota(account: str) -> dict:
+def get_quota(account_id: str) -> dict:
 	"""Return quota usage for the user"""
+
+	account = get_session_account(account_id)
 
 	result = {
 		"disk_quota": 0,
@@ -321,8 +330,10 @@ def get_quota(account: str) -> dict:
 
 
 @frappe.whitelist()
-def get_identities(account: str) -> list[dict]:
+def get_identities(account_id: str) -> list[dict]:
 	"""Return the email identities for the user"""
+
+	account = get_session_account(account_id)
 
 	return fetch_identities(account, page=1, limit=100)
 

--- a/mail/api/contacts.py
+++ b/mail/api/contacts.py
@@ -7,11 +7,14 @@ from mail.api.utils import get_avatar_url
 from mail.client.doctype.address_book.address_book import fetch_address_books
 from mail.client.doctype.contact_card.contact_card import bulk_add_contact_cards, fetch_contact_cards
 from mail.jmap import get_default_address_book_id
+from mail.utils.user import get_session_account
 
 
 @frappe.whitelist()
-def get_address_books(account: str) -> list[dict]:
+def get_address_books(account_id: str) -> list[dict]:
 	"""Returns the address books for the given account."""
+
+	account = get_session_account(account_id)
 
 	if not (address_books := fetch_address_books(account, 1, 50)):
 		return []
@@ -21,8 +24,10 @@ def get_address_books(account: str) -> list[dict]:
 
 
 @frappe.whitelist()
-def get_contact_cards(account: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
+def get_contact_cards(account_id: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
 	"""Returns the contact cards for the given account."""
+
+	account = get_session_account(account_id)
 
 	if filter:
 		filter = {k: v for k, v in filter.items() if v}
@@ -35,8 +40,10 @@ def get_contact_cards(account: str, filter: dict | None = None, limit: int = 50)
 
 
 @frappe.whitelist()
-def get_contacts(account: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
+def get_contacts(account_id: str, filter: dict | None = None, limit: int = 50) -> list[dict]:
 	"""Returns the emails contacts for the given account."""
+
+	account = get_session_account(account_id)
 
 	contacts = []
 	contact_cards = get_contact_cards(account, filter, limit)
@@ -69,8 +76,10 @@ def enrich_contacts_with_user_images(contacts: list[dict]) -> list[dict]:
 
 
 @frappe.whitelist()
-def get_address_book_contact_count(account: str, address_book: str) -> int:
+def get_address_book_contact_count(account_id: str, address_book: str) -> int:
 	"""Returns the total no. of contacts for the given address book."""
+
+	account = get_session_account(account_id)
 
 	return fetch_contact_cards(account, {"inAddressBook": address_book}, 0, 1)[1]
 
@@ -78,8 +87,10 @@ def get_address_book_contact_count(account: str, address_book: str) -> int:
 def create_contacts_if_not_exists(account: str, recipients: list[dict] | str) -> None:
 	"""Creates contacts for the given recipients if they do not exist."""
 
+	from mail.jmap import parse_account
+
 	if not frappe.db.get_value(
-		"Account Settings", {"account": account}, "create_contacts_after_email_submit"
+		"Account Settings", parse_account(account)[1], "create_contacts_after_email_submit"
 	):
 		return
 
@@ -97,7 +108,7 @@ def create_contacts_if_not_exists(account: str, recipients: list[dict] | str) ->
 	for email in new_emails:
 		contact_card = {
 			"account": account,
-			"address_book_ids": [get_default_address_book_id(account)],
+			"address_book_ids": [get_default_address_book_id(*parse_account(account))],
 			"full_name": extract_name_from_email(email),
 			"kind": "Individual",
 			"emails": [{"address": email, "type": "Personal"}],

--- a/mail/api/inbound.py
+++ b/mail/api/inbound.py
@@ -9,7 +9,7 @@ from frappe.utils import cint, convert_utc_to_system_timezone, create_batch, now
 from mail.api.auth import validate_user
 from mail.client.doctype.mail_message.mail_message import fetch_blobs, fetch_messages
 from mail.client.doctype.mail_sync_history.mail_sync_history import get_mail_sync_history
-from mail.jmap import get_mailbox_id_by_role
+from mail.jmap import get_mailbox_id_by_role, parse_account
 from mail.utils import get_mail_config
 from mail.utils.dt import convert_to_utc
 from mail.utils.logger import get_inbound_logger
@@ -158,7 +158,7 @@ def get_mails(
 ) -> dict[str, list[dict] | str]:
 	"""Returns the emails for the given mailbox."""
 
-	mailbox_id = get_mailbox_id_by_role(account, mailbox, raise_exception=True)
+	mailbox_id = get_mailbox_id_by_role(*parse_account(account), mailbox, raise_exception=True)
 
 	filter = {"inMailbox": mailbox_id}
 	if last_received_at:

--- a/mail/api/jmap.py
+++ b/mail/api/jmap.py
@@ -92,11 +92,11 @@ def push_notification() -> dict:
 
 					elif entity == "Mailbox":
 						logger.debug("invalidating-mailbox-cache", entity=entity, state=state)
-						invalidate_jmap_mailboxes_cache(account)
+						invalidate_jmap_mailboxes_cache(account_id)
 
 					elif entity == "Identity":
 						logger.debug("invalidating-identity-cache", entity=entity, state=state)
-						invalidate_jmap_identities_cache(account)
+						invalidate_jmap_identities_cache(account_id)
 
 					else:
 						logger.warning("unhandled-state-change-entity", entity=entity)

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -41,15 +41,17 @@ from mail.client.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes
 from mail.client.doctype.mailbox_settings.mailbox_settings import set_mailbox_settings
 from mail.jmap import get_email_service, get_mailbox_id_by_role, parse_account
 from mail.utils import convert_html_to_text, get_mail_config
-from mail.utils.user import get_account_emails, is_jmap_configured
+from mail.utils.user import get_account_emails, get_session_account, is_jmap_configured
 from mail.utils.validation import has_permission_for_user
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
 
 
 @frappe.whitelist()
-def get_mailboxes(account: str) -> list[dict]:
+def get_mailboxes(account_id: str) -> list[dict]:
 	"""Serializes and returns the user's mailboxes."""
+
+	account = get_session_account(account_id)
 
 	user = frappe.session.user
 	if not is_jmap_configured(user):
@@ -63,7 +65,10 @@ def get_mailboxes(account: str) -> list[dict]:
 
 	mailbox_settings = frappe.db.get_all(
 		"Mailbox Settings",
-		filters={"account": account, "mailbox_id": ["in", [m["id"] for m in mailboxes]]},
+		filters={
+			"account_id": parse_account(account)[1],
+			"mailbox_id": ["in", [m["id"] for m in mailboxes]],
+		},
 		fields=["mailbox_id", "icon", "color", "disable_push_notification"],
 	)
 
@@ -145,15 +150,23 @@ def add_user_images_to_emails(account: str, mails: list[dict], is_thread: bool =
 
 
 @frappe.whitelist()
-def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_by: str | None = None) -> list:
+def get_threads(
+	account_id: str, mailbox: str, limit: int, start: int = 0, filter_by: str | None = None
+) -> list:
 	"""Returns a page of threads from the selected mailbox for the account."""
+
+	account = get_session_account(account_id)
 
 	if mailbox == "starred":
 		conditions = [
 			{
 				"inMailboxOtherThan": [
-					get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True),
-					get_mailbox_id_by_role(account, "trash", create_if_not_exists=True, raise_exception=True),
+					get_mailbox_id_by_role(
+						*parse_account(account), "junk", create_if_not_exists=True, raise_exception=True
+					),
+					get_mailbox_id_by_role(
+						*parse_account(account), "trash", create_if_not_exists=True, raise_exception=True
+					),
 				]
 			},
 			{"someInThreadHaveKeyword": "$flagged"},
@@ -176,7 +189,7 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 
 	conversations = fetch_threads(account, filter, start, limit)
 
-	sent_mailbox = get_mailbox_id_by_role(account, "sent")
+	sent_mailbox = get_mailbox_id_by_role(*parse_account(account), "sent")
 
 	threads = []
 	for conversation in conversations.values():
@@ -202,17 +215,21 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
 
 
 @frappe.whitelist()
-def get_thread(account: str, thread_id: str) -> list[dict]:
+def get_thread(account_id: str, thread_id: str) -> list[dict]:
 	"""Returns the full list of messages in a thread, for threads not present in the mailbox list
 	(e.g. search results or a thread on another page)."""
+
+	account = get_session_account(account_id)
 
 	mails = [serialize_mail(m) for m in fetch_thread(account, thread_id)]
 	return add_user_images_to_emails(account, mails, is_thread=True)
 
 
 @frappe.whitelist()
-def get_attachment(account: str, blob_id: str, filename: str | None = None) -> None:
+def get_attachment(account_id: str, blob_id: str, filename: str | None = None) -> None:
 	"""Fetches and returns the attachment."""
+
+	account = get_session_account(account_id)
 
 	if not blob_id:
 		frappe.throw(_("Blob ID is required."))
@@ -239,7 +256,6 @@ def serialize_thread(messages: list[dict], thread_messages: list[dict], latest: 
 
 	thread_fields = [
 		"name",
-		"account",
 		"id",
 		"thread_id",
 		"mailboxes",
@@ -307,15 +323,19 @@ def serialize_attachments(attachments: list[dict]) -> list[dict]:
 
 
 @frappe.whitelist()
-def fetch_attachment(account: str, blob_id: str) -> bytes:
+def fetch_attachment(account_id: str, blob_id: str) -> bytes:
 	"""Returns the content of an attachment."""
+
+	account = get_session_account(account_id)
 
 	return fetch_blob(account, blob_id)
 
 
 @frappe.whitelist()
-def fetch_attachments_as_zip(account: str, attachments: list[dict] | str) -> bytes:
+def fetch_attachments_as_zip(account_id: str, attachments: list[dict] | str) -> bytes:
 	"""Returns the provided attachments bundled into a ZIP archive."""
+
+	account = get_session_account(account_id)
 
 	if isinstance(attachments, str):
 		attachments = frappe.parse_json(attachments)
@@ -368,7 +388,7 @@ def fetch_mail_as_eml(name: str) -> bytes:
 
 @frappe.whitelist()
 def create_mail(
-	account: str,
+	account_id: str,
 	from_email: str,
 	to: list[dict],
 	cc: list[dict],
@@ -383,6 +403,8 @@ def create_mail(
 	save_as_draft: bool = False,
 ) -> dict:
 	"""Creates new mail queue."""
+
+	account = get_session_account(account_id)
 
 	doc_attachments = []
 	for d in attachments:
@@ -428,7 +450,7 @@ def create_mail(
 
 @frappe.whitelist()
 def update_draft_mail(
-	account: str,
+	account_id: str,
 	id: str,
 	from_email: str,
 	to: list[dict],
@@ -441,6 +463,8 @@ def update_draft_mail(
 	submit: bool = False,
 ) -> dict:
 	"""Creates new mail queue from existing draft message."""
+
+	account = get_session_account(account_id)
 
 	doc = frappe.get_doc("Mail Message", f"{account}|{id}")
 	doc.check_permission(permtype="write")
@@ -505,8 +529,10 @@ def update_draft_mail(
 
 
 @frappe.whitelist()
-def delete_mail(account: str, id: str) -> None:
+def delete_mail(account_id: str, id: str) -> None:
 	"""Deletes the given mail."""
+
+	account = get_session_account(account_id)
 
 	delete_messages(account, [id])
 
@@ -554,8 +580,10 @@ def get_mime_message(name: str) -> dict:
 
 
 @frappe.whitelist()
-def set_flagged(account: str, ids: list[str], flagged: bool) -> dict:
+def set_flagged(account_id: str, ids: list[str], flagged: bool) -> dict:
 	"""Sets flagged for mails."""
+
+	account = get_session_account(account_id)
 
 	set_flagged_status(account, ids, flagged)
 
@@ -563,8 +591,10 @@ def set_flagged(account: str, ids: list[str], flagged: bool) -> dict:
 
 
 @frappe.whitelist()
-def set_mails_seen(account: str, ids: list[str], seen: bool) -> list[str]:
+def set_mails_seen(account_id: str, ids: list[str], seen: bool) -> list[str]:
 	"""Sets seen status for the given mails."""
+
+	account = get_session_account(account_id)
 
 	set_seen_status(account, ids, seen)
 
@@ -572,8 +602,10 @@ def set_mails_seen(account: str, ids: list[str], seen: bool) -> list[str]:
 
 
 @frappe.whitelist()
-def move_mails(account: str, ids: list[str], mailbox: str, clear_junk: bool = False) -> None:
+def move_mails(account_id: str, ids: list[str], mailbox: str, clear_junk: bool = False) -> None:
 	"""Sets mailbox for mails."""
+
+	account = get_session_account(account_id)
 
 	if clear_junk:
 		set_spam_status(account, ids, spam=False)
@@ -581,29 +613,37 @@ def move_mails(account: str, ids: list[str], mailbox: str, clear_junk: bool = Fa
 
 
 @frappe.whitelist()
-def add_mails_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
+def add_mails_to_mailbox(account_id: str, ids: list[str], mailbox_id: str) -> None:
 	"""Adds mails to a mailbox without removing them from their existing mailboxes."""
+
+	account = get_session_account(account_id)
 
 	add_messages_to_mailbox(account, ids, mailbox_id)
 
 
 @frappe.whitelist()
-def remove_mails_from_mailbox(account: str, ids: list[str], mailbox_id: str) -> None:
+def remove_mails_from_mailbox(account_id: str, ids: list[str], mailbox_id: str) -> None:
 	"""Removes mails from a mailbox without deleting them."""
+
+	account = get_session_account(account_id)
 
 	remove_messages_from_mailbox(account, ids, mailbox_id)
 
 
 @frappe.whitelist()
-def set_mails_mailboxes(account: str, mails: list[dict]) -> None:
+def set_mails_mailboxes(account_id: str, mails: list[dict]) -> None:
 	"""Restores each mail's exact mailbox membership and junk status (used to undo a move)."""
+
+	account = get_session_account(account_id)
 
 	set_messages_mailboxes(account, mails)
 
 
 @frappe.whitelist()
-def set_mails_spam_status(account: str, ids: list[str], spam: bool) -> list[str]:
+def set_mails_spam_status(account_id: str, ids: list[str], spam: bool) -> list[str]:
 	"""Sets spam status of the given mails."""
+
+	account = get_session_account(account_id)
 
 	set_spam_status(account, ids, spam)
 
@@ -611,17 +651,21 @@ def set_mails_spam_status(account: str, ids: list[str], spam: bool) -> list[str]
 
 
 @frappe.whitelist()
-def empty_user_mailbox(account: str, mailbox: str) -> None:
+def empty_user_mailbox(account_id: str, mailbox: str) -> None:
 	"""Empties the given mailbox."""
+
+	account = get_session_account(account_id)
 
 	empty_mailbox(account, mailbox)
 
 
 @frappe.whitelist()
 def search_mails(
-	account: str, filter: dict | None = None, limit: int = 5, start: int = 0
+	account_id: str, filter: dict | None = None, limit: int = 5, start: int = 0
 ) -> tuple[list[dict], int]:
 	"""Returns search results for the given query."""
+
+	account = get_session_account(account_id)
 
 	if not filter:
 		return ([], 0)
@@ -722,13 +766,13 @@ def get_email_suggestions(account: str, query: str, limit: int = 5) -> list[str]
 		return []
 
 	has_permission_for_user(frappe.session.user)
-	service = get_email_service(account)
+	service = get_email_service(*parse_account(account))
 	return service.get_email_suggestions(query, limit)
 
 
 @frappe.whitelist()
 def create_mailbox(
-	account: str,
+	account_id: str,
 	name: str,
 	parent: str | None = None,
 	icon: str | None = None,
@@ -737,6 +781,8 @@ def create_mailbox(
 	automation_rules: dict | None = None,
 ) -> str:
 	"""Creates a new mailbox and initializes its settings for the given account."""
+
+	account = get_session_account(account_id)
 
 	mailbox_id = add_mailbox(account, name, None, parent)
 
@@ -753,7 +799,7 @@ def create_mailbox(
 
 @frappe.whitelist()
 def update_mailbox(
-	account: str,
+	account_id: str,
 	id: str,
 	name: str,
 	old_name: str,
@@ -765,6 +811,8 @@ def update_mailbox(
 	automation_rules: dict | None = None,
 ) -> None:
 	"""Updates Mailbox Settings for the given mailbox ID."""
+
+	account = get_session_account(account_id)
 
 	set_mailbox_settings(
 		account,
@@ -781,39 +829,51 @@ def update_mailbox(
 
 
 @frappe.whitelist()
-def delete_mailbox(account: str, id: str, name: str) -> None:
+def delete_mailbox(account_id: str, id: str, name: str) -> None:
 	"""Deletes the mailbox with the given mailbox ID, followed by its settings."""
+
+	account = get_session_account(account_id)
 
 	delete_mailboxes(account, [id])
 	update_sieve_script_for_mailbox(account, name)
-	frappe.db.delete("Mailbox Settings", {"account": account, "mailbox_id": id})
+	frappe.db.delete("Mailbox Settings", {"account_id": parse_account(account)[1], "mailbox_id": id})
 
 
 @frappe.whitelist()
-def get_blocked_addresses(account: str) -> list[dict]:
+def get_blocked_addresses(account_id: str) -> list[dict]:
 	"""Returns the list of blocked email addresses for the given account."""
+
+	account = get_session_account(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 	return get_blocked_email_addresses(account)
 
 
 @frappe.whitelist()
-def block_email_address(account: str, email: str) -> dict:
+def block_email_address(account_id: str, email: str) -> dict:
 	"""Blocks an email address for the given account."""
 
+	account = get_session_account(account_id)
+
 	has_permission_for_user(parse_account(account)[0])
-	doc = frappe.get_doc({"doctype": "Blocked Email Address", "account": account, "email": email})
+	doc = frappe.get_doc(
+		{"doctype": "Blocked Email Address", "account_id": parse_account(account)[1], "email": email}
+	)
+	# Pass the full handle so after_insert can reach JMAP to regenerate the sieve block.
+	doc.flags.account = account
 	doc.insert()
 
 
 @frappe.whitelist()
-def block_email_addresses(account: str, emails: list[str]) -> None:
+def block_email_addresses(account_id: str, emails: list[str]) -> None:
 	"""Blocks multiple email addresses for the given account in a single request.
 
 	Inserts in one batched query via `bulk_insert` (no per-document hooks) instead of looping over
 	`doc.insert()`. Addresses already blocked are skipped, `ignore_duplicates` guards against races,
 	and the sieve script is regenerated once at the end since it is rebuilt from the full list.
 	"""
+
+	account = get_session_account(account_id)
 
 	user, account_id = parse_account(account)
 	has_permission_for_user(user)
@@ -823,14 +883,11 @@ def block_email_addresses(account: str, emails: list[str]) -> None:
 	for email in dict.fromkeys(emails):  # de-duplicate while preserving order
 		if not email or email in already_blocked:
 			continue
-		# bulk_insert bypasses before_insert, so set account_id (the shared key) explicitly.
 		doc = frappe.get_doc(
 			{
 				"doctype": "Blocked Email Address",
-				"account": account,
 				"account_id": account_id,
 				"email": email,
-				"user": user,
 			}
 		)
 		doc.set_new_name()
@@ -846,7 +903,7 @@ def block_email_addresses(account: str, emails: list[str]) -> None:
 
 
 @frappe.whitelist()
-def junk_senders(account: str, emails: list[str]) -> None:
+def junk_senders(account_id: str, emails: list[str]) -> None:
 	"""Routes future mail from the given senders into Junk for the account, in a single request.
 
 	The soft counterpart to `block_email_addresses`: instead of discarding, the generated sieve block
@@ -854,7 +911,9 @@ def junk_senders(account: str, emails: list[str]) -> None:
 	script is regenerated once at the end.
 	"""
 
-	user = parse_account(account)[0]
+	account = get_session_account(account_id)
+
+	user, account_id = parse_account(account)
 	has_permission_for_user(user)
 
 	already_junked = set(get_junk_email_addresses(account))
@@ -862,9 +921,7 @@ def junk_senders(account: str, emails: list[str]) -> None:
 	for email in dict.fromkeys(emails):  # de-duplicate while preserving order
 		if not email or email in already_junked:
 			continue
-		doc = frappe.get_doc(
-			{"doctype": "Junk Email Address", "account": account, "email": email, "user": user}
-		)
+		doc = frappe.get_doc({"doctype": "Junk Email Address", "account_id": account_id, "email": email})
 		doc.set_new_name()
 		docs.append(doc)
 
@@ -874,8 +931,10 @@ def junk_senders(account: str, emails: list[str]) -> None:
 
 
 @frappe.whitelist()
-def unjunk_senders(account: str, emails: list[str]) -> None:
+def unjunk_senders(account_id: str, emails: list[str]) -> None:
 	"""Removes senders from the account's junk list (e.g. when a junk action is undone)."""
+
+	account = get_session_account(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 	remove_junk_senders(account, emails)
@@ -887,8 +946,9 @@ def remove_junk_senders(account: str, emails: list[str]) -> None:
 	if not emails:
 		return
 
+	account_id = parse_account(account)[1]
 	deleted = frappe.db.get_all(
-		"Junk Email Address", filters={"account": account, "email": ["in", emails]}, pluck="name"
+		"Junk Email Address", filters={"account_id": account_id, "email": ["in", emails]}, pluck="name"
 	)
 	if not deleted:
 		return
@@ -898,13 +958,15 @@ def remove_junk_senders(account: str, emails: list[str]) -> None:
 
 
 @frappe.whitelist()
-def unblock_email_addresses(account: str, emails: list[str]) -> None:
+def unblock_email_addresses(account_id: str, emails: list[str]) -> None:
 	"""Unblocks email addresses by deleting Blocked Email Address records and regenerating the sieve.
 
 	Scoped to the shared account_id (not the per-user handle), so a block added by any user on a
 	shared account can be removed. `frappe.db.delete` bypasses the doctype's `after_delete` hook, so
 	the blocked-emails sieve block is rebuilt explicitly here (mirrors `remove_junk_senders`).
 	"""
+
+	account = get_session_account(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 

--- a/mail/api/sieve.py
+++ b/mail/api/sieve.py
@@ -11,37 +11,47 @@ from mail.jmap import (
 	get_mailbox_id_by_role,
 	get_mailbox_name_by_id,
 	get_mailboxes,
+	parse_account,
 )
+from mail.utils.user import get_session_account
 
 AUTOMATION_SCRIPT_NAME = "frappe_mail_automation"
 AUTOMATION_SCRIPT_REQUIRE = 'require ["fileinto", "imap4flags"];'
 
 
 @frappe.whitelist()
-def get_sieve_scripts(account: str) -> list[dict]:
+def get_sieve_scripts(account_id: str) -> list[dict]:
 	"""Return the sieve scripts for the account"""
+
+	account = get_session_account(account_id)
 
 	ids = [d["id"] for d in SieveScript._fetch_sieve_scripts(account)[0]]
 	return SieveScript._get_sieve_scripts(account, ids, True)
 
 
 @frappe.whitelist()
-def create_sieve_script(account: str, _name: str, content: str, active: bool) -> None:
+def create_sieve_script(account_id: str, _name: str, content: str, active: bool) -> None:
 	"""Create a sieve script for the account"""
+
+	account = get_session_account(account_id)
 
 	SieveScript._add_sieve_script(account, _name, content, active)
 
 
 @frappe.whitelist()
-def update_sieve_script(account: str, id: str, _name: str, content: str, active: bool = False) -> None:
+def update_sieve_script(account_id: str, id: str, _name: str, content: str, active: bool = False) -> None:
 	"""Update a sieve script for the account"""
+
+	account = get_session_account(account_id)
 
 	SieveScript._update_sieve_script(account, id, _name, content, active)
 
 
 @frappe.whitelist()
-def delete_sieve_script(account: str, id: str) -> None:
+def delete_sieve_script(account_id: str, id: str) -> None:
 	"""Delete a sieve script for the account"""
+
+	account = get_session_account(account_id)
 
 	SieveScript._delete_sieve_scripts(account, [id])
 
@@ -124,8 +134,10 @@ def remove_sieve_block(sieve_script: str, block_name: str) -> str:
 
 
 @frappe.whitelist()
-def create_automation_script(account: str, active: bool = False) -> str:
+def create_automation_script(account_id: str, active: bool = False) -> str:
 	"""Create the frappe_mail_automation sieve script for the account."""
+
+	account = get_session_account(account_id)
 
 	frappe.flags.allow_automation_script_creation = True
 	return SieveScript._add_sieve_script(
@@ -204,15 +216,15 @@ def extract_rules_from_script(content: str, mailbox_name: str) -> dict | None:
 def get_child_mailbox_names(account: str, parent_name: str) -> list[str]:
 	"""Return the names of all direct child mailboxes for the given parent."""
 
-	parent_id = get_mailbox_id_by_name(account, parent_name)
-	mailboxes = get_mailboxes(account)
+	parent_id = get_mailbox_id_by_name(*parse_account(account), parent_name)
+	mailboxes = get_mailboxes(*parse_account(account))
 	return [mailbox["_name"] for mailbox in mailboxes if mailbox.get("parent_id") == parent_id]
 
 
 def get_mailbox_folder_path(account: str, name: str, raise_exception: bool = False) -> str | None:
 	"""Return the full slash-separated folder path for a mailbox."""
 
-	mailboxes = {mailbox["_name"]: mailbox for mailbox in get_mailboxes(account)}
+	mailboxes = {mailbox["_name"]: mailbox for mailbox in get_mailboxes(*parse_account(account))}
 	if name not in mailboxes:
 		if raise_exception:
 			frappe.throw(_("Mailbox with name '{0}' not found.").format(name))
@@ -227,7 +239,7 @@ def get_mailbox_folder_path(account: str, name: str, raise_exception: bool = Fal
 		if not parent_id:
 			break
 
-		parent_name = get_mailbox_name_by_id(account, parent_id)
+		parent_name = get_mailbox_name_by_id(*parse_account(account), parent_id)
 		current = mailboxes.get(parent_name)
 		if current is None:
 			if raise_exception:
@@ -318,8 +330,10 @@ def update_sieve_script_for_blocked_emails(account: str) -> None:
 def get_junk_folder_path(account: str) -> str:
 	"""Return the folder path of the account's Junk mailbox (for sieve `fileinto`)."""
 
-	junk_id = get_mailbox_id_by_role(account, "junk", create_if_not_exists=True, raise_exception=True)
-	junk_name = get_mailbox_name_by_id(account, junk_id, raise_exception=True)
+	junk_id = get_mailbox_id_by_role(
+		*parse_account(account), "junk", create_if_not_exists=True, raise_exception=True
+	)
+	junk_name = get_mailbox_name_by_id(*parse_account(account), junk_id, raise_exception=True)
 	return get_mailbox_folder_path(account, junk_name, raise_exception=True)
 
 

--- a/mail/client/doctype/account_settings/account_settings.js
+++ b/mail/client/doctype/account_settings/account_settings.js
@@ -4,11 +4,6 @@
 frappe.ui.form.on('Account Settings', {
 	refresh(frm) {
 		frm.trigger('add_actions')
-		frm.trigger('set_account_options')
-	},
-
-	user(frm) {
-		frm.trigger('set_account_options')
 	},
 
 	add_actions(frm) {
@@ -56,26 +51,6 @@ frappe.ui.form.on('Account Settings', {
 				__('Clear Cache'),
 			)
 		})
-	},
-
-	set_account_options(frm) {
-		if (frm.doc.user) {
-			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
-				args: {
-					user: frm.doc.user,
-				},
-				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
-				},
-			})
-		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
-		}
 	},
 
 	run_cache_clear_action(frm, action) {

--- a/mail/client/doctype/account_settings/account_settings.json
+++ b/mail/client/doctype/account_settings/account_settings.json
@@ -4,18 +4,9 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "section_break_hpbp",
-  "user",
-  "column_break_kjbb",
-  "account",
-  "jmap_states_section",
-  "email_state_last_update",
-  "column_break_vftu",
-  "email_current_state",
-  "column_break_bkvs",
-  "email_previous_state",
   "outgoing_section",
   "default_outgoing_email",
+  "column_break_outgoing",
   "create_contacts_after_email_submit",
   "destroy_email_after_submit",
   "destroy_newsletter_after_submit",
@@ -29,72 +20,10 @@
   "total_cached_mail_messages",
   "total_cached_contact_cards",
   "sieve_section",
-  "last_active_sieve_script_id",
-  "column_break_jaxh"
+  "last_active_sieve_script_id"
  ],
  "fields": [
   {
-   "fieldname": "section_break_hpbp",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "account",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "search_index": 1,
-   "set_only_once": 1
-  },
-  {
-   "fieldname": "email_previous_state",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "is_virtual": 1,
-   "label": "Previous State (Email)",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "email_current_state",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "is_virtual": 1,
-   "label": "Current State (Email)",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_vftu",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "email_state_last_update",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "State Last Update (Email)",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_kjbb",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "User",
-   "no_copy": 1,
-   "options": "User",
-   "search_index": 1,
-   "set_only_once": 1
-  },
-  {
-   "depends_on": "eval: !doc.__islocal",
    "fieldname": "outgoing_section",
    "fieldtype": "Section Break",
    "label": "Outgoing"
@@ -103,14 +32,21 @@
    "description": "Default email address used as the sender when composing new messages.",
    "fieldname": "default_outgoing_email",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Default Email",
    "options": "Email"
+  },
+  {
+   "fieldname": "column_break_outgoing",
+   "fieldtype": "Column Break"
   },
   {
    "default": "0",
    "description": "Automatically creates contact cards for new recipients after an email is sent.",
    "fieldname": "create_contacts_after_email_submit",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Create Contacts After Email Submit"
   },
   {
@@ -118,6 +54,7 @@
    "description": "Automatically deletes the email from your mailbox after it is sent.",
    "fieldname": "destroy_email_after_submit",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Destroy Email After Submit"
   },
   {
@@ -125,6 +62,7 @@
    "description": "Automatically delete newsletters after they are sent.",
    "fieldname": "destroy_newsletter_after_submit",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Destroy Newsletter After Submit"
   },
   {
@@ -137,6 +75,8 @@
    "description": "What to do with the sender when a message is marked as Junk. \"Junk Sender's Mail\" files their future mail into Junk; \"Ask to Block Sender\" prompts to block them outright.",
    "fieldname": "on_mark_as_junk",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "On Mark As Junk",
    "options": "Junk Sender's Mail\nAsk to Block Sender"
   },
@@ -148,6 +88,7 @@
   },
   {
    "default": "0",
+   "description": "Whether this account's JMAP identities are cached for your session.",
    "fieldname": "has_cached_jmap_identities",
    "fieldtype": "Check",
    "is_virtual": 1,
@@ -157,6 +98,7 @@
   },
   {
    "default": "0",
+   "description": "Whether this account's JMAP mailboxes are cached for your session.",
    "fieldname": "has_cached_jmap_mailboxes",
    "fieldtype": "Check",
    "is_virtual": 1,
@@ -169,6 +111,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Number of message blobs (bodies and attachments) cached for your session.",
    "fieldname": "total_cached_blobs",
    "fieldtype": "Int",
    "is_virtual": 1,
@@ -177,6 +120,7 @@
    "read_only": 1
   },
   {
+   "description": "Number of mail messages cached for your session.",
    "fieldname": "total_cached_mail_messages",
    "fieldtype": "Int",
    "is_virtual": 1,
@@ -185,6 +129,7 @@
    "read_only": 1
   },
   {
+   "description": "Number of contact cards cached for your session.",
    "fieldname": "total_cached_contact_cards",
    "fieldtype": "Int",
    "is_virtual": 1,
@@ -193,38 +138,28 @@
    "read_only": 1
   },
   {
+   "collapsible": 1,
    "depends_on": "eval: !doc.__islocal",
    "fieldname": "sieve_section",
    "fieldtype": "Section Break",
    "label": "Sieve"
   },
   {
+   "description": "ID of the Sieve script that was active before a vacation auto-reply was enabled; it is re-activated when the vacation response is turned off.",
    "fieldname": "last_active_sieve_script_id",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Last Active Sieve Script ID",
    "no_copy": 1,
    "read_only": 1,
    "search_index": 1
-  },
-  {
-   "fieldname": "column_break_jaxh",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval: !doc.__islocal",
-   "fieldname": "jmap_states_section",
-   "fieldtype": "Section Break",
-   "label": "JMAP States"
-  },
-  {
-   "fieldname": "column_break_bkvs",
-   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-30 11:13:57.163513",
+ "modified": "2026-06-23 10:10:53.961267",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Account Settings",

--- a/mail/client/doctype/account_settings/account_settings.py
+++ b/mail/client/doctype/account_settings/account_settings.py
@@ -2,7 +2,6 @@
 # For license information, please see license.txt
 
 from typing import TYPE_CHECKING
-from uuid import uuid7
 
 import frappe
 from frappe import _
@@ -23,42 +22,47 @@ if TYPE_CHECKING:
 	from mail.jmap.services.core import CoreService
 
 from mail.utils import log_error
-from mail.utils.user import get_account_emails, is_system_manager
-from mail.utils.validation import has_permission_for_user
+from mail.utils.user import (
+	get_account_emails,
+	get_account_scoped_permission_query,
+	has_account_scoped_permission,
+)
 
 
 class AccountSettings(Document):
+	"""Per-account settings shared across every user that has JMAP access to the account.
+
+	The document is named by the bare JMAP account ID. Cache-related fields and actions
+	operate on the *session user's* local store for the account, since the cache is kept
+	per (user, account).
+	"""
+
 	def autoname(self) -> None:
-		self.name = str(uuid7())
+		# The account ID is supplied by `get_or_create_account_settings` via flags.
+		self.name = self.flags.account_id
+
+	@property
+	def account(self) -> str:
+		"""The full `user:account_id` for the relevant user.
+
+		Uses the creating user during insert (set via flags) and the session user
+		otherwise, so cache lookups reflect the user currently viewing the document.
+		"""
+
+		return self.flags.get("account") or f"{frappe.session.user}:{self.name}"
 
 	@property
 	def core_service(self) -> "CoreService" | None:
 		"""Return the JMAP core service for the account, or None if there is an error."""
 
-		if self.flags.in_delete or not self.account:
+		if self.flags.in_delete or not self.name:
 			return None
 
 		try:
-			return get_core_service(self.account)
+			return get_core_service(*parse_account(self.account))
 		except Exception:
-			frappe.msgprint(f"Error getting JMAP core service for account {self.account}")
+			frappe.msgprint(f"Error getting JMAP core service for account {self.name}")
 			return None
-
-	@property
-	def email_current_state(self) -> str:
-		"""Returns the current state of the email sync for the account, or an empty string if not set."""
-
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		return store.get(Entity.STATE, "email_current_state") or ""
-
-	@property
-	def email_previous_state(self) -> str:
-		"""Returns the previous state of the email sync for the account, or an empty string if not set."""
-
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		return store.get(Entity.STATE, "email_previous_state") or ""
 
 	@property
 	def has_cached_jmap_identities(self) -> int:
@@ -84,25 +88,19 @@ class AccountSettings(Document):
 	def total_cached_blobs(self) -> int:
 		"""Get the total number of cached blobs for the account."""
 
-		user, account_id = parse_account(self.account)
-		store = get_blob_store(user, account_id)
-		return store.count()
+		return get_blob_store(self.name).count()
 
 	@property
 	def total_cached_mail_messages(self) -> int:
 		"""Get the total number of cached mail messages for the account."""
 
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		return store.count(Entity.EMAIL)
+		return get_data_store(self.name).count(Entity.EMAIL)
 
 	@property
 	def total_cached_contact_cards(self) -> int:
 		"""Get the total number of cached contact cards for the account."""
 
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		return store.count(Entity.CONTACT_CARD)
+		return get_data_store(self.name).count(Entity.CONTACT_CARD)
 
 	def validate(self) -> None:
 		self.validate_default_outgoing_email()
@@ -122,9 +120,6 @@ class AccountSettings(Document):
 		if emails and self.default_outgoing_email not in emails:
 			self.default_outgoing_email = emails[0]
 
-	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
-
 	def after_insert(self) -> None:
 		create_archive_mailbox(self.account)
 
@@ -142,14 +137,14 @@ class AccountSettings(Document):
 		"""Clear all cached JMAP identities for the current account."""
 
 		if self.has_clear_cache_permission():
-			invalidate_jmap_identities_cache(self.account)
+			invalidate_jmap_identities_cache(parse_account(self.account)[1])
 
 	@frappe.whitelist()
 	def clear_cached_jmap_mailboxes(self) -> None:
 		"""Clear all cached JMAP mailboxes for the current account."""
 
 		if self.has_clear_cache_permission():
-			invalidate_jmap_mailboxes_cache(self.account)
+			invalidate_jmap_mailboxes_cache(parse_account(self.account)[1])
 
 	@frappe.whitelist()
 	def clear_cached_blobs(self) -> None:
@@ -158,9 +153,7 @@ class AccountSettings(Document):
 		if not self.has_clear_cache_permission():
 			return
 
-		user, account_id = parse_account(self.account)
-		store = get_blob_store(user, account_id)
-		store.delete_all()
+		get_blob_store(self.name).delete_all()
 
 	@frappe.whitelist()
 	def clear_cached_mail_messages(self) -> None:
@@ -169,9 +162,7 @@ class AccountSettings(Document):
 		if not self.has_clear_cache_permission():
 			return
 
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		store.delete_all(Entity.EMAIL)
+		get_data_store(self.name).delete_all(Entity.EMAIL)
 
 	@frappe.whitelist()
 	def clear_cached_contact_cards(self) -> None:
@@ -180,14 +171,17 @@ class AccountSettings(Document):
 		if not self.has_clear_cache_permission():
 			return
 
-		user, account_id = parse_account(self.account)
-		store = get_data_store(user, account_id)
-		store.delete_all(Entity.CONTACT_CARD)
+		get_data_store(self.name).delete_all(Entity.CONTACT_CARD)
 
 	def has_clear_cache_permission(self) -> bool:
-		"""Check if the user has permission to clear cache."""
+		"""Check if the session user has permission to clear cache."""
 
-		return has_permission_for_user(self.user, raise_exception=True)
+		if has_permission(self, "write"):
+			return True
+
+		frappe.throw(
+			_("You do not have permission to clear the cache for this account."), frappe.PermissionError
+		)
 
 	def _db_set(
 		self,
@@ -201,30 +195,43 @@ class AccountSettings(Document):
 		self.db_set(kwargs, update_modified=update_modified, notify=notify, commit=commit)
 
 
-def sync_account_settings(user: str, accounts: dict[str, dict]) -> None:
-	"""Sync the Account Settings doctype with the current accounts of the user."""
+def get_or_create_account_settings(account: str) -> str:
+	"""Return the name of the (shared) Account Settings for the given `user:account_id`,
+	creating it if it does not already exist. The document is named by the account ID."""
 
-	existing_account_settings_map = {
-		s["account"]: s["name"]
-		for s in frappe.db.get_all("Account Settings", {"user": user}, ["name", "account"])
-	}
-	current_accounts = set([f"{user}:{account_id}" for account_id in accounts.keys()])
+	account_id = parse_account(account)[1]
 
-	accounts_to_delete = set(existing_account_settings_map.keys()) - current_accounts
-	accounts_to_add = current_accounts - set(existing_account_settings_map.keys())
+	if frappe.db.exists("Account Settings", account_id):
+		return account_id
 
-	for account in accounts_to_delete:
-		frappe.delete_doc("Account Settings", existing_account_settings_map[account], ignore_permissions=True)
+	settings = frappe.new_doc("Account Settings")
+	settings.flags.account_id = account_id
+	# Carry the full account so after_insert / validate can reach JMAP for this user.
+	settings.flags.account = account
 
-	for account in accounts_to_add:
-		settings = frappe.new_doc("Account Settings")
-		settings.user = user
-		settings.account = account
-		# Default the outgoing sender to the account's first identity.
+	# Default the outgoing sender to the account's first identity.
+	try:
 		emails = get_account_emails(account)
 		if emails:
 			settings.default_outgoing_email = emails[0]
-		settings.save(ignore_permissions=True)
+	except Exception:
+		pass
+
+	settings.flags.ignore_links = True
+	settings.insert(ignore_permissions=True)
+
+	return settings.name
+
+
+def sync_account_settings(user: str, accounts: dict[str, dict]) -> None:
+	"""Ensure a shared Account Settings document exists for each of the user's accounts.
+
+	Settings are shared by account ID across every user with access, so documents for
+	accounts the user can no longer see are intentionally left untouched.
+	"""
+
+	for account_id in accounts.keys():
+		get_or_create_account_settings(f"{user}:{account_id}")
 
 
 def backfill_default_outgoing_emails() -> None:
@@ -235,63 +242,57 @@ def backfill_default_outgoing_emails() -> None:
 	the account's identities, otherwise uses the account's first identity.
 	"""
 
-	for settings in frappe.get_all("Account Settings", fields=["name", "account", "default_outgoing_email"]):
+	from mail.jmap import get_jmap_connection
+
+	for user in frappe.get_all("User Settings", filters={"username": ["is", "set"]}, pluck="user"):
 		try:
-			emails = get_account_emails(settings["account"])
+			account_ids = list(get_jmap_connection(user, ignore_permissions=True).accounts.keys())
 		except Exception:
 			continue
 
-		if not emails:
-			continue
+		for account_id in account_ids:
+			if not frappe.db.exists("Account Settings", account_id):
+				continue
 
-		current = settings["default_outgoing_email"]
-		resolved = current if current in emails else emails[0]
-		if resolved != current:
-			frappe.db.set_value(
-				"Account Settings",
-				settings["name"],
-				"default_outgoing_email",
-				resolved,
-				update_modified=False,
-			)
+			try:
+				emails = get_account_emails(f"{user}:{account_id}")
+			except Exception:
+				continue
+
+			if not emails:
+				continue
+
+			current = frappe.db.get_value("Account Settings", account_id, "default_outgoing_email")
+			resolved = current if current in emails else emails[0]
+			if resolved != current:
+				frappe.db.set_value(
+					"Account Settings",
+					account_id,
+					"default_outgoing_email",
+					resolved,
+					update_modified=False,
+				)
 
 	frappe.db.commit()
 
 
 def get_permission_query_condition(user: str | None = None) -> str:
-	user = user or frappe.session.user
-
-	if is_system_manager(user):
-		return ""
-
-	return f"(`tabAccount Settings`.user = '{user}')"
+	# Account Settings is named directly by the account ID, so scope on `name`.
+	return get_account_scoped_permission_query("Account Settings", column="name", user=user)
 
 
 def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 	if doc.doctype != "Account Settings":
 		return False
 
-	user = user or frappe.session.user
-
-	if is_system_manager(user):
-		return True
-
-	return doc.user == user
-
-
-def on_doctype_update() -> None:
-	frappe.db.add_unique(
-		"Account Settings",
-		["account"],
-		constraint_name="unique_account_settings",
-	)
+	return has_account_scoped_permission(doc, column="name", user=user)
 
 
 def create_archive_mailbox(account: str) -> None:
 	"""Create the archive mailbox for the account if it does not already exist."""
 
 	try:
-		get_mailbox_id_by_role(account, "archive", create_if_not_exists=True)
+		get_mailbox_id_by_role(*parse_account(account), "archive", create_if_not_exists=True)
 
 	except Exception:
 		log_error(

--- a/mail/client/doctype/account_settings/account_settings_list.js
+++ b/mail/client/doctype/account_settings/account_settings_list.js
@@ -1,32 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Account Settings'] = {
-	refresh: (listview) => {
-		set_account_options(listview)
-	},
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
-	})
-}
+frappe.listview_settings['Account Settings'] = {}

--- a/mail/client/doctype/address_book/address_book.js
+++ b/mail/client/doctype/address_book/address_book.js
@@ -3,35 +3,29 @@
 
 frappe.ui.form.on('Address Book', {
 	refresh(frm) {
-		frm.trigger('set_queries')
+		frm.trigger('set_account_options')
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
-	},
-
-	set_queries(frm) {
-		frm.set_query('account', () => ({
-			query: 'mail.utils.query.get_user_accounts',
-			filters: {
-				user: frappe.session.user,
-			},
-		}))
 	},
 })

--- a/mail/client/doctype/address_book/address_book.json
+++ b/mail/client/doctype/address_book/address_book.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_rxvr",
   "user",
-  "account",
+  "account_id",
   "column_break_lzqg",
   "default",
   "subscribed",
@@ -140,15 +140,10 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The account this address book belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this address book belongs to.",

--- a/mail/client/doctype/address_book/address_book.py
+++ b/mail/client/doctype/address_book/address_book.py
@@ -11,10 +11,17 @@ from frappe.utils import cint, today
 
 from mail.jmap import get_address_book_service, parse_account
 from mail.utils import parse_filters
+from mail.utils.user import resolve_account_handle
 from mail.utils.validation import has_permission_for_user
 
 
 class AddressBook(Document):
+	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
 	def db_insert(self, *args, **kwargs) -> None:
 		self.id = add_address_book(
 			self.account,
@@ -52,6 +59,8 @@ class AddressBook(Document):
 		filters = parse_filters(filters)
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view address books."), alert=True)
@@ -73,6 +82,8 @@ class AddressBook(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -119,7 +130,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 @frappe.whitelist()
 def add_address_book(
-	account: str,
+	account_id: str,
 	name: str,
 	description: str | None = None,
 	sort_order: int = 0,
@@ -127,6 +138,8 @@ def add_address_book(
 	subscribed: bool = True,
 ) -> str:
 	"""Adds a address book for the given account with the specified parameters."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
@@ -140,7 +153,7 @@ def add_address_book(
 		"is_subscribed": subscribed,
 	}
 
-	service = get_address_book_service(account)
+	service = get_address_book_service(*parse_account(account))
 	response = service.create([address_book])
 
 	title = _("Address Book Creation Error")
@@ -158,7 +171,7 @@ def get_address_book(account: str, id: str, raise_exception: bool = True) -> dic
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_address_book_service(account)
+	service = get_address_book_service(*parse_account(account))
 	if address_books := service.get([id]):
 		return format_address_book(account, address_books[0])
 
@@ -194,7 +207,7 @@ def update_address_book(
 		"is_subscribed": subscribed,
 	}
 
-	service = get_address_book_service(account)
+	service = get_address_book_service(*parse_account(account))
 	response = service.update([address_book])
 
 	title = _("Address Book Update Error")
@@ -206,12 +219,14 @@ def update_address_book(
 
 
 @frappe.whitelist()
-def delete_address_books(account: str, ids: list[str]) -> None:
+def delete_address_books(account_id: str, ids: list[str]) -> None:
 	"""Deletes address books for the given account and list of address book IDs."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_address_book_service(account)
+	service = get_address_book_service(*parse_account(account))
 	response = service.delete(ids, remove_contents=True)
 
 	if response.get("notDestroyed"):
@@ -230,7 +245,7 @@ def fetch_address_books(account: str, page: int = 1, limit: int = 10) -> list:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_address_book_service(account)
+	service = get_address_book_service(*parse_account(account))
 	address_books = service.get()
 	formatted_address_books = [format_address_book(account, book) for book in address_books]
 	sorted_address_books = sorted(formatted_address_books, key=lambda x: x["sort_order"])
@@ -250,7 +265,8 @@ def format_address_book(account: str, address_book: dict) -> dict:
 
 	return {
 		"name": f"{account}|{address_book['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": address_book["id"],
 		"_name": address_book["name"],
 		"sort_order": sort_order,

--- a/mail/client/doctype/address_book/address_book_list.js
+++ b/mail/client/doctype/address_book/address_book_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Address Book'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/blocked_email_address/blocked_email_address.js
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address.js
@@ -1,24 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Blocked Email Address', {
-	user(frm) {
-		if (frm.doc.user) {
-			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
-				args: {
-					user: frm.doc.user,
-				},
-				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
-				},
-			})
-		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
-		}
-	},
-})
+frappe.ui.form.on('Blocked Email Address', {})

--- a/mail/client/doctype/blocked_email_address/blocked_email_address.json
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address.json
@@ -5,8 +5,6 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_gl6l",
-  "user",
-  "account",
   "account_id",
   "column_break_20of",
   "email"
@@ -17,13 +15,14 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "user",
-   "fieldtype": "Link",
+   "description": "The shared JMAP account ID this block belongs to. The block list is the same for everyone with access to the account.",
+   "fieldname": "account_id",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "User",
+   "label": "Account ID",
    "no_copy": 1,
-   "options": "User",
+   "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   },
@@ -32,6 +31,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "The email address whose mail is blocked (discarded) for the account.",
    "fieldname": "email",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -41,33 +41,12 @@
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
-  },
-  {
-   "fieldname": "account",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "search_index": 1,
-   "set_only_once": 1
-  },
-  {
-   "description": "The shared JMAP account id (without the user prefix). Blocks are scoped to this so a shared account's block list is the same for everyone with access.",
-   "fieldname": "account_id",
-   "fieldtype": "Data",
-   "label": "Account ID",
-   "no_copy": 1,
-   "read_only": 1,
-   "search_index": 1,
-   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-06 14:54:42.253326",
+ "modified": "2026-06-23 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Blocked Email Address",

--- a/mail/client/doctype/blocked_email_address/blocked_email_address.py
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address.py
@@ -7,18 +7,15 @@ import frappe
 from frappe.model.document import Document
 
 from mail.jmap import parse_account
+from mail.utils.user import get_account_scoped_permission_query, has_account_scoped_permission
 
 
 class BlockedEmailAddress(Document):
+	"""A blocked sender, shared per JMAP account ID — every user with access to the
+	account sees and manages the same block list."""
+
 	def autoname(self) -> None:
 		self.name = str(uuid7())
-
-	def before_insert(self) -> None:
-		# `account` is the "user:account_id" handle; `user` records who blocked, while `account_id`
-		# is the shared key so a group account's block list is the same for everyone with access.
-		user, account_id = parse_account(self.account)
-		self.user = user
-		self.account_id = account_id
 
 	def validate(self) -> None:
 		self.validate_duplicate_email()
@@ -26,18 +23,26 @@ class BlockedEmailAddress(Document):
 	def after_insert(self) -> None:
 		from mail.api.sieve import update_sieve_script_for_blocked_emails
 
-		update_sieve_script_for_blocked_emails(self.account)
+		update_sieve_script_for_blocked_emails(self._full_account())
 
 	def after_delete(self) -> None:
 		from mail.api.sieve import update_sieve_script_for_blocked_emails
 
-		update_sieve_script_for_blocked_emails(self.account)
+		update_sieve_script_for_blocked_emails(self._full_account())
+
+	def _full_account(self) -> str:
+		"""The `user:account_id` handle for the user acting on the shared list.
+
+		The blocked-emails sieve block lives on the account's server-side script, so
+		regenerating it needs a JMAP connection — use the acting user's handle (passed via
+		flags for API inserts, otherwise the session user, who must have access)."""
+
+		return self.flags.get("account") or f"{frappe.session.user}:{self.account_id}"
 
 	def validate_duplicate_email(self) -> None:
 		"""Validates that the same email address is not blocked multiple times for the same account.
 
-		Scoped to `account_id` (not the per-user `account` handle) so a shared account can't have the
-		same address blocked twice by different users.
+		Scoped to `account_id` so a shared account can't have the same address blocked twice.
 		"""
 
 		if frappe.db.exists(
@@ -57,6 +62,17 @@ def get_blocked_email_addresses(account: str) -> list[str]:
 
 	account_id = parse_account(account)[1]
 	return frappe.db.get_all("Blocked Email Address", filters={"account_id": account_id}, pluck="email")
+
+
+def get_permission_query_condition(user: str | None = None) -> str:
+	return get_account_scoped_permission_query("Blocked Email Address", user=user)
+
+
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Blocked Email Address":
+		return False
+
+	return has_account_scoped_permission(doc, user=user)
 
 
 def on_doctype_update() -> None:

--- a/mail/client/doctype/blocked_email_address/blocked_email_address_list.js
+++ b/mail/client/doctype/blocked_email_address/blocked_email_address_list.js
@@ -1,32 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Blocked Email Address'] = {
-	refresh: (listview) => {
-		set_account_options(listview)
-	},
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
-	})
-}
+frappe.listview_settings['Blocked Email Address'] = {}

--- a/mail/client/doctype/calendar/calendar.py
+++ b/mail/client/doctype/calendar/calendar.py
@@ -151,7 +151,7 @@ def add_calendar(
 		"is_default": default,
 	}
 
-	service = get_calendar_service(account)
+	service = get_calendar_service(*parse_account(account))
 	response = service.create([calendar])
 
 	title = _("Calendar Creation Error")
@@ -169,7 +169,7 @@ def get_calendar(account: str, id: str) -> dict:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_service(account)
+	service = get_calendar_service(*parse_account(account))
 	if calendars := service.get([id]):
 		return format_calendar(account, calendars[0])
 
@@ -210,7 +210,7 @@ def update_calendar(
 		"is_default": default,
 	}
 
-	service = get_calendar_service(account)
+	service = get_calendar_service(*parse_account(account))
 	response = service.update([calendar])
 
 	title = _("Calendar Update Error")
@@ -227,7 +227,7 @@ def delete_calendars(account: str, ids: list[str], remove_events: bool = True) -
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_service(account)
+	service = get_calendar_service(*parse_account(account))
 	response = service.delete(ids, remove_events=remove_events)
 
 	if response.get("notDestroyed"):
@@ -246,7 +246,7 @@ def fetch_calendars(account: str, page: int = 1, limit: int = 10) -> list:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_service(account)
+	service = get_calendar_service(*parse_account(account))
 	calendars = service.get()
 	formatted_calendars = [format_calendar(account, calendar) for calendar in calendars]
 	frappe.cache.set_value(_get_total_cache_key(account), len(calendars), expires_in_sec=600)

--- a/mail/client/doctype/calendar_event/calendar_event.py
+++ b/mail/client/doctype/calendar_event/calendar_event.py
@@ -326,7 +326,7 @@ def add_calendar_event(
 		"use_default_alerts": use_default_alerts,
 	}
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	response = service.create([event], send_scheduling_messages=send_scheduling_messages)
 
 	title = _("Calendar Event Creation Error")
@@ -354,7 +354,7 @@ def fetch_calendar_events(
 
 	calendar_events = []
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	data = service.query(filter, position, limit, sort, time_zone, expand_recurrences)
 
 	ids = data.get("ids", [])
@@ -371,7 +371,7 @@ def get_calendar_events(account: str, ids: list[str]) -> list[dict]:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	calendar_map = {c["id"]: c["name"] for c in service.calendars}
 
 	events = {}
@@ -390,7 +390,7 @@ def get_master_events_by_uids(account: str, uids: list[str]) -> dict:
 
 	events = {}
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 
 	if master_ids := service.get_master_ids(uids):
 		calendar_map = {c["id"]: c["name"] for c in service.calendars}
@@ -454,7 +454,7 @@ def update_calendar_event(
 		"use_default_alerts": use_default_alerts,
 	}
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	response = service.update([event], send_scheduling_messages=send_scheduling_messages)
 
 	title = _("Calendar Event Update Error")
@@ -477,7 +477,7 @@ def update_calendar_event_instance(
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	response = service.update_instance(
 		master_id, recurrence_id, patch, send_scheduling_messages=send_scheduling_messages
 	)
@@ -496,7 +496,7 @@ def delete_calendar_events(account: str, ids: list[str]) -> None:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	response = service.delete(ids)
 
 	if response.get("notDestroyed"):
@@ -518,7 +518,7 @@ def delete_calendar_event_instance(account: str, master_id: str, recurrence_id: 
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	response = service.delete_instance(master_id, recurrence_id)
 
 	title = _("Calendar Event Instance Deletion Error")
@@ -535,7 +535,7 @@ def parse_ics(account: str, ics_data: bytes | str) -> list[dict]:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_service(account)
+	service = get_calendar_event_service(*parse_account(account))
 	blob_id = service.upload_blob(ics_data, content_type="text/calendar; charset=utf-8").get("blobId")
 
 	if not blob_id:

--- a/mail/client/doctype/contact_card/contact_card.js
+++ b/mail/client/doctype/contact_card/contact_card.js
@@ -3,26 +3,30 @@
 
 frappe.ui.form.on('Contact Card', {
 	refresh(frm) {
+		frm.trigger('set_account_options')
 		frm.trigger('set_queries')
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 
@@ -30,7 +34,7 @@ frappe.ui.form.on('Contact Card', {
 		frm.set_query('address_book', 'address_books', () => ({
 			query: 'mail.utils.query.get_account_address_books',
 			filters: {
-				account: frm.doc.account,
+				account: `${frm.doc.user}:${frm.doc.account_id}`,
 			},
 		}))
 	},

--- a/mail/client/doctype/contact_card/contact_card.json
+++ b/mail/client/doctype/contact_card/contact_card.json
@@ -9,7 +9,7 @@
   "phone",
   "section_break_04au",
   "user",
-  "account",
+  "account_id",
   "column_break_lrhc",
   "id",
   "uid",
@@ -162,15 +162,10 @@
    "set_only_once": 1
   },
   {
-   "description": "The account this contact card belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this contact card belongs to.",

--- a/mail/client/doctype/contact_card/contact_card.py
+++ b/mail/client/doctype/contact_card/contact_card.py
@@ -15,10 +15,17 @@ from mail.storage import get_data_store
 from mail.storage.data_store import Entity
 from mail.utils import parse_filters
 from mail.utils.dt import parse_iso_datetime
+from mail.utils.user import resolve_account_handle
 from mail.utils.validation import has_permission_for_user
 
 
 class ContactCard(Document):
+	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
 	@property
 	def address_book_ids(self) -> list[str]:
 		"""Returns a list of address book IDs associated with this contact card."""
@@ -134,6 +141,8 @@ class ContactCard(Document):
 
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view contact cards."), alert=True)
@@ -171,6 +180,8 @@ class ContactCard(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -217,7 +228,7 @@ def bulk_delete(names: str | list[str]) -> None:
 
 @frappe.whitelist()
 def add_contact_card(
-	account: str,
+	account_id: str,
 	address_book_ids: list[str],
 	full_name: str | None = None,
 	emails: list[dict] | None = None,
@@ -226,6 +237,8 @@ def add_contact_card(
 	kind: str | None = None,
 ) -> str:
 	"""Adds a contact card for the given account with the specified parameters."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
@@ -240,7 +253,7 @@ def add_contact_card(
 		"kind": kind or "individual",
 	}
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 	response = service.create([contact_card])
 
 	title = _("Contact Card Creation Error")
@@ -258,7 +271,7 @@ def bulk_add_contact_cards(account: str, contact_cards: list[dict], raise_except
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 
 	for card in contact_cards:
 		if not card.get("creation_id"):
@@ -286,7 +299,7 @@ def fetch_contact_cards(
 
 	contact_cards = []
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 	data = service.query(filter, position, limit, sort)
 
 	ids = data.get("ids", [])
@@ -314,7 +327,7 @@ def get_contact_cards(account: str, ids: list[str]) -> list[dict]:
 			ids_to_fetch.append(id)
 
 	if ids_to_fetch:
-		service = get_contact_card_service(account)
+		service = get_contact_card_service(*parse_account(account))
 		cards = service.get(ids_to_fetch)
 		address_book_map = {ab["id"]: ab["name"] for ab in service.address_books}
 
@@ -355,7 +368,7 @@ def update_contact_card(
 		"kind": kind or "individual",
 	}
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 	response = service.update([contact_card])
 
 	title = _("Contact Card Update Error")
@@ -387,7 +400,7 @@ def contact_card_update_address_books(
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 	response = service.update_address_book_ids(
 		ids, add_address_book_id, remove_address_book_id, move_to_address_book_id
 	)
@@ -403,19 +416,23 @@ def contact_card_update_address_books(
 
 
 @frappe.whitelist()
-def contact_card_add_to_address_book(account: str, ids: list[str], address_book_id: str) -> None:
+def contact_card_add_to_address_book(account_id: str, ids: list[str], address_book_id: str) -> None:
 	"""Adds the provided contact cards to an address book."""
+
+	account = resolve_account_handle(account_id)
 
 	return contact_card_update_address_books(account, ids, add_address_book_id=address_book_id)
 
 
 @frappe.whitelist()
 def contact_card_remove_from_address_book(
-	account: str,
+	account_id: str,
 	ids: list[str],
 	address_book_id: str,
 ) -> None:
 	"""Removes the provided contact cards from an address book."""
+
+	account = resolve_account_handle(account_id)
 
 	return contact_card_update_address_books(account, ids, remove_address_book_id=address_book_id)
 
@@ -446,12 +463,14 @@ def contact_card_move_to_address_book(
 
 
 @frappe.whitelist()
-def delete_contact_cards(account: str, ids: list[str]) -> None:
+def delete_contact_cards(account_id: str, ids: list[str]) -> None:
 	"""Deletes contact cards for the given account by its IDs."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_contact_card_service(account)
+	service = get_contact_card_service(*parse_account(account))
 	service.delete(ids)
 	_remove_cached_contact_cards(account, ids)
 
@@ -465,24 +484,21 @@ def _get_total_cache_key(account: str) -> str:
 def _get_cached_contact_cards(account: str, ids: list[str]) -> dict[str, dict | None]:
 	"""Returns a dictionary of cached contact cards for the given account and IDs."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	return store.get_many(Entity.CONTACT_CARD, subkeys=ids)
 
 
 def _cache_contact_cards(account: str, contact_cards: dict[str, dict]) -> None:
 	"""Caches contact cards for the given account."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	store.set_many(Entity.CONTACT_CARD, items=contact_cards)
 
 
 def _remove_cached_contact_cards(account: str, ids: list[str]) -> None:
 	"""Removes cached contact cards for the given account and IDs."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	store.delete_many(Entity.CONTACT_CARD, subkeys=ids)
 
 
@@ -572,7 +588,8 @@ def format_contact_card(account: str, address_book_map: dict, contact_card: dict
 
 	return {
 		"name": f"{account}|{contact_card['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": contact_card["id"],
 		"uid": contact_card.get("uid"),
 		"kind": contact_card.get("kind"),

--- a/mail/client/doctype/contact_card/contact_card_list.js
+++ b/mail/client/doctype/contact_card/contact_card_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Contact Card'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/event_notification/event_notification.py
+++ b/mail/client/doctype/event_notification/event_notification.py
@@ -111,7 +111,7 @@ def fetch_event_notifications(
 
 	notifications = []
 
-	service = get_calendar_event_notification_service(account)
+	service = get_calendar_event_notification_service(*parse_account(account))
 	data = service.query(filter, position, limit, sort)
 
 	ids = data.get("ids", [])
@@ -128,7 +128,7 @@ def get_event_notifications(account: str, ids: list[str]) -> list[dict]:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_notification_service(account)
+	service = get_calendar_event_notification_service(*parse_account(account))
 
 	notifications = {}
 	for notification in service.get(ids):
@@ -144,7 +144,7 @@ def delete_event_notifications(account: str, ids: list[str]) -> None:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_calendar_event_notification_service(account)
+	service = get_calendar_event_notification_service(*parse_account(account))
 	response = service.delete(ids)
 
 	if response.get("notDestroyed"):

--- a/mail/client/doctype/identity/identity.js
+++ b/mail/client/doctype/identity/identity.js
@@ -2,23 +2,30 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Identity', {
+	refresh(frm) {
+		frm.trigger('set_account_options')
+	},
+
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 })

--- a/mail/client/doctype/identity/identity.json
+++ b/mail/client/doctype/identity/identity.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_qwpt",
   "user",
-  "account",
+  "account_id",
   "column_break_owjz",
   "may_delete",
   "section_break_mtnr",
@@ -111,15 +111,10 @@
    "label": "Signature"
   },
   {
-   "description": "The account this identity belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this identity belongs to.",

--- a/mail/client/doctype/identity/identity.py
+++ b/mail/client/doctype/identity/identity.py
@@ -17,6 +17,12 @@ from mail.utils.validation import has_permission_for_user
 
 class Identity(Document):
 	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
+	@property
 	def _bcc(self) -> list[dict]:
 		"""Returns the BCC list in the JMAP required format."""
 
@@ -72,6 +78,8 @@ class Identity(Document):
 		filters = parse_filters(filters)
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view identities."), alert=True)
@@ -93,6 +101,8 @@ class Identity(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -165,7 +175,7 @@ def add_identity(
 		"html_signature": html_signature,
 	}
 
-	service = get_identity_service(account)
+	service = get_identity_service(*parse_account(account))
 	response = service.create([identity])
 
 	title = _("Identity Creation Error")
@@ -183,7 +193,7 @@ def get_identity(account: str, id: str, raise_exception: bool = True) -> dict | 
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_identity_service(account)
+	service = get_identity_service(*parse_account(account))
 	if identities := service.get([id]):
 		return format_identity(account, identities[0])
 
@@ -217,7 +227,7 @@ def update_identity(
 		"html_signature": html_signature,
 	}
 
-	service = get_identity_service(account)
+	service = get_identity_service(*parse_account(account))
 	response = service.update([identity])
 
 	if not response.get("updated"):
@@ -234,7 +244,7 @@ def delete_identities(account: str, ids: list[str]) -> None:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_identity_service(account, ignore_permissions=True)
+	service = get_identity_service(*parse_account(account), ignore_permissions=True)
 	response = service.delete(ids)
 
 	if response.get("notDestroyed"):
@@ -261,7 +271,7 @@ def fetch_identities(account: str, page: int = 1, limit: int = 10) -> list:
 				)
 			)
 
-	service = get_identity_service(account, ignore_permissions=True)
+	service = get_identity_service(*parse_account(account), ignore_permissions=True)
 	identities = service.get()
 
 	formatted_identities = [format_identity(account, identity) for identity in identities]
@@ -286,7 +296,8 @@ def format_identity(account: str, identity: dict) -> dict:
 
 	return {
 		"name": f"{account}|{identity['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": identity["id"],
 		"_name": identity["name"],
 		"email": identity["email"].lower(),

--- a/mail/client/doctype/identity/identity_list.js
+++ b/mail/client/doctype/identity/identity_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Identity'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/junk_email_address/junk_email_address.js
+++ b/mail/client/doctype/junk_email_address/junk_email_address.js
@@ -1,24 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Junk Email Address', {
-	user(frm) {
-		if (frm.doc.user) {
-			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
-				args: {
-					user: frm.doc.user,
-				},
-				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
-				},
-			})
-		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
-		}
-	},
-})
+frappe.ui.form.on('Junk Email Address', {})

--- a/mail/client/doctype/junk_email_address/junk_email_address.json
+++ b/mail/client/doctype/junk_email_address/junk_email_address.json
@@ -5,8 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_gl6l",
-  "user",
-  "account",
+  "account_id",
   "column_break_20of",
   "email"
  ],
@@ -16,13 +15,14 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "user",
-   "fieldtype": "Link",
+   "description": "The shared JMAP account ID this junk rule belongs to. The junk list is the same for everyone with access to the account.",
+   "fieldname": "account_id",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "User",
+   "label": "Account ID",
    "no_copy": 1,
-   "options": "User",
+   "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   },
@@ -31,6 +31,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "The email address whose future mail is filed into Junk for the account.",
    "fieldname": "email",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -40,23 +41,12 @@
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
-  },
-  {
-   "fieldname": "account",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "search_index": 1,
-   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-22 11:54:31.220491",
+ "modified": "2026-06-23 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Junk Email Address",

--- a/mail/client/doctype/junk_email_address/junk_email_address.py
+++ b/mail/client/doctype/junk_email_address/junk_email_address.py
@@ -7,14 +7,15 @@ import frappe
 from frappe.model.document import Document
 
 from mail.jmap import parse_account
+from mail.utils.user import get_account_scoped_permission_query, has_account_scoped_permission
 
 
 class JunkEmailAddress(Document):
+	"""A junked sender, shared per JMAP account ID — every user with access to the
+	account sees and manages the same junk list."""
+
 	def autoname(self) -> None:
 		self.name = str(uuid7())
-
-	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
 
 	def validate(self) -> None:
 		self.validate_duplicate_email()
@@ -22,36 +23,62 @@ class JunkEmailAddress(Document):
 	def after_insert(self) -> None:
 		from mail.api.sieve import update_sieve_script_for_junk_senders
 
-		update_sieve_script_for_junk_senders(self.account)
+		update_sieve_script_for_junk_senders(self._full_account())
 
 	def after_delete(self) -> None:
 		from mail.api.sieve import update_sieve_script_for_junk_senders
 
-		update_sieve_script_for_junk_senders(self.account)
+		update_sieve_script_for_junk_senders(self._full_account())
+
+	def _full_account(self) -> str:
+		"""The `user:account_id` handle for the user acting on the shared list.
+
+		The junk-senders sieve block lives on the account's server-side script, so
+		regenerating it needs a JMAP connection — use the acting user's handle (passed via
+		flags for API inserts, otherwise the session user, who must have access)."""
+
+		return self.flags.get("account") or f"{frappe.session.user}:{self.account_id}"
 
 	def validate_duplicate_email(self) -> None:
-		"""Validates that the same email address is not junked multiple times for the same account."""
+		"""Validates that the same email address is not junked multiple times for the same account.
+
+		Scoped to `account_id` so a shared account can't have the same address junked twice.
+		"""
 
 		if frappe.db.exists(
 			"Junk Email Address",
-			{"account": self.account, "email": self.email, "name": ["!=", self.name]},
+			{"account_id": self.account_id, "email": self.email, "name": ["!=", self.name]},
 		):
 			frappe.throw(
-				frappe._("The email address {0} is already junked for account {1}.").format(
-					self.email, self.account
-				)
+				frappe._("The email address {0} is already junked for this account.").format(self.email)
 			)
 
 
 def get_junk_email_addresses(account: str) -> list[str]:
-	"""Returns a list of junked email addresses for the given account."""
+	"""Returns a list of junked email addresses for the given account.
 
-	return frappe.db.get_all("Junk Email Address", filters={"account": account}, pluck="email")
+	Keyed on `account_id` so every user with access to a shared account sees the same list.
+	"""
+
+	account_id = parse_account(account)[1]
+	return frappe.db.get_all("Junk Email Address", filters={"account_id": account_id}, pluck="email")
+
+
+def get_permission_query_condition(user: str | None = None) -> str:
+	return get_account_scoped_permission_query("Junk Email Address", user=user)
+
+
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Junk Email Address":
+		return False
+
+	return has_account_scoped_permission(doc, user=user)
 
 
 def on_doctype_update() -> None:
+	# Junk list is shared per account_id, so uniqueness is on (account_id, email).
 	frappe.db.add_unique(
 		"Junk Email Address",
-		["account", "email"],
-		constraint_name="unique_account_junk_email",
+		["account_id", "email"],
+		constraint_name="unique_account_id_junk_email",
 	)

--- a/mail/client/doctype/junk_email_address/junk_email_address_list.js
+++ b/mail/client/doctype/junk_email_address/junk_email_address_list.js
@@ -1,32 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Junk Email Address'] = {
-	refresh: (listview) => {
-		set_account_options(listview)
-	},
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
-	})
-}
+frappe.listview_settings['Junk Email Address'] = {}

--- a/mail/client/doctype/mail_exchange/mail_exchange.js
+++ b/mail/client/doctype/mail_exchange/mail_exchange.js
@@ -3,13 +3,14 @@
 
 frappe.ui.form.on('Mail Exchange', {
 	refresh(frm) {
+		frm.trigger('set_account_options')
 		if (!frm.doc.__islocal) {
 			frm.trigger('add_actions')
-			frm.trigger('set_account_options')
 		}
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
 		frm.trigger('set_account_options')
 	},
 
@@ -25,20 +26,18 @@ frappe.ui.form.on('Mail Exchange', {
 	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 

--- a/mail/client/doctype/mail_exchange/mail_exchange.json
+++ b/mail/client/doctype/mail_exchange/mail_exchange.json
@@ -9,7 +9,7 @@
   "section_break_vxtc",
   "column_break_frsy",
   "user",
-  "account",
+  "account_id",
   "operation",
   "import_format",
   "import_metadata",
@@ -247,21 +247,24 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "account",
+   "description": "The JMAP account ID to import into or export from. Populated from the accounts the selected user can access.",
+   "fieldname": "account_id",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
+   "label": "Account ID",
    "reqd": 1,
    "search_index": 1
   },
   {
+   "description": "The user whose JMAP credentials are used to authenticate the import/export.",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "User",
    "no_copy": 1,
    "options": "User",
+   "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   }

--- a/mail/client/doctype/mail_exchange/mail_exchange.py
+++ b/mail/client/doctype/mail_exchange/mail_exchange.py
@@ -526,6 +526,15 @@ class MailExchange(Document):
 			"receivedAt": metadata.get("receivedAt"),
 		}
 
+	@property
+	def account(self) -> str:
+		"""The full `user:account_id` JMAP handle.
+
+		`user` provides the credentials used to authenticate with JMAP, while `account_id`
+		is the (shared) account being imported into or exported from."""
+
+		return f"{self.user}:{self.account_id}"
+
 	def autoname(self) -> None:
 		self.name = str(uuid7())
 
@@ -538,9 +547,6 @@ class MailExchange(Document):
 		elif self.operation == "Export":
 			self.validate_export()
 
-	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
-
 	def before_submit(self) -> None:
 		self.status = "Queued"
 		self.queued_at = now()
@@ -552,11 +558,21 @@ class MailExchange(Document):
 		self.status = "Cancelled"
 
 	def validate_account(self) -> None:
-		"""Validate the account."""
+		"""Validate that the selected user can authenticate and has access to the account."""
 
 		if not is_jmap_configured(self.user):
 			frappe.throw(
 				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+				frappe.PermissionError,
+			)
+
+		from mail.jmap import get_user_account_ids
+
+		if self.account_id not in get_user_account_ids(self.user):
+			frappe.throw(
+				_("Account ID {0} is not accessible to user {1}.").format(
+					frappe.bold(self.account_id), frappe.bold(self.user)
+				),
 				frappe.PermissionError,
 			)
 
@@ -709,7 +725,7 @@ class MailExchange(Document):
 				extract_compressed_file(import_file, base_dir)
 			logger.debug("import-source-prepared", base_dir=base_dir)
 
-			service = get_email_service(self.account)
+			service = get_email_service(*parse_account(self.account))
 
 			mailbox_map = {}
 			if self.import_format == "maildir-nested":
@@ -756,7 +772,7 @@ class MailExchange(Document):
 
 		kwargs = {}
 		try:
-			service = get_email_service(self.account)
+			service = get_email_service(*parse_account(self.account))
 			total = service.query(self.export_filter_dict, limit=1)["total"]
 			limit = min(total, cint(self.export_limit or total))
 			logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)

--- a/mail/client/doctype/mail_exchange/mail_exchange_list.js
+++ b/mail/client/doctype/mail_exchange/mail_exchange_list.js
@@ -27,15 +27,15 @@ function set_account_options(listview) {
 	if (!user) return
 
 	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
+		method: 'mail.jmap.get_user_account_ids',
 		args: {
 			user: user,
 		},
 		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
+			const account_field = listview.page.fields_dict.account_id
 			if (!account_field) return
 
-			const options = r.message
+			const options = r.message || []
 			options.unshift('')
 			account_field.df.options = options
 			account_field.set_options()

--- a/mail/client/doctype/mail_message/mail_message.js
+++ b/mail/client/doctype/mail_message/mail_message.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on('Mail Message', {
 	refresh(frm) {
 		frm.disable_save()
+		frm.trigger('set_account_options')
 
 		if (!frm.doc.__islocal) {
 			if (!frm.doc.draft) {
@@ -23,22 +24,25 @@ frappe.ui.form.on('Mail Message', {
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 
@@ -110,7 +114,8 @@ frappe.ui.form.on('Mail Message', {
 		frappe.call({
 			method: 'mail.jmap.get_mailboxes_for_account',
 			args: {
-				account: frm.doc.account,
+				user: frm.doc.user,
+				account_id: frm.doc.account_id,
 			},
 			freeze: true,
 			freeze_message: __('Loading Mailboxes...'),

--- a/mail/client/doctype/mail_message/mail_message.json
+++ b/mail/client/doctype/mail_message/mail_message.json
@@ -20,7 +20,7 @@
   "not_keyword",
   "section_break_8xbl",
   "user",
-  "account",
+  "account_id",
   "from_name",
   "from_email",
   "column_break_nwlx",
@@ -592,14 +592,10 @@
    "read_only": 1
   },
   {
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "read_only": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "fieldname": "user",

--- a/mail/client/doctype/mail_message/mail_message.py
+++ b/mail/client/doctype/mail_message/mail_message.py
@@ -47,6 +47,12 @@ from mail.utils.validation import has_permission_for_user
 
 class MailMessage(Document):
 	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
+	@property
 	def to(self) -> list[dict[str, str | None]]:
 		"""Returns the recipients in the To field."""
 
@@ -200,6 +206,8 @@ class MailMessage(Document):
 
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view messages."), alert=True)
@@ -269,6 +277,8 @@ class MailMessage(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -645,7 +655,7 @@ def fetch_messages(
 
 	messages = []
 
-	service = get_email_service(account)
+	service = get_email_service(*parse_account(account))
 	data = service.query(filter, position, limit, sort)
 
 	ids = data.get("ids", [])
@@ -668,7 +678,7 @@ def fetch_threads(
 	has_permission_for_user(parse_account(account)[0])
 
 	# Page of threads (each mapped to all of its email IDs across mailboxes).
-	service = get_email_service(account)
+	service = get_email_service(*parse_account(account))
 	thread_email_ids = service.query_thread(filter, position, limit, fetch_all=True)
 	if not thread_email_ids:
 		return {}
@@ -692,7 +702,7 @@ def fetch_thread(account: str, thread_id: str, sort: Literal["asc", "desc"] = "a
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_thread_service(account)
+	service = get_thread_service(*parse_account(account))
 	result = service.get([thread_id])
 	ids = result.get(thread_id, [])
 	messages = get_messages(account, ids=ids)
@@ -744,7 +754,7 @@ def get_messages(account: str, ids: list[str]) -> list[dict]:
 			ids_to_fetch.append(id)
 
 	if ids_to_fetch:
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		emails = service.get(ids_to_fetch)
 		mailbox_map = {mb["id"]: mb["name"] for mb in service.mailboxes}
 
@@ -771,14 +781,14 @@ def get_message_ids(
 	has_permission_for_user(parse_account(account)[0])
 
 	try:
-		thread_service = get_thread_service(account)
+		thread_service = get_thread_service(*parse_account(account))
 		result = thread_service.get(thread_ids)
 		ids = [id for _thread_id, ids in result.items() for id in ids]
 
 		if not mailbox_id:
 			return ids
 
-		email_service = get_email_service(account)
+		email_service = get_email_service(*parse_account(account))
 		emails = email_service.get(ids, properties=["id", "mailboxIds"])
 		if isinstance(mailbox_id, str):
 			return [email["id"] for email in emails if mailbox_id in email["mailboxIds"]]
@@ -799,7 +809,7 @@ def delete_messages(account: str, ids: list[str]) -> None:
 	has_permission_for_user(parse_account(account)[0])
 
 	try:
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.delete(ids)
 		_remove_cached_messages(account, ids)
 	except Exception:
@@ -819,7 +829,7 @@ def empty_mailbox(account: str, mailbox_id: str) -> None:
 	has_permission_for_user(parse_account(account)[0])
 
 	try:
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 
 		while True:
 			result = service.query({"inMailbox": mailbox_id}, position=0, limit=service.max_objects_in_get)
@@ -848,7 +858,7 @@ def move_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> N
 
 	try:
 		emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_mailboxes=True)
 		_remove_cached_messages(account, ids)
 	except Exception:
@@ -878,7 +888,7 @@ def set_messages_mailboxes(account: str, mails: list[dict]) -> None:
 					"keywords": {"$junk": junk, "$notjunk": not junk},
 				}
 			)
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_keywords=False, replace_mailboxes=True)
 		_remove_cached_messages(account, [mail["id"] for mail in mails])
 	except Exception:
@@ -899,7 +909,7 @@ def add_messages_to_mailbox(account: str, ids: list[str], mailbox_id: str) -> No
 
 	try:
 		emails = [{"id": id, "mailbox_ids": {mailbox_id: True}} for id in ids]
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
@@ -920,7 +930,7 @@ def remove_messages_from_mailbox(account: str, ids: list[str], mailbox_id: str) 
 
 	try:
 		emails = [{"id": id, "mailbox_ids": {mailbox_id: False}} for id in ids]
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_mailboxes=False)
 		_remove_cached_messages(account, ids)
 	except Exception:
@@ -941,7 +951,7 @@ def set_seen_status(account: str, ids: list[str], seen: bool = True) -> None:
 
 	try:
 		emails = [{"id": id, "keywords": {"$seen": seen}} for id in ids]
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_keywords=False)
 
 		messages_to_cache = {}
@@ -976,7 +986,7 @@ def set_flagged_status(account: str, ids: list[str], flagged: bool = True) -> No
 
 	try:
 		emails = [{"id": id, "keywords": {"$flagged": flagged}} for id in ids]
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		service.update(emails, replace_keywords=False)
 
 		messages_to_cache = {}
@@ -1007,13 +1017,13 @@ def set_spam_status(account: str, ids: list[str], spam: bool = True) -> None:
 	if not account or not ids:
 		frappe.throw(_("Account and Mail IDs are required."))
 
-	user = parse_account(account)[0]
+	user, account_id = parse_account(account)
 	has_permission_for_user(user)
 
 	try:
 		connection = get_jmap_connection(user)
-		email_service = EmailService(account, connection)
-		mailbox_service = MailboxService(account, connection)
+		email_service = EmailService(account_id, connection)
+		mailbox_service = MailboxService(account_id, connection)
 
 		mailbox_id = mailbox_service.get_mailbox_id_by_role(
 			"junk" if spam else "inbox", create_if_not_exists=True, raise_exception=True
@@ -1064,7 +1074,7 @@ def fetch_blobs(account: str, blobs: list[str] | list[tuple[str, str | None]]) -
 		return result
 
 	try:
-		service = get_email_service(account)
+		service = get_email_service(*parse_account(account))
 		fetched_blobs = service.download_blobs_concurrently(blobs_to_fetch)
 
 		blobs_to_cache = {}
@@ -1109,7 +1119,8 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
 
 	sent_at = parse_iso_datetime(message["sentAt"])
 	formatted_message = {
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"sent_at": sent_at,
 		"creation": sent_at,
 		"id": message["id"],
@@ -1193,7 +1204,7 @@ def format_message(account: str, mailbox_map: dict, message: dict) -> dict:
 
 	for attachment in formatted_message["attachments"]:
 		if blob_id := attachment["blob_id"]:
-			params = f"account={account}&blob_id={blob_id}"
+			params = f"account_id={parse_account(account)[1]}&blob_id={blob_id}"
 			if filename := attachment["filename"]:
 				params += f"&filename={quote(filename)}"
 			attachment["url"] = f"/api/method/mail.api.mail.get_attachment?{params}"
@@ -1217,40 +1228,35 @@ def _get_total_cache_key(account: str) -> str:
 def _get_cached_messages(account: str, ids: list[str]) -> dict[str, dict | None]:
 	"""Returns a dictionary of cached messages for the provided IDs."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	return store.get_many(Entity.EMAIL, subkeys=ids)
 
 
 def _cache_messages(account: str, messages: dict[str, dict]) -> None:
 	"""Store messages in cache with the message ID as the subkey."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	store.set_many(Entity.EMAIL, items=messages)
 
 
 def _remove_cached_messages(account: str, ids: list[str]) -> None:
 	"""Remove messages from cache for the provided IDs."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	store.delete_many(Entity.EMAIL, subkeys=ids)
 
 
 def _get_cached_blobs(account: str, blob_ids: list[str]) -> dict[str, bytes | None]:
 	"""Returns a dictionary of cached blobs for the provided blob IDs."""
 
-	user, account_id = parse_account(account)
-	store = get_blob_store(user, account_id)
+	store = get_blob_store(parse_account(account)[1])
 	return store.get_many(subkeys=blob_ids)
 
 
 def _cache_blobs(account: str, blobs: dict[str, bytes]) -> None:
 	"""Store blobs in cache with the blob ID as the subkey."""
 
-	user, account_id = parse_account(account)
-	store = get_blob_store(user, account_id)
+	store = get_blob_store(parse_account(account)[1])
 	store.set_many(items=blobs)
 
 
@@ -1279,8 +1285,8 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 		logger.debug("fetching-changes-from-server")
 
 		connection = get_jmap_connection(user)
-		email_service = EmailService(account, connection)
-		mailbox_service = MailboxService(account, connection)
+		email_service = EmailService(account_id, connection)
+		mailbox_service = MailboxService(account_id, connection)
 
 		result = email_service.changes(current_state)
 
@@ -1294,7 +1300,7 @@ def fetch_changes(account: str, email_state: str | None = None, ctx: dict | None
 				disabled_mailboxes = set(
 					frappe.db.get_all(
 						"Mailbox Settings",
-						{"account": account, "disable_push_notification": 1},
+						{"account_id": account_id, "disable_push_notification": 1},
 						pluck="mailbox_id",
 					)
 				) | {
@@ -1433,33 +1439,46 @@ def enqueue_fetch_changes(account: str, email_state: str | None = None, ctx: dic
 
 
 def schedule_fetch_changes() -> None:
-	"""Schedule fetch_changes for users who have email accounts configured and haven't had their email state updated in the last 3 hours."""
+	"""Schedule fetch_changes for every (user, account) whose email state hasn't been
+	updated in the last 3 hours.
+
+	Account Settings are now shared per account ID, so the set of accounts to sync is
+	derived from each JMAP-configured user's accounts, and the last-update timestamp is
+	read from that user's per-account data store."""
 
 	USER = frappe.qb.DocType("User")
 	USER_SETTINGS = frappe.qb.DocType("User Settings")
-	ACCOUNT_SETTINGS = frappe.qb.DocType("Account Settings")
 
-	threshold = add_to_date(now(), hours=-3)
+	threshold = get_datetime(add_to_date(now(), hours=-3))
 
-	accounts = (
-		frappe.qb.from_(ACCOUNT_SETTINGS)
+	users = (
+		frappe.qb.from_(USER_SETTINGS)
 		.join(USER)
-		.on(USER.name == ACCOUNT_SETTINGS.user)
-		.join(USER_SETTINGS)
-		.on(USER_SETTINGS.user == USER.name)
-		.select(ACCOUNT_SETTINGS.account)
-		.distinct()
+		.on(USER.name == USER_SETTINGS.user)
+		.select(USER_SETTINGS.user)
 		.where(
 			(USER.enabled == 1)
 			& (USER_SETTINGS.username != "")
 			& (USER_SETTINGS.username.isnotnull())
 			& (USER_SETTINGS.skip_schedule_fetch_changes == 0)
-			& (
-				ACCOUNT_SETTINGS.email_state_last_update.isnull()
-				| (ACCOUNT_SETTINGS.email_state_last_update < threshold)
-			)
 		)
-	).run(pluck="account")
+	).run(pluck="user")
+
+	if not users:
+		return
+
+	accounts = []
+	for user in users:
+		try:
+			account_ids = list(get_jmap_connection(user, ignore_permissions=True).accounts.keys())
+		except Exception:
+			continue
+
+		for account_id in account_ids:
+			store = get_data_store(account_id)
+			last_update = store.get(Entity.STATE, "email_state_last_update")
+			if not last_update or get_datetime(last_update) < threshold:
+				accounts.append(f"{user}:{account_id}")
 
 	if not accounts:
 		return

--- a/mail/client/doctype/mail_message/mail_message_list.js
+++ b/mail/client/doctype/mail_message/mail_message_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Mail Message'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/mail_queue/mail_queue.js
+++ b/mail/client/doctype/mail_queue/mail_queue.js
@@ -12,6 +12,7 @@ frappe.ui.form.on('Mail Queue', {
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
 		frm.trigger('set_account_options')
 	},
 
@@ -48,20 +49,18 @@ frappe.ui.form.on('Mail Queue', {
 	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 

--- a/mail/client/doctype/mail_queue/mail_queue.json
+++ b/mail/client/doctype/mail_queue/mail_queue.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_zwhk",
   "user",
-  "account",
+  "account_id",
   "status",
   "from_name",
   "from_email",
@@ -543,16 +543,18 @@
    "set_only_once": 1
   },
   {
-   "fieldname": "account",
+   "description": "The JMAP account ID this message is sent from. Populated from the accounts the selected user can access.",
+   "fieldname": "account_id",
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
+   "label": "Account ID",
    "reqd": 1,
    "search_index": 1,
    "set_only_once": 1
   },
   {
+   "description": "The user whose JMAP credentials are used to send this message.",
    "fieldname": "user",
    "fieldtype": "Link",
    "in_standard_filter": 1,

--- a/mail/client/doctype/mail_queue/mail_queue.py
+++ b/mail/client/doctype/mail_queue/mail_queue.py
@@ -40,6 +40,15 @@ from mail.utils.validation import has_permission_for_user
 
 
 class MailQueue(Document):
+	@property
+	def account(self) -> str:
+		"""The full `user:account_id` JMAP handle.
+
+		`user` provides the credentials used to authenticate with JMAP, while `account_id`
+		is the account this message is sent from."""
+
+		return f"{self.user}:{self.account_id}"
+
 	@staticmethod
 	def clear_old_logs(days: int = 3) -> None:
 		MQ = frappe.qb.DocType("Mail Queue")
@@ -90,7 +99,9 @@ class MailQueue(Document):
 		kwargs = frappe._dict(kwargs)
 
 		doc = frappe.new_doc("Mail Queue")
-		doc.account = kwargs.account
+		# `account` is the "user:account_id" handle; store the credentials user and the bare
+		# account id separately (the full handle is exposed via the `account` property).
+		doc.user, doc.account_id = parse_account(kwargs.account)
 		doc.from_name = kwargs.from_name
 		doc.from_email = kwargs.from_email
 		doc.subject = kwargs.subject
@@ -150,7 +161,7 @@ class MailQueue(Document):
 		identity = {}
 
 		if self.from_email:
-			for i in get_identities(self.account):
+			for i in get_identities(*parse_account(self.account)):
 				if self.from_email.lower() == i.get("email").lower():
 					identity = i
 					break
@@ -268,9 +279,6 @@ class MailQueue(Document):
 			self.validate_in_reply_to()
 			self.validate_in_reply_to_id()
 
-	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
-
 	def after_insert(self) -> None:
 		if self.delivery_mode == "Immediate":
 			self._process()
@@ -374,12 +382,11 @@ class MailQueue(Document):
 		if self.save_as_draft or self.destroy_after_submit:
 			return
 
+		account_id = self.account_id
 		if self.newsletter:
-			if frappe.db.get_value(
-				"Account Settings", {"account": self.account}, "destroy_newsletter_after_submit"
-			):
+			if frappe.db.get_value("Account Settings", account_id, "destroy_newsletter_after_submit"):
 				self.destroy_after_submit = 1
-		elif frappe.db.get_value("Account Settings", {"account": self.account}, "destroy_email_after_submit"):
+		elif frappe.db.get_value("Account Settings", account_id, "destroy_email_after_submit"):
 			self.destroy_after_submit = 1
 
 	def validate_delivery_mode(self) -> None:
@@ -558,7 +565,7 @@ class MailQueue(Document):
 
 		if self.in_reply_to and not self.in_reply_to_id:
 			try:
-				service = get_email_service(self.account)
+				service = get_email_service(*parse_account(self.account))
 				result = service.query({"header": ["Message-ID", self.in_reply_to]})
 				if ids := result["ids"]:
 					self.in_reply_to_id = ids[0]
@@ -595,8 +602,8 @@ class MailQueue(Document):
 
 		try:
 			connection = get_jmap_connection(self.user)
-			email_service = EmailService(self.account, connection)
-			mailbox_service = MailboxService(self.account, connection)
+			email_service = EmailService(self.account_id, connection)
+			mailbox_service = MailboxService(self.account_id, connection)
 
 			draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
 				"drafts", create_if_not_exists=True, raise_exception=True
@@ -799,7 +806,7 @@ def process_pending_emails(mails: list[str]) -> None:
 	total_count = len(mails)
 
 	for mail in mails:
-		doc: "MailQueue" = frappe.get_doc("Mail Queue", mail)
+		doc: MailQueue = frappe.get_doc("Mail Queue", mail)
 		doc._process()
 
 		if doc.status in ["Failed", "Failed to Draft", "Failed to Submit"]:
@@ -893,6 +900,4 @@ def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 	if doc.doctype != "Mail Queue":
 		return False
 
-	user = doc.user or parse_account(doc.account)[0]
-
-	return has_permission_for_user(user, raise_exception=False)
+	return has_permission_for_user(doc.user, raise_exception=False)

--- a/mail/client/doctype/mail_queue/mail_queue_list.js
+++ b/mail/client/doctype/mail_queue/mail_queue_list.js
@@ -47,15 +47,15 @@ function set_account_options(listview) {
 	if (!user) return
 
 	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
+		method: 'mail.jmap.get_user_account_ids',
 		args: {
 			user: user,
 		},
 		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
+			const account_field = listview.page.fields_dict.account_id
 			if (!account_field) return
 
-			const options = r.message
+			const options = r.message || []
 			options.unshift('')
 			account_field.df.options = options
 			account_field.set_options()

--- a/mail/client/doctype/mail_sync_history/mail_sync_history.js
+++ b/mail/client/doctype/mail_sync_history/mail_sync_history.js
@@ -1,24 +1,4 @@
 // Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Mail Sync History', {
-	user(frm) {
-		if (frm.doc.user) {
-			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
-				args: {
-					user: frm.doc.user,
-				},
-				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
-				},
-			})
-		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
-		}
-	},
-})
+frappe.ui.form.on('Mail Sync History', {})

--- a/mail/client/doctype/mail_sync_history/mail_sync_history.json
+++ b/mail/client/doctype/mail_sync_history/mail_sync_history.json
@@ -5,14 +5,25 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "user",
-  "account",
+  "account_id",
   "source",
   "column_break_6jsu",
   "last_received_at",
   "last_received_mail"
  ],
  "fields": [
+  {
+   "description": "The shared JMAP account ID this sync watermark belongs to. It is the same for everyone with access to the account.",
+   "fieldname": "account_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account ID",
+   "no_copy": 1,
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  },
   {
    "fieldname": "column_break_6jsu",
    "fieldtype": "Column Break"
@@ -37,26 +48,6 @@
    "fieldname": "last_received_mail",
    "fieldtype": "Data",
    "label": "Last Received Mail"
-  },
-  {
-   "fieldname": "account",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Account",
-   "reqd": 1,
-   "search_index": 1
-  },
-  {
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "User",
-   "no_copy": 1,
-   "options": "User",
-   "search_index": 1,
-   "set_only_once": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/mail/client/doctype/mail_sync_history/mail_sync_history.py
+++ b/mail/client/doctype/mail_sync_history/mail_sync_history.py
@@ -6,19 +6,22 @@ from frappe import _
 from frappe.model.document import Document
 
 from mail.jmap import parse_account
+from mail.utils.user import get_account_scoped_permission_query, has_account_scoped_permission
 
 
 class MailSyncHistory(Document):
+	"""Per-source inbound-pull watermark, shared per JMAP account ID — every user with
+	access to the account shares the same last-received state for a given source."""
+
 	def before_insert(self) -> None:
 		self.validate_duplicate()
-		self.user = parse_account(self.account)[0]
 
 	def validate_duplicate(self) -> None:
 		"""Validate if the Mail Sync History already exists."""
 
 		if frappe.db.exists(
 			"Mail Sync History",
-			{"account": self.account, "source": self.source},
+			{"account_id": self.account_id, "source": self.source},
 		):
 			frappe.throw(_("Mail Sync History already exists for this account and source."))
 
@@ -32,7 +35,7 @@ def create_mail_sync_history(
 	"""Create a Mail Sync History."""
 
 	doc = frappe.new_doc("Mail Sync History")
-	doc.account = account
+	doc.account_id = parse_account(account)[1]
 	doc.source = source
 	doc.last_received_at = last_received_at
 	doc.insert(ignore_permissions=True)
@@ -46,15 +49,28 @@ def create_mail_sync_history(
 def get_mail_sync_history(account: str, source: str) -> "MailSyncHistory":
 	"""Returns the Mail Sync History for the given account and source."""
 
-	if name := frappe.db.exists("Mail Sync History", {"account": account, "source": source}):
+	account_id = parse_account(account)[1]
+	if name := frappe.db.exists("Mail Sync History", {"account_id": account_id, "source": source}):
 		return frappe.get_doc("Mail Sync History", name)
 
 	return create_mail_sync_history(account, source, commit=True)
 
 
+def get_permission_query_condition(user: str | None = None) -> str:
+	return get_account_scoped_permission_query("Mail Sync History", user=user)
+
+
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Mail Sync History":
+		return False
+
+	return has_account_scoped_permission(doc, user=user)
+
+
 def on_doctype_update() -> None:
+	# Sync history is shared per account_id, so uniqueness is on (account_id, source).
 	frappe.db.add_unique(
 		"Mail Sync History",
-		["account", "source"],
-		constraint_name="unique_account_source",
+		["account_id", "source"],
+		constraint_name="unique_account_id_source",
 	)

--- a/mail/client/doctype/mail_sync_history/mail_sync_history_list.js
+++ b/mail/client/doctype/mail_sync_history/mail_sync_history_list.js
@@ -1,32 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Mail Sync History'] = {
-	refresh: (listview) => {
-		set_account_options(listview)
-	},
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
-	})
-}
+frappe.listview_settings['Mail Sync History'] = {}

--- a/mail/client/doctype/mailbox/mailbox.js
+++ b/mail/client/doctype/mailbox/mailbox.js
@@ -3,26 +3,30 @@
 
 frappe.ui.form.on('Mailbox', {
 	refresh(frm) {
+		frm.trigger('set_account_options')
 		frm.trigger('set_queries')
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 
@@ -30,7 +34,7 @@ frappe.ui.form.on('Mailbox', {
 		frm.set_query('_parent', () => ({
 			query: 'mail.utils.query.get_account_mailboxes',
 			filters: {
-				account: frm.doc.account,
+				account: `${frm.doc.user}:${frm.doc.account_id}`,
 			},
 		}))
 	},

--- a/mail/client/doctype/mailbox/mailbox.json
+++ b/mail/client/doctype/mailbox/mailbox.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_nuoa",
   "user",
-  "account",
+  "account_id",
   "column_break_5a4x",
   "subscribed",
   "section_break_cbgf",
@@ -256,14 +256,10 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "The account this mailbox belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
    "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this mailbox belongs to.",

--- a/mail/client/doctype/mailbox/mailbox.py
+++ b/mail/client/doctype/mailbox/mailbox.py
@@ -19,6 +19,12 @@ REBALANCE_MAILBOX_WINDOW = 10
 
 
 class Mailbox(Document):
+	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
 	def db_insert(self, *args, **kwargs) -> None:
 		parent = self._parent.replace(f"{self.account}|", "") if self._parent else None
 		self.id = add_mailbox(
@@ -47,6 +53,8 @@ class Mailbox(Document):
 		filters = parse_filters(filters)
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view mailboxes."), alert=True)
@@ -68,6 +76,8 @@ class Mailbox(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -127,7 +137,7 @@ def add_mailbox(
 		"is_subscribed": subscribed,
 	}
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	response = service.create([mailbox])
 
 	title = _("Mailbox Creation Error")
@@ -146,7 +156,7 @@ def get_mailbox(account: str, id: str, raise_exception: bool = False) -> dict | 
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	if mailboxes := service.get([id]):
 		return format_mailbox(account, mailboxes[0])
 
@@ -184,7 +194,7 @@ def update_mailbox(
 		"is_subscribed": subscribed,
 	}
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	response = service.update([mailbox])
 
 	if not response.get("updated"):
@@ -202,7 +212,7 @@ def delete_mailboxes(account: str, ids: list[str], remove_emails: bool = True) -
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	response = service.delete(ids, remove_emails=remove_emails)
 
 	if response.get("notDestroyed"):
@@ -221,7 +231,7 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	mailboxes = service.get()
 	formatted_mailboxes = [format_mailbox(account, mailbox) for mailbox in mailboxes]
 	sorted_mailboxes = sorted(
@@ -316,7 +326,7 @@ def update_mailbox_position(
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_mailbox_service(account)
+	service = get_mailbox_service(*parse_account(account))
 	mailboxes = sorted(
 		service.get(), key=lambda m: (m["sortOrder"], get_sort_order(m["role"]), m["name"], m["id"])
 	)
@@ -358,7 +368,8 @@ def format_mailbox(account: str, mailbox: dict) -> dict:
 
 	return {
 		"name": f"{account}|{mailbox['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": mailbox["id"],
 		"_name": mailbox["name"],
 		"_parent": _parent,

--- a/mail/client/doctype/mailbox/mailbox_list.js
+++ b/mail/client/doctype/mailbox/mailbox_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Mailbox'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/mailbox_settings/mailbox_settings.js
+++ b/mail/client/doctype/mailbox_settings/mailbox_settings.js
@@ -1,24 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Mailbox Settings', {
-	user(frm) {
-		if (frm.doc.user) {
-			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
-				args: {
-					user: frm.doc.user,
-				},
-				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
-				},
-			})
-		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
-		}
-	},
-})
+frappe.ui.form.on('Mailbox Settings', {})

--- a/mail/client/doctype/mailbox_settings/mailbox_settings.json
+++ b/mail/client/doctype/mailbox_settings/mailbox_settings.json
@@ -5,8 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "section_break_e10u",
-  "user",
-  "account",
+  "account_id",
   "column_break_zgrx",
   "mailbox_id",
   "section_break_qhyu",
@@ -19,6 +18,18 @@
   {
    "fieldname": "section_break_e10u",
    "fieldtype": "Section Break"
+  },
+  {
+   "description": "The shared JMAP account ID these mailbox settings belong to. They are the same for everyone with access to the account.",
+   "fieldname": "account_id",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account ID",
+   "no_copy": 1,
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "column_break_zgrx",
@@ -64,36 +75,12 @@
    "fieldtype": "Check",
    "label": "Disable Push Notification",
    "search_index": 1
-  },
-  {
-   "description": "The account to whom these mailbox settings apply.",
-   "fieldname": "account",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "search_index": 1,
-   "set_only_once": 1
-  },
-  {
-   "description": "The user to whom these mailbox settings apply.",
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "User",
-   "no_copy": 1,
-   "options": "User",
-   "search_index": 1,
-   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-17 15:15:30.171327",
+ "modified": "2026-06-23 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Client",
  "name": "Mailbox Settings",

--- a/mail/client/doctype/mailbox_settings/mailbox_settings.py
+++ b/mail/client/doctype/mailbox_settings/mailbox_settings.py
@@ -8,19 +8,18 @@ from frappe import _
 from frappe.model.document import Document
 
 from mail.jmap import parse_account
-from mail.utils.user import is_system_manager
-from mail.utils.validation import has_permission_for_user
+from mail.utils.user import get_account_scoped_permission_query, has_account_scoped_permission
 
 
 class MailboxSettings(Document):
+	"""Per-mailbox settings, shared per JMAP account ID — every user with access to the
+	account sees the same mailbox icons, colors, and push-notification preferences."""
+
 	def autoname(self) -> None:
 		self.name = str(uuid7())
 
 	def validate(self) -> None:
 		self.validate_duplicate()
-
-	def before_insert(self) -> None:
-		self.user = parse_account(self.account)[0]
 
 	def validate_duplicate(self) -> None:
 		"""Checks for duplicate Mailbox Settings for the same account and mailbox ID."""
@@ -28,7 +27,7 @@ class MailboxSettings(Document):
 		existing = frappe.db.exists(
 			"Mailbox Settings",
 			{
-				"account": self.account,
+				"account_id": self.account_id,
 				"mailbox_id": self.mailbox_id,
 				"name": ["!=", self.name],
 			},
@@ -37,7 +36,7 @@ class MailboxSettings(Document):
 		if existing:
 			frappe.throw(
 				_("Mailbox Settings for account {0} with mailbox ID {1} already exists.").format(
-					frappe.bold(self.account), frappe.bold(self.mailbox_id)
+					frappe.bold(self.account_id), frappe.bold(self.mailbox_id)
 				),
 				title=_("Duplicate Mailbox Settings"),
 			)
@@ -59,7 +58,10 @@ def get_mailbox_settings(
 ) -> MailboxSettings | None:
 	"""Fetches the Mailbox Settings for a given account and mailbox ID."""
 
-	if settings := frappe.db.get_value("Mailbox Settings", {"account": account, "mailbox_id": mailbox_id}):
+	account_id = parse_account(account)[1]
+	if settings := frappe.db.get_value(
+		"Mailbox Settings", {"account_id": account_id, "mailbox_id": mailbox_id}
+	):
 		return frappe.get_doc("Mailbox Settings", settings)
 
 	if raise_exception:
@@ -77,7 +79,7 @@ def set_mailbox_settings(account: str, mailbox_id: str, **kwargs) -> None:
 
 	if not settings:
 		settings = frappe.new_doc("Mailbox Settings")
-		settings.account = account
+		settings.account_id = parse_account(account)[1]
 		settings.mailbox_id = mailbox_id
 		settings.insert()
 
@@ -96,24 +98,18 @@ def set_mailbox_settings(account: str, mailbox_id: str, **kwargs) -> None:
 
 
 def on_doctype_update() -> None:
+	# Mailbox settings are shared per account_id, so uniqueness is on (account_id, mailbox_id).
 	frappe.db.add_unique(
-		"Mailbox Settings", ["account", "mailbox_id"], constraint_name="unique_account_mailbox"
+		"Mailbox Settings", ["account_id", "mailbox_id"], constraint_name="unique_account_id_mailbox"
 	)
 
 
 def get_permission_query_condition(user: str | None = None) -> str:
-	user = user or frappe.session.user
-
-	if is_system_manager(user):
-		return ""
-
-	return f"(`tabMailbox Settings`.user = '{user}')"
+	return get_account_scoped_permission_query("Mailbox Settings", user=user)
 
 
 def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 	if doc.doctype != "Mailbox Settings":
 		return False
 
-	user = doc.user or parse_account(doc.account)[0]
-
-	return has_permission_for_user(user, raise_exception=False)
+	return has_account_scoped_permission(doc, user=user)

--- a/mail/client/doctype/mailbox_settings/mailbox_settings_list.js
+++ b/mail/client/doctype/mailbox_settings/mailbox_settings_list.js
@@ -1,32 +1,4 @@
 // Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.listview_settings['Mailbox Settings'] = {
-	refresh: (listview) => {
-		set_account_options(listview)
-	},
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
-	})
-}
+frappe.listview_settings['Mailbox Settings'] = {}

--- a/mail/client/doctype/participant_identity/participant_identity.py
+++ b/mail/client/doctype/participant_identity/participant_identity.py
@@ -119,7 +119,7 @@ def add_participant_identity(account: str, name: str, email: str, default: bool 
 		"is_default": default,
 	}
 
-	service = get_participant_identity_service(account)
+	service = get_participant_identity_service(*parse_account(account))
 	response = service.create([participant_identity])
 
 	title = _("Participant Identity Creation Error")
@@ -137,7 +137,7 @@ def get_participant_identity(account: str, id: str) -> dict:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_participant_identity_service(account)
+	service = get_participant_identity_service(*parse_account(account))
 	if identities := service.get([id]):
 		return format_participant_identity(account, identities[0])
 
@@ -162,7 +162,7 @@ def update_participant_identity(account: str, id: str, name: str, email: str, de
 		"is_default": default,
 	}
 
-	service = get_participant_identity_service(account)
+	service = get_participant_identity_service(*parse_account(account))
 	response = service.update([participant_identity])
 
 	if not response.get("updated"):
@@ -179,7 +179,7 @@ def delete_participant_identities(account: str, ids: list[str]) -> None:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_participant_identity_service(account)
+	service = get_participant_identity_service(*parse_account(account))
 	response = service.delete(ids)
 
 	if response.get("notDestroyed"):
@@ -198,7 +198,7 @@ def fetch_participant_identities(account: str, page: int = 1, limit: int = 10) -
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_participant_identity_service(account)
+	service = get_participant_identity_service(*parse_account(account))
 	identities = service.get()
 	formatted_identities = [format_participant_identity(account, identity) for identity in identities]
 	frappe.cache.set_value(_get_total_cache_key(account), len(identities), expires_in_sec=600)

--- a/mail/client/doctype/quota/quota.js
+++ b/mail/client/doctype/quota/quota.js
@@ -2,23 +2,30 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Quota', {
+	refresh(frm) {
+		frm.trigger('set_account_options')
+	},
+
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 })

--- a/mail/client/doctype/quota/quota.json
+++ b/mail/client/doctype/quota/quota.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_i7qy",
   "user",
-  "account",
+  "account_id",
   "column_break_mzms",
   "resource_type",
   "section_break_onaw",
@@ -125,15 +125,10 @@
    "read_only": 1
   },
   {
-   "description": "The account this quota belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "no_copy": 1,
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this quota belongs to.",

--- a/mail/client/doctype/quota/quota.py
+++ b/mail/client/doctype/quota/quota.py
@@ -14,6 +14,12 @@ from mail.utils.validation import has_permission_for_user
 
 
 class Quota(Document):
+	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
 	def db_insert(self, *args, **kwargs) -> None:
 		raise NotImplementedError
 
@@ -33,6 +39,8 @@ class Quota(Document):
 		filters = parse_filters(filters)
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view quotas."), alert=True)
@@ -54,6 +62,8 @@ class Quota(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -78,7 +88,7 @@ def get_quota(account: str, id: str, raise_exception: bool = True) -> dict | Non
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_quota_service(account)
+	service = get_quota_service(*parse_account(account))
 
 	if quotas := service.get([id]):
 		return format_quota(account, quotas[0])
@@ -96,7 +106,7 @@ def fetch_quotas(account: str, page: int = 1, limit: int = 10) -> list:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_quota_service(account)
+	service = get_quota_service(*parse_account(account))
 	quotas = service.get()
 	formatted_quotas = [format_quota(account, quota) for quota in quotas]
 	frappe.cache.set_value(_get_total_cache_key(account), len(quotas), expires_in_sec=600)
@@ -112,7 +122,8 @@ def format_quota(account: str, quota: dict) -> dict:
 
 	return {
 		"name": f"{account}|{quota['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": quota["id"],
 		"_name": quota["name"],
 		"resource_type": quota["resourceType"],

--- a/mail/client/doctype/quota/quota_list.js
+++ b/mail/client/doctype/quota/quota_list.js
@@ -15,15 +15,15 @@ function set_account_options(listview) {
 	if (!user) return
 
 	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
+		method: 'mail.jmap.get_user_account_ids',
 		args: {
 			user: user,
 		},
 		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
+			const account_field = listview.page.fields_dict.account_id
 			if (!account_field) return
 
-			const options = r.message
+			const options = r.message || []
 			options.unshift('')
 			account_field.df.options = options
 			account_field.set_options()

--- a/mail/client/doctype/sieve_script/sieve_script.js
+++ b/mail/client/doctype/sieve_script/sieve_script.js
@@ -2,23 +2,30 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Sieve Script', {
+	refresh(frm) {
+		frm.trigger('set_account_options')
+	},
+
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
 	},
 

--- a/mail/client/doctype/sieve_script/sieve_script.json
+++ b/mail/client/doctype/sieve_script/sieve_script.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_iw72",
   "user",
-  "account",
+  "account_id",
   "column_break_cesj",
   "active",
   "read_only",
@@ -108,14 +108,10 @@
    "set_only_once": 1
   },
   {
-   "description": "The account this script belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account",
-   "reqd": 1,
-   "set_only_once": 1
+   "label": "Account ID"
   },
   {
    "description": "The user this script belongs to.",

--- a/mail/client/doctype/sieve_script/sieve_script.py
+++ b/mail/client/doctype/sieve_script/sieve_script.py
@@ -15,6 +15,12 @@ from mail.utils.validation import has_permission_for_user
 
 
 class SieveScript(Document):
+	@property
+	def account(self) -> str:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		return f"{self.user}:{self.account_id}"
+
 	def db_insert(self, *args, **kwargs) -> None:
 		self.id = SieveScript._add_sieve_script(self.account, self._name, self.content, bool(self.active))
 		self.name = f"{self.account}|{self.id}"
@@ -48,6 +54,8 @@ class SieveScript(Document):
 		filters = parse_filters(filters)
 		id = filters.get("id")
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if not account:
 			frappe.msgprint(_("Please select an account to view the Sieve Scripts."), alert=True)
@@ -78,6 +86,8 @@ class SieveScript(Document):
 	def get_count(filters=None, **kwargs) -> int:
 		filters = parse_filters(filters)
 		account = filters.get("account")
+		if not account and filters.get("user") and filters.get("account_id"):
+			account = f"{filters['user']}:{filters['account_id']}"
 
 		if account:
 			if has_permission_for_user(parse_account(account)[0], raise_exception=False):
@@ -108,7 +118,7 @@ class SieveScript(Document):
 			frappe.throw(_("Not allowed to create automation script."))
 
 		creation_id = str(uuid7())
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		sieve_script = {
 			"creation_id": creation_id,
 			"name": name,
@@ -139,7 +149,7 @@ class SieveScript(Document):
 
 		scripts = []
 
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		data = service.query(filter, position, limit)
 
 		ids = data.get("ids", [])
@@ -157,7 +167,7 @@ class SieveScript(Document):
 
 		sieve_scripts = {}
 
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		scripts = service.get(ids)
 
 		if download_content:
@@ -182,7 +192,7 @@ class SieveScript(Document):
 
 		has_permission_for_user(parse_account(account)[0])
 
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		response = service.validate(content)
 
 		if error := response.get("error"):
@@ -207,7 +217,7 @@ class SieveScript(Document):
 
 		has_permission_for_user(parse_account(account)[0])
 
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		scripts = service.get([id])
 
 		if not scripts:
@@ -234,7 +244,7 @@ class SieveScript(Document):
 
 		has_permission_for_user(parse_account(account)[0])
 
-		service = get_sieve_script_service(account)
+		service = get_sieve_script_service(*parse_account(account))
 		response = service.delete(ids)
 
 		if response.get("notDestroyed"):
@@ -291,7 +301,7 @@ def bulk_delete(names: str | list[str]) -> None:
 def get_active_sieve_script_id(account: str) -> str | None:
 	"""Returns the ID of the currently active sieve script for the given account, if any."""
 
-	service = get_sieve_script_service(account)
+	service = get_sieve_script_service(*parse_account(account))
 	query_result = service.query({"isActive": True})
 
 	if query_result.get("ids") and len(query_result["ids"]) > 0:
@@ -302,7 +312,7 @@ def activate_last_active_sieve_script(account: str) -> None:
 	"""Activates the last active sieve script for the given account, if any, and clears the last active sieve script setting."""
 
 	sieve_script_id = frappe.db.get_value(
-		"Account Settings", {"account": account}, "last_active_sieve_script_id"
+		"Account Settings", parse_account(account)[1], "last_active_sieve_script_id"
 	)
 	if not sieve_script_id:
 		return
@@ -325,9 +335,11 @@ def activate_last_active_sieve_script(account: str) -> None:
 def set_last_active_sieve_script_id(account: str, sieve_script_id: str | None = None) -> None:
 	"""Sets the given sieve script ID as the last active sieve script for the given account."""
 
+	from mail.client.doctype.account_settings.account_settings import get_or_create_account_settings
+
 	frappe.db.set_value(
 		"Account Settings",
-		{"account": account},
+		get_or_create_account_settings(account),
 		"last_active_sieve_script_id",
 		sieve_script_id,
 		update_modified=False,
@@ -341,7 +353,8 @@ def format_sieve_script(account: str, script: dict) -> dict:
 
 	return {
 		"name": f"{account}|{script['id']}",
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"id": script["id"],
 		"_name": script["name"],
 		"active": cint(script["isActive"]),

--- a/mail/client/doctype/sieve_script/sieve_script_list.js
+++ b/mail/client/doctype/sieve_script/sieve_script_list.js
@@ -8,6 +8,30 @@ frappe.listview_settings['Sieve Script'] = {
 	},
 }
 
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}
+
 function add_bulk_delete_button_to_actions(listview) {
 	listview.page.add_actions_menu_item(__('Bulk Delete'), () => {
 		const count = listview.get_checked_items().length
@@ -28,29 +52,5 @@ function add_bulk_delete_button_to_actions(listview) {
 				})
 			},
 		)
-	})
-}
-
-function set_account_options(listview) {
-	const user_field = listview.page.fields_dict.user
-	if (!user_field) return
-
-	const user = user_field ? user_field.get_value() : null
-	if (!user) return
-
-	frappe.call({
-		method: 'mail.jmap.get_user_accounts',
-		args: {
-			user: user,
-		},
-		callback: (r) => {
-			const account_field = listview.page.fields_dict.account
-			if (!account_field) return
-
-			const options = r.message
-			options.unshift('')
-			account_field.df.options = options
-			account_field.set_options()
-		},
 	})
 }

--- a/mail/client/doctype/vacation_response/vacation_response.js
+++ b/mail/client/doctype/vacation_response/vacation_response.js
@@ -2,42 +2,30 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Vacation Response', {
-	account(frm) {
-		frm.trigger('get_vacation_response')
+	refresh(frm) {
+		frm.trigger('set_account_options')
 	},
 
 	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	set_account_options(frm) {
 		if (frm.doc.user) {
 			frappe.call({
-				method: 'mail.jmap.get_user_accounts',
+				method: 'mail.jmap.get_user_account_ids',
 				args: {
 					user: frm.doc.user,
 				},
 				callback: (r) => {
-					if (r.message) {
-						frm.set_df_property('account', 'options', r.message)
-						frm.refresh_field('account')
-					}
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
 				},
 			})
 		} else {
-			frm.set_df_property('account', 'options', [])
-			frm.refresh_field('account')
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
 		}
-	},
-
-	get_vacation_response(frm) {
-		frappe.call({
-			doc: frm.doc,
-			method: 'load_from_db',
-			args: {},
-			freeze: true,
-			freeze_message: __('Loading Vacation Response...'),
-			callback: (r) => {
-				if (!r.exc) {
-					frm.refresh()
-				}
-			},
-		})
 	},
 })

--- a/mail/client/doctype/vacation_response/vacation_response.json
+++ b/mail/client/doctype/vacation_response/vacation_response.json
@@ -6,7 +6,7 @@
  "field_order": [
   "section_break_bvdc",
   "user",
-  "account",
+  "account_id",
   "column_break_ksnk",
   "enabled",
   "section_break_rrca",
@@ -83,12 +83,10 @@
    "label": "HTML"
   },
   {
-   "description": "The account this vacation response belongs to.",
-   "fieldname": "account",
+   "fieldname": "account_id",
    "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Account",
-   "reqd": 1
+   "in_standard_filter": 1,
+   "label": "Account ID"
   },
   {
    "description": "The user this vacation response belongs to.",

--- a/mail/client/doctype/vacation_response/vacation_response.py
+++ b/mail/client/doctype/vacation_response/vacation_response.py
@@ -17,17 +17,25 @@ from mail.client.doctype.sieve_script.sieve_script import (
 from mail.jmap import get_vacation_response_service, parse_account
 from mail.utils import convert_html_to_text
 from mail.utils.dt import convert_to_utc
+from mail.utils.user import resolve_account_handle
 from mail.utils.validation import has_permission_for_user
 
 
 class VacationResponse(Document):
+	@property
+	def account(self) -> str | None:
+		"""Full ``user:account_id`` JMAP handle, rebuilt from the selected user and account ID."""
+
+		if self.get("user") and self.get("account_id"):
+			return f"{self.user}:{self.account_id}"
+
+		return None
+
 	def db_insert(self, *args, **kwargs) -> None:
 		raise NotImplementedError
 
 	@frappe.whitelist()
 	def load_from_db(self) -> "VacationResponse":
-		self.account = self.get("account")
-
 		if not self.account:
 			frappe.msgprint(_("Please select an account to view vacation response details."), alert=True)
 			return super(Document, self).__init__({"creation": today(), "modified": today()})
@@ -67,19 +75,21 @@ class VacationResponse(Document):
 
 
 @frappe.whitelist()
-def get_vacation_response(account: str) -> dict:
+def get_vacation_response(account_id: str) -> dict:
 	"""Returns the vacation response settings for the given account."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
-	service = get_vacation_response_service(account)
+	service = get_vacation_response_service(*parse_account(account))
 	vc = service.get()
 	return format_vacation_response(account, vc)
 
 
 @frappe.whitelist()
 def update_vacation_response(
-	account: str,
+	account_id: str,
 	enabled: bool | int,
 	from_date: datetime | str | None = None,
 	to_date: datetime | str | None = None,
@@ -88,6 +98,8 @@ def update_vacation_response(
 	html_body: str | None = None,
 ) -> None:
 	"""Updates the vacation response settings for the given account."""
+
+	account = resolve_account_handle(account_id)
 
 	has_permission_for_user(parse_account(account)[0])
 
@@ -103,7 +115,7 @@ def update_vacation_response(
 
 	current_active_sieve_script_id = get_active_sieve_script_id(account)
 
-	service = get_vacation_response_service(account)
+	service = get_vacation_response_service(*parse_account(account))
 	previous_vacation_response = service.get()
 	vacation_update_result = service.update(
 		{
@@ -134,7 +146,8 @@ def format_vacation_response(account, vc: dict) -> dict:
 	local_to_date = convert_utc_to_system_timezone(get_datetime(to_date)) if to_date else None
 
 	return {
-		"account": account,
+		"account_id": parse_account(account)[1],
+		"user": parse_account(account)[0],
 		"enabled": cint(vc.get("isEnabled")),
 		"from_date": local_from_date,
 		"to_date": local_to_date,

--- a/mail/client/doctype/vacation_response/vacation_response_list.js
+++ b/mail/client/doctype/vacation_response/vacation_response_list.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings['Vacation Response'] = {
+	refresh: (listview) => {
+		set_account_options(listview)
+	},
+}
+
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -163,8 +163,11 @@ permission_query_conditions = {
 	"Principal Settings": "mail.server.doctype.principal_settings.principal_settings.get_permission_query_condition",
 	# Client
 	"Account Settings": "mail.client.doctype.account_settings.account_settings.get_permission_query_condition",
+	"Blocked Email Address": "mail.client.doctype.blocked_email_address.blocked_email_address.get_permission_query_condition",
+	"Junk Email Address": "mail.client.doctype.junk_email_address.junk_email_address.get_permission_query_condition",
 	"Mail Exchange": "mail.client.doctype.mail_exchange.mail_exchange.get_permission_query_condition",
 	"Mail Queue": "mail.client.doctype.mail_queue.mail_queue.get_permission_query_condition",
+	"Mail Sync History": "mail.client.doctype.mail_sync_history.mail_sync_history.get_permission_query_condition",
 	"Mailbox Settings": "mail.client.doctype.mailbox_settings.mailbox_settings.get_permission_query_condition",
 	"User Settings": "mail.client.doctype.user_settings.user_settings.get_permission_query_condition",
 }
@@ -179,13 +182,16 @@ has_permission = {
 	# Client
 	"Account Settings": "mail.client.doctype.account_settings.account_settings.has_permission",
 	"Address Book": "mail.client.doctype.address_book.address_book.has_permission",
+	"Blocked Email Address": "mail.client.doctype.blocked_email_address.blocked_email_address.has_permission",
 	"Calendar": "mail.client.doctype.calendar.calendar.has_permission",
 	"Calendar Event": "mail.client.doctype.calendar_event.calendar_event.has_permission",
 	"Contact Card": "mail.client.doctype.contact_card.contact_card.has_permission",
 	"Event Notification": "mail.client.doctype.event_notification.event_notification.has_permission",
 	"Identity": "mail.client.doctype.identity.identity.has_permission",
+	"Junk Email Address": "mail.client.doctype.junk_email_address.junk_email_address.has_permission",
 	"Mail Exchange": "mail.client.doctype.mail_exchange.mail_exchange.has_permission",
 	"Mail Queue": "mail.client.doctype.mail_queue.mail_queue.has_permission",
+	"Mail Sync History": "mail.client.doctype.mail_sync_history.mail_sync_history.has_permission",
 	"Mailbox": "mail.client.doctype.mailbox.mailbox.has_permission",
 	"Mailbox Settings": "mail.client.doctype.mailbox_settings.mailbox_settings.has_permission",
 	"Participant Identity": "mail.client.doctype.participant_identity.participant_identity.has_permission",

--- a/mail/jmap/__init__.py
+++ b/mail/jmap/__init__.py
@@ -78,133 +78,146 @@ def get_jmap_session_manager(user) -> JMAPSessionManager:
 
 
 def get_address_book_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> AddressBookService:
 	"""Returns an instance of AddressBookService for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return AddressBookService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return AddressBookService(account_id, connection)
 
 
 def get_core_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> CoreService:
 	"""Returns an instance of CoreService for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return CoreService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return CoreService(account_id, connection)
 
 
 def get_blob_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> BlobService:
 	"""Returns an instance of BlobService for handling blob-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return BlobService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return BlobService(account_id, connection)
 
 
 def get_calendar_event_notification_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> CalendarEventNotificationService:
 	"""Returns an instance of CalendarEventNotificationService for handling calendar event notification-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return CalendarEventNotificationService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return CalendarEventNotificationService(account_id, connection)
 
 
 def get_calendar_event_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> CalendarEventService:
 	"""Returns an instance of CalendarEventService for handling calendar event-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return CalendarEventService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return CalendarEventService(account_id, connection)
 
 
 def get_calendar_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> CalendarService:
 	"""Returns an instance of CalendarService for handling calendar-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return CalendarService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return CalendarService(account_id, connection)
 
 
 def get_contact_card_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> ContactCardService:
 	"""Returns an instance of ContactCardService for handling contact card-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return ContactCardService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return ContactCardService(account_id, connection)
 
 
 def get_email_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> EmailService:
 	"""Returns an instance of EmailService for handling email-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return EmailService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return EmailService(account_id, connection)
 
 
 def get_email_submission_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> EmailSubmissionService:
 	"""Returns an instance of EmailSubmissionService for handling email submission-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return EmailSubmissionService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return EmailSubmissionService(account_id, connection)
 
 
 def get_identity_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> IdentityService:
 	"""Returns an instance of IdentityService for handling identity-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return IdentityService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return IdentityService(account_id, connection)
 
 
 def get_mailbox_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> MailboxService:
 	"""Returns an instance of MailboxService for handling mailbox-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return MailboxService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return MailboxService(account_id, connection)
 
 
 def get_participant_identity_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> ParticipantIdentityService:
 	"""Returns an instance of ParticipantIdentityService for handling participant identity-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return ParticipantIdentityService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return ParticipantIdentityService(account_id, connection)
 
 
 def get_principal_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> PrincipalService:
 	"""Returns an instance of PrincipalService for handling principal-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return PrincipalService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return PrincipalService(account_id, connection)
 
 
 def get_push_subscription_service(
@@ -218,81 +231,85 @@ def get_push_subscription_service(
 
 
 def get_quota_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> QuotaService:
 	"""Returns an instance of QuotaService for handling quota-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return QuotaService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return QuotaService(account_id, connection)
 
 
 def get_sieve_script_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> SieveScriptService:
 	"""Returns an instance of SieveScriptService for handling sieve script-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return SieveScriptService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return SieveScriptService(account_id, connection)
 
 
 def get_thread_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> ThreadService:
 	"""Returns an instance of ThreadService for handling thread-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return ThreadService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return ThreadService(account_id, connection)
 
 
 def get_vacation_response_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> VacationResponseService:
 	"""Returns an instance of VacationResponseService for handling vacation response-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return VacationResponseService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return VacationResponseService(account_id, connection)
 
 
 def get_websocket_service(
-	account: str,
+	user: str,
+	account_id: str,
 	ignore_permissions: bool = False,
 ) -> WebSocketService:
 	"""Returns an instance of WebSocketService for handling WebSocket-related operations for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0], ignore_permissions=ignore_permissions)
-	return WebSocketService(account, connection)
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+	return WebSocketService(account_id, connection)
 
 
-def invalidate_jmap_identities_cache(account: str) -> None:
+def invalidate_jmap_identities_cache(account_id: str) -> None:
 	"""Invalidates the JMAP identities cache for the specified account."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(account_id)
 	store.delete_all(Entity.IDENTITY)
 
 
-def invalidate_jmap_mailboxes_cache(account: str) -> None:
+def invalidate_jmap_mailboxes_cache(account_id: str) -> None:
 	"""Invalidates the JMAP mailboxes cache for the specified account."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(account_id)
 	store.delete_all(Entity.MAILBOX)
 
 
-def get_identities(account: str) -> list[dict]:
+def get_identities(user: str, account_id: str) -> list[dict]:
 	"""Returns the list of identities for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = IdentityService(account, connection)
+	connection = get_jmap_connection(user)
+	service = IdentityService(account_id, connection)
 
 	identities = [
 		{
-			"name": f"{account}|{i['id']}",
-			"account": account,
+			"name": f"{user}:{account_id}|{i['id']}",
+			"account_id": account_id,
+			"user": user,
 			"id": i["id"],
 			"_name": i["name"],
 			"email": i["email"].lower(),
@@ -310,28 +327,31 @@ def get_identities(account: str) -> list[dict]:
 	return identities
 
 
-def get_identity_id_by_email(account: str, email: str, raise_exception: bool = False) -> str | None:
+def get_identity_id_by_email(
+	user: str, account_id: str, email: str, raise_exception: bool = False
+) -> str | None:
 	"""Returns the identity ID for the specified email address, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = IdentityService(account, connection)
+	connection = get_jmap_connection(user)
+	service = IdentityService(account_id, connection)
 	return service.get_identity_id_by_email(email, raise_exception=raise_exception)
 
 
-def get_mailboxes(account: str) -> list[dict]:
+def get_mailboxes(user: str, account_id: str) -> list[dict]:
 	"""Returns the list of mailboxes for the specified account."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = MailboxService(account, connection)
+	connection = get_jmap_connection(user)
+	service = MailboxService(account_id, connection)
 
 	mailboxes = [
 		{
-			"name": f"{account}|{m['id']}",
-			"account": account,
+			"name": f"{user}:{account_id}|{m['id']}",
+			"account_id": account_id,
+			"user": user,
 			"id": m["id"],
 			"role": m["role"],
 			"_name": m["name"],
-			"_parent": f"{account}|{m['parentId']}" if m.get("parentId") else None,
+			"_parent": f"{user}:{account_id}|{m['parentId']}" if m.get("parentId") else None,
 			"parent_id": m["parentId"],
 			"subscribed": m["isSubscribed"],
 		}
@@ -342,54 +362,60 @@ def get_mailboxes(account: str) -> list[dict]:
 
 
 def get_mailbox_id_by_role(
-	account: str, role: str, create_if_not_exists: bool = False, raise_exception: bool = False
+	user: str,
+	account_id: str,
+	role: str,
+	create_if_not_exists: bool = False,
+	raise_exception: bool = False,
 ) -> str | None:
 	"""Returns the mailbox ID for the specified role, or None if not found. Optionally creates the mailbox if it does not exist."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = MailboxService(account, connection)
+	connection = get_jmap_connection(user)
+	service = MailboxService(account_id, connection)
 	return service.get_mailbox_id_by_role(
 		role, create_if_not_exists=create_if_not_exists, raise_exception=raise_exception
 	)
 
 
-def get_mailbox_role_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
+def get_mailbox_role_by_id(user: str, account_id: str, id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox role for the specified mailbox ID, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = MailboxService(account, connection)
+	connection = get_jmap_connection(user)
+	service = MailboxService(account_id, connection)
 	return service.get_mailbox_role_by_id(id, raise_exception=raise_exception)
 
 
-def get_mailbox_name_by_id(account: str, id: str, raise_exception: bool = False) -> str | None:
+def get_mailbox_name_by_id(user: str, account_id: str, id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the mailbox name for the specified mailbox ID, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = MailboxService(account, connection)
+	connection = get_jmap_connection(user)
+	service = MailboxService(account_id, connection)
 	return service.get_mailbox_name_by_id(id, raise_exception=raise_exception)
 
 
-def get_mailbox_id_by_name(account: str, name: str, raise_exception: bool = False) -> str | None:
+def get_mailbox_id_by_name(
+	user: str, account_id: str, name: str, raise_exception: bool = False
+) -> str | None:
 	"""Returns the mailbox ID for the specified mailbox name, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = MailboxService(account, connection)
+	connection = get_jmap_connection(user)
+	service = MailboxService(account_id, connection)
 	return service.get_mailbox_id_by_name(name, raise_exception=raise_exception)
 
 
-def get_default_address_book_id(account: str, raise_exception: bool = False) -> str | None:
+def get_default_address_book_id(user: str, account_id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the ID of the default address book for the specified account, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = AddressBookService(account, connection)
+	connection = get_jmap_connection(user)
+	service = AddressBookService(account_id, connection)
 	return service.get_default(raise_exception=raise_exception)
 
 
-def get_default_calendar_id(account: str, raise_exception: bool = False) -> str | None:
+def get_default_calendar_id(user: str, account_id: str, raise_exception: bool = False) -> str | None:
 	"""Returns the ID of the default calendar for the specified account, or None if not found."""
 
-	connection = get_jmap_connection(parse_account(account)[0])
-	service = CalendarService(account, connection)
+	connection = get_jmap_connection(user)
+	service = CalendarService(account_id, connection)
 	return service.get_default(raise_exception=raise_exception)
 
 
@@ -405,41 +431,57 @@ def get_user_accounts(user: str) -> list[str]:
 
 
 @frappe.whitelist()
-def get_mailboxes_for_account(account: str) -> list[dict]:
+def get_user_account_ids(user: str) -> list[str]:
+	"""Returns the JMAP account IDs the specified user has access to."""
+
+	has_permission_for_user(user)
+
+	from mail.client.doctype.user_account.user_account import fetch_user_accounts
+
+	return [a["id"] for a in fetch_user_accounts(user, limit=None)]
+
+
+@frappe.whitelist()
+def get_mailboxes_for_account(user: str, account_id: str) -> list[dict]:
 	"""Returns the list of mailboxes for the specified account."""
 
-	has_permission_for_user(parse_account(account)[0])
-	return get_mailboxes(account)
+	has_permission_for_user(user)
+	return get_mailboxes(user, account_id)
 
 
 @frappe.whitelist()
 def get_mailbox_id_for_account(
-	account: str, role: str, create_if_not_exists: bool = False, raise_exception: bool = False
+	user: str,
+	account_id: str,
+	role: str,
+	create_if_not_exists: bool = False,
+	raise_exception: bool = False,
 ) -> str | None:
 	"""Returns the mailbox ID for the specified role, or None if not found. Optionally creates the mailbox if it does not exist."""
 
-	has_permission_for_user(parse_account(account)[0])
+	has_permission_for_user(user)
 	return get_mailbox_id_by_role(
-		account, role, create_if_not_exists=create_if_not_exists, raise_exception=raise_exception
+		user, account_id, role, create_if_not_exists=create_if_not_exists, raise_exception=raise_exception
 	)
 
 
 @frappe.whitelist()
-def get_mailbox_name_for_account(account: str, id: str, raise_exception: bool = False) -> str | None:
+def get_mailbox_name_for_account(
+	user: str, account_id: str, id: str, raise_exception: bool = False
+) -> str | None:
 	"""Returns the mailbox name for the specified mailbox ID, or None if not found."""
 
-	has_permission_for_user(parse_account(account)[0])
-	return get_mailbox_name_by_id(account, id, raise_exception=raise_exception)
+	has_permission_for_user(user)
+	return get_mailbox_name_by_id(user, account_id, id, raise_exception=raise_exception)
 
 
 @frappe.whitelist()
-def make_jmap_request(account: str, capabilities: list[str], method_calls: list[list]) -> Any:
+def make_jmap_request(user: str, account_id: str, capabilities: list[str], method_calls: list[list]) -> Any:
 	"""Makes a JMAP request on behalf of the specified account, with the given method calls."""
 
-	user = parse_account(account)[0]
 	has_permission_for_user(user)
 
 	connection = get_jmap_connection(user)
-	service = CoreService(account, connection)
+	service = CoreService(account_id, connection)
 
 	return service._call(capabilities, method_calls)

--- a/mail/jmap/services/calendars/calendar_event.py
+++ b/mail/jmap/services/calendars/calendar_event.py
@@ -27,12 +27,12 @@ class CalendarEventService(CalendarsService):
 				calendar_ids = event.get("calendar_ids")
 				if not calendar_ids:
 					calendar_ids = [
-						CalendarService(self.account, self.connection).get_default(raise_exception=True)
+						CalendarService(self.account_id, self.connection).get_default(raise_exception=True)
 					]
 
 				organizer = event.get("organizer")
 				if not organizer:
-					organizer = ParticipantIdentityService(self.account, self.connection).get_default(
+					organizer = ParticipantIdentityService(self.account_id, self.connection).get_default(
 						raise_exception=True
 					)
 
@@ -104,7 +104,7 @@ class CalendarEventService(CalendarsService):
 				calendar_ids = event.get("calendar_ids")
 				if not calendar_ids:
 					calendar_ids = [
-						CalendarService(self.account, self.connection).get_default(raise_exception=True)
+						CalendarService(self.account_id, self.connection).get_default(raise_exception=True)
 					]
 
 				payload[event["id"]] = {

--- a/mail/jmap/services/core.py
+++ b/mail/jmap/services/core.py
@@ -49,11 +49,14 @@ class CoreService(CoreServiceHelper):
 
 	capabilities: ClassVar[list[str]] = ["urn:ietf:params:jmap:core"]
 
-	def __init__(self, account: str, connection: JMAPConnection) -> None:
-		"""Initializes the CoreService with the provided account and JMAP connection."""
+	def __init__(self, account_id: str, connection: JMAPConnection) -> None:
+		"""Initializes the CoreService with the provided account ID and JMAP connection.
 
-		self.account = account
-		self.account_id = parse_account(account)[1]
+		The connection carries the authenticated user; only the JMAP ``account_id`` is needed
+		to scope requests (and as the cache key, since account data is shared across the users
+		who have access to it)."""
+
+		self.account_id = account_id
 		self.connection = connection
 
 	def __post_init__(self) -> None:
@@ -64,16 +67,16 @@ class CoreService(CoreServiceHelper):
 
 	@classmethod
 	def invalidate_cache(
-		cls, account: str | None = None, key: Literal["identities", "mailboxes"] | None = None
+		cls, account_id: str | None = None, key: Literal["identities", "mailboxes"] | None = None
 	) -> None:
 		"""Invalidates the cache for a specific account and key, or for all accounts and keys if no parameters are provided."""
 
-		if account:
+		if account_id:
 			if key:
-				if account in cls._cache and key in cls._cache[account]:
-					del cls._cache[account][key]  # Remove the specific key from the account's cache
+				if account_id in cls._cache and key in cls._cache[account_id]:
+					del cls._cache[account_id][key]  # Remove the specific key from the account's cache
 			else:
-				cls._cache.pop(account, None)  # Remove the entire cache for the specified account
+				cls._cache.pop(account_id, None)  # Remove the entire cache for the specified account
 		else:
 			if key:
 				for account_cache in cls._cache.values():  # Remove the specific key from all account caches
@@ -96,12 +99,12 @@ class CoreService(CoreServiceHelper):
 	def cache(self) -> dict:
 		"""Returns the cache for the current account, creating a new cache entry if it does not exist."""
 
-		if self.account in self._cache:
-			return self._cache[self.account]
+		if self.account_id in self._cache:
+			return self._cache[self.account_id]
 
-		self._cache[self.account] = {}
+		self._cache[self.account_id] = {}
 
-		return self._cache[self.account]
+		return self._cache[self.account_id]
 
 	@property
 	def core(self) -> dict:
@@ -186,7 +189,7 @@ class CoreService(CoreServiceHelper):
 
 		from mail.jmap.services.mail.identity import IdentityService
 
-		identities = IdentityService(self.account, self.connection).get()
+		identities = IdentityService(self.account_id, self.connection).get()
 		self.cache["identities"] = identities
 
 		return identities
@@ -200,7 +203,7 @@ class CoreService(CoreServiceHelper):
 
 		from mail.jmap.services.mail.mailbox import MailboxService
 
-		mailboxes = MailboxService(self.account, self.connection).get()
+		mailboxes = MailboxService(self.account_id, self.connection).get()
 		self.cache["mailboxes"] = mailboxes
 
 		return mailboxes
@@ -211,7 +214,7 @@ class CoreService(CoreServiceHelper):
 
 		from mail.jmap.services.contacts.address_book import AddressBookService
 
-		return AddressBookService(self.account, self.connection).get()
+		return AddressBookService(self.account_id, self.connection).get()
 
 	@cached_property
 	def calendars(self) -> list[dict]:
@@ -219,7 +222,7 @@ class CoreService(CoreServiceHelper):
 
 		from mail.jmap.services.calendars.calendar import CalendarService
 
-		return CalendarService(self.account, self.connection).get()
+		return CalendarService(self.account_id, self.connection).get()
 
 	@cached_property
 	def participant_identities(self) -> list[dict]:
@@ -227,7 +230,7 @@ class CoreService(CoreServiceHelper):
 
 		from mail.jmap.services.calendars.participant_identity import ParticipantIdentityService
 
-		return ParticipantIdentityService(self.account, self.connection).get()
+		return ParticipantIdentityService(self.account_id, self.connection).get()
 
 	def validate_capabilities(self, required_capabilities: list[str], raise_exception: bool = False) -> bool:
 		"""Validates that the required capabilities are supported by the JMAP server."""

--- a/mail/jmap/services/mail/email.py
+++ b/mail/jmap/services/mail/email.py
@@ -29,7 +29,7 @@ class EmailService(MailService):
 		draft_calls, draft_refs = self._create(emails, call_id_gen)
 		method_calls.extend(draft_calls)
 
-		submission_service = EmailSubmissionService(self.account, self.connection)
+		submission_service = EmailSubmissionService(self.account_id, self.connection)
 		submission_calls = submission_service._create(emails, draft_refs, call_id_gen)
 		method_calls.extend(submission_calls)
 
@@ -357,7 +357,7 @@ class EmailService(MailService):
 		method_calls = []
 		draft_refs = {}
 
-		mailbox_service = MailboxService(self.account, self.connection)
+		mailbox_service = MailboxService(self.account_id, self.connection)
 		draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
 			"drafts", create_if_not_exists=True, raise_exception=True
 		)

--- a/mail/jmap/services/mail/mailbox.py
+++ b/mail/jmap/services/mail/mailbox.py
@@ -120,7 +120,7 @@ class MailboxService(MailService):
 			if raise_exception:
 				raise ValueError(f"Failed to create mailbox with role '{role}'")
 
-		self.invalidate_cache(self.account, key="mailboxes")
+		self.invalidate_cache(self.account_id, key="mailboxes")
 
 		return find_id(role)
 

--- a/mail/jmap/services/mail/submission/email_submission.py
+++ b/mail/jmap/services/mail/submission/email_submission.py
@@ -41,8 +41,8 @@ class EmailSubmissionService(CoreService):
 
 		method_calls = []
 
-		identity_service = IdentityService(self.account, self.connection)
-		mailbox_service = MailboxService(self.account, self.connection)
+		identity_service = IdentityService(self.account_id, self.connection)
+		mailbox_service = MailboxService(self.account_id, self.connection)
 
 		draft_mailbox_id = mailbox_service.get_mailbox_id_by_role(
 			"drafts", create_if_not_exists=True, raise_exception=True

--- a/mail/jmap/services/push_subscription.py
+++ b/mail/jmap/services/push_subscription.py
@@ -15,8 +15,9 @@ class PushSubscriptionService(CoreService):
 		"""Initializes the PushSubscriptionService with the provided user and JMAP connection."""
 
 		self.connection = connection
-		self.account_id = self.primary_account_id
-		self.account = f"{user}:{self.account_id}"
+		# PushSubscription is not account-scoped (requests omit accountId); use a per-user
+		# cache key so subscriptions for different users don't collide.
+		self.account_id = f"{user}:{self.primary_account_id}"
 
 	def create(self, subscriptions: list[dict]) -> dict:
 		"""Public method to create push subscriptions, handling batching if the number of subscriptions exceeds the server's maximum allowed in a single 'set' call."""

--- a/mail/patches.txt
+++ b/mail/patches.txt
@@ -2,6 +2,7 @@
 mail.patches.rename_mail_principal_binding_to_principal_settings
 mail.patches.capture_user_outgoing_settings
 mail.patches.rebuild_rate_limit_unique_constraint
+mail.patches.refactor_account_settings
 
 [post_model_sync]
 mail.patches.migrate_outgoing_settings_to_account
@@ -17,3 +18,10 @@ mail.patches.set_user_account
 mail.patches.create_archive_mailbox
 mail.patches.migrate_data_store_to_lmdb
 mail.patches.backfill_blocked_email_account_id
+mail.patches.backfill_junk_email_account_id
+mail.patches.backfill_mailbox_settings_account_id
+mail.patches.backfill_mail_exchange_account_id
+mail.patches.backfill_mail_sync_history_account_id
+mail.patches.backfill_mail_queue_account_id
+mail.patches.clear_legacy_user_scoped_stores
+mail.patches.clear_legacy_blob_store_layout

--- a/mail/patches/backfill_blocked_email_account_id.py
+++ b/mail/patches/backfill_blocked_email_account_id.py
@@ -12,6 +12,11 @@ def execute() -> None:
 	(account_id, email) and fills account_id in, and drops the now-redundant per-handle index.
 	"""
 
+	if not frappe.db.has_column("Blocked Email Address", "account"):
+		# The per-user `account` handle was later dropped (block list shared per account_id);
+		# nothing to backfill on fresh installs.
+		return
+
 	rows = frappe.get_all(
 		"Blocked Email Address",
 		fields=["name", "account", "email"],

--- a/mail/patches/backfill_junk_email_account_id.py
+++ b/mail/patches/backfill_junk_email_account_id.py
@@ -1,0 +1,53 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Junk Email Address.account_id` from the per-user "user:account_id" handle so the
+	junk list is keyed on the shared account_id rather than per user.
+
+	The (account_id, email) unique index is added during model sync, when existing rows still have a
+	NULL account_id (NULLs are distinct, so the index applies cleanly). This patch then deduplicates
+	(account_id, email) and fills account_id in, and drops the now-redundant per-handle index.
+	"""
+
+	if not frappe.db.has_column("Junk Email Address", "account"):
+		# Fresh install (or already migrated) — nothing to backfill.
+		return
+
+	rows = frappe.get_all(
+		"Junk Email Address",
+		fields=["name", "account", "email"],
+		order_by="creation asc",
+	)
+
+	seen: set[tuple[str, str]] = set()
+	duplicates: list[str] = []
+	updates: list[tuple[str, str]] = []
+
+	for row in rows:
+		try:
+			account_id = parse_account(row.account)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		key = (account_id, row.email)
+		if key in seen:
+			duplicates.append(row.name)
+		else:
+			seen.add(key)
+			updates.append((row.name, account_id))
+
+	# Drop redundant duplicate junk rules first (same address junked by multiple users on a shared
+	# account) so populating account_id can't violate the unique (account_id, email) index. The set
+	# of junked addresses per account is unchanged, so the sieve scripts don't need regenerating.
+	if duplicates:
+		frappe.db.delete("Junk Email Address", {"name": ["in", duplicates]})
+
+	for name, account_id in updates:
+		frappe.db.set_value("Junk Email Address", name, "account_id", account_id, update_modified=False)
+
+	# The junk list is keyed on account_id now; drop the stale per-handle unique index.
+	if frappe.db.has_index("tabJunk Email Address", "unique_account_junk_email"):
+		frappe.db.sql_ddl("ALTER TABLE `tabJunk Email Address` DROP INDEX `unique_account_junk_email`")

--- a/mail/patches/backfill_mail_exchange_account_id.py
+++ b/mail/patches/backfill_mail_exchange_account_id.py
@@ -1,0 +1,27 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Mail Exchange.account_id` from the old "user:account_id" handle.
+
+	The `account` handle was replaced by a bare `account_id` (the `user` field still carries
+	the credentials used to authenticate the import/export). Each row keeps its user, so we
+	just split the stored handle to fill account_id in.
+	"""
+
+	if not frappe.db.has_column("Mail Exchange", "account"):
+		# Fresh install (or already migrated) — nothing to backfill.
+		return
+
+	for row in frappe.get_all("Mail Exchange", fields=["name", "account"]):
+		if not row.account:
+			continue
+
+		try:
+			account_id = parse_account(row.account)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		frappe.db.set_value("Mail Exchange", row.name, "account_id", account_id, update_modified=False)

--- a/mail/patches/backfill_mail_queue_account_id.py
+++ b/mail/patches/backfill_mail_queue_account_id.py
@@ -1,0 +1,29 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Mail Queue.account_id` from the old "user:account_id" handle.
+
+	The `account` handle was replaced by a bare `account_id` (the `user` field still carries
+	the credentials used to send the message). Each row keeps its user, so we just split the
+	stored handle to fill account_id in.
+	"""
+
+	if not frappe.db.has_column("Mail Queue", "account"):
+		# Fresh install (or already migrated) — nothing to backfill.
+		return
+
+	MQ = frappe.qb.DocType("Mail Queue")
+
+	# Map each distinct handle to its account id and update in bulk (Mail Queue can be large).
+	handles = frappe.qb.from_(MQ).select(MQ.account).distinct().where(MQ.account.isnotnull()).run(pluck=True)
+
+	for handle in handles:
+		try:
+			account_id = parse_account(handle)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		(frappe.qb.update(MQ).set(MQ.account_id, account_id).where(MQ.account == handle)).run()

--- a/mail/patches/backfill_mail_sync_history_account_id.py
+++ b/mail/patches/backfill_mail_sync_history_account_id.py
@@ -1,0 +1,55 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Mail Sync History.account_id` from the per-user "user:account_id" handle so the
+	sync watermark is keyed on the shared account_id rather than per user.
+
+	The (account_id, source) unique index is added during model sync, when existing rows still have
+	a NULL account_id (NULLs are distinct, so the index applies cleanly). This patch then
+	deduplicates (account_id, source) and fills account_id in, and drops the now-redundant per-handle
+	index.
+	"""
+
+	if not frappe.db.has_column("Mail Sync History", "account"):
+		# The per-user `account` handle was later dropped (watermark shared per account_id);
+		# nothing to backfill on fresh installs.
+		return
+
+	rows = frappe.get_all(
+		"Mail Sync History",
+		fields=["name", "account", "source", "last_received_at"],
+		order_by="last_received_at desc",
+	)
+
+	seen: set[tuple[str, str]] = set()
+	duplicates: list[str] = []
+	updates: list[tuple[str, str]] = []
+
+	for row in rows:
+		try:
+			account_id = parse_account(row.account)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		key = (account_id, row.source)
+		if key in seen:
+			duplicates.append(row.name)
+		else:
+			seen.add(key)
+			updates.append((row.name, account_id))
+
+	# Drop redundant duplicate rows first (same source synced by multiple users on a shared account)
+	# so populating account_id can't violate the unique (account_id, source) index. Rows are ordered
+	# by most-recent last_received_at, so the freshest watermark per (account_id, source) is kept.
+	if duplicates:
+		frappe.db.delete("Mail Sync History", {"name": ["in", duplicates]})
+
+	for name, account_id in updates:
+		frappe.db.set_value("Mail Sync History", name, "account_id", account_id, update_modified=False)
+
+	# The watermark is keyed on account_id now; drop the stale per-handle unique index.
+	if frappe.db.has_index("tabMail Sync History", "unique_account_source"):
+		frappe.db.sql_ddl("ALTER TABLE `tabMail Sync History` DROP INDEX `unique_account_source`")

--- a/mail/patches/backfill_mailbox_settings_account_id.py
+++ b/mail/patches/backfill_mailbox_settings_account_id.py
@@ -1,0 +1,55 @@
+import frappe
+
+from mail.jmap import parse_account
+
+
+def execute() -> None:
+	"""Backfill `Mailbox Settings.account_id` from the per-user "user:account_id" handle so the
+	mailbox settings are keyed on the shared account_id rather than per user.
+
+	The (account_id, mailbox_id) unique index is added during model sync, when existing rows still
+	have a NULL account_id (NULLs are distinct, so the index applies cleanly). This patch then
+	deduplicates (account_id, mailbox_id) and fills account_id in, and drops the now-redundant
+	per-handle index.
+	"""
+
+	if not frappe.db.has_column("Mailbox Settings", "account"):
+		# The per-user `account` handle was later dropped (settings shared per account_id);
+		# nothing to backfill on fresh installs.
+		return
+
+	rows = frappe.get_all(
+		"Mailbox Settings",
+		fields=["name", "account", "mailbox_id"],
+		order_by="creation asc",
+	)
+
+	seen: set[tuple[str, str]] = set()
+	duplicates: list[str] = []
+	updates: list[tuple[str, str]] = []
+
+	for row in rows:
+		try:
+			account_id = parse_account(row.account)[1]
+		except Exception:
+			continue  # skip malformed handles rather than abort the migration
+
+		key = (account_id, row.mailbox_id)
+		if key in seen:
+			duplicates.append(row.name)
+		else:
+			seen.add(key)
+			updates.append((row.name, account_id))
+
+	# Drop redundant duplicate settings first (same mailbox configured by multiple users on a shared
+	# account) so populating account_id can't violate the unique (account_id, mailbox_id) index. The
+	# earliest row per (account_id, mailbox_id) wins.
+	if duplicates:
+		frappe.db.delete("Mailbox Settings", {"name": ["in", duplicates]})
+
+	for name, account_id in updates:
+		frappe.db.set_value("Mailbox Settings", name, "account_id", account_id, update_modified=False)
+
+	# The settings are keyed on account_id now; drop the stale per-handle unique index.
+	if frappe.db.has_index("tabMailbox Settings", "unique_account_mailbox"):
+		frappe.db.sql_ddl("ALTER TABLE `tabMailbox Settings` DROP INDEX `unique_account_mailbox`")

--- a/mail/patches/clear_legacy_blob_store_layout.py
+++ b/mail/patches/clear_legacy_blob_store_layout.py
@@ -1,0 +1,19 @@
+import os
+import shutil
+
+from mail.storage import _get_blob_base_path
+
+
+def execute() -> None:
+	"""Drop the blob store after switching it to a per-account directory layout.
+
+	Blobs used to be stored as flat files (one per ``account_id:blob_id`` key) directly in the
+	blob-store base path, optionally split across ``shard-NN`` directories. They are now stored
+	inside a directory named by the account ID, so the old files are unreachable under the new
+	layout. The blob store is a cache, so we drop it once; it rebuilds on demand as blobs are
+	re-fetched from the JMAP server.
+	"""
+
+	base_path = _get_blob_base_path()
+	if os.path.exists(base_path):
+		shutil.rmtree(base_path, ignore_errors=True)

--- a/mail/patches/clear_legacy_user_scoped_stores.py
+++ b/mail/patches/clear_legacy_user_scoped_stores.py
@@ -1,0 +1,23 @@
+import os
+import shutil
+
+from mail.storage import _get_blob_base_path, _get_data_base_path
+from mail.storage.data_store import DataStore
+
+
+def execute() -> None:
+	"""Clear the data and blob stores after switching them from per-user to per-account keys.
+
+	The stores used to be keyed by ``user:account_id``; they are now keyed by the bare
+	``account_id`` so all users of a shared account hit the same cache. The old per-user
+	directories/files are unreachable under the new keys, so we drop both stores once. They
+	rebuild on demand — cached JMAP data (identities, mailboxes, emails, contacts, blobs) is
+	re-fetched, and the email sync state simply re-initialises on the next pull.
+	"""
+
+	# Release any LMDB environments this process has open before removing their files.
+	DataStore.close_all_envs()
+
+	for base_path in (_get_data_base_path(), _get_blob_base_path()):
+		if os.path.exists(base_path):
+			shutil.rmtree(base_path, ignore_errors=True)

--- a/mail/patches/create_archive_mailbox.py
+++ b/mail/patches/create_archive_mailbox.py
@@ -4,5 +4,12 @@ from mail.client.doctype.account_settings.account_settings import create_archive
 
 
 def execute() -> None:
+	# Account Settings was later reshaped to be shared per account ID, dropping the
+	# `account` (`user:account_id`) column. Without it we can't build the per-user JMAP
+	# connection this patch needs, so it only runs against the legacy schema; the archive
+	# mailbox is created on demand by Account Settings.after_insert thereafter.
+	if not frappe.db.has_column("Account Settings", "account"):
+		return
+
 	for account in frappe.get_all("Account Settings", pluck="account"):
 		create_archive_mailbox(account)

--- a/mail/patches/migrate_data_store_to_lmdb.py
+++ b/mail/patches/migrate_data_store_to_lmdb.py
@@ -9,6 +9,9 @@ from mail.storage.base_store import BaseStore
 from mail.storage.data_store import DataStore, Entity, env_dirname
 
 SEPARATOR = BaseStore.SEPARATOR
+# The legacy RocksDB DataStore hash-sharded accounts into ``shard-NN`` directories. Sharding has
+# since been removed from the storage layer, so this one-time migration keeps its own constant.
+SHARD_DIR_PREFIX = "shard-"
 ENTITY_VALUES = {entity.value for entity in Entity}
 
 
@@ -32,7 +35,7 @@ def execute() -> None:
 	shard_dirs = sorted(
 		entry.path
 		for entry in os.scandir(base_path)
-		if entry.is_dir() and entry.name.startswith(BaseStore.SHARD_DIR_PREFIX)
+		if entry.is_dir() and entry.name.startswith(SHARD_DIR_PREFIX)
 	)
 	if not shard_dirs:
 		return

--- a/mail/patches/migrate_outgoing_settings_to_account.py
+++ b/mail/patches/migrate_outgoing_settings_to_account.py
@@ -13,6 +13,12 @@ def execute() -> None:
 	each account's identities by a background job once migrate is done.
 	"""
 
+	# Account Settings was later reshaped to be shared per account ID, dropping the
+	# `user`/`account` columns (see refactor_account_settings). When those columns are
+	# gone there is nothing for this legacy patch to migrate.
+	if not frappe.db.has_column("Account Settings", "account"):
+		return
+
 	captured = frappe.cache.get_value(CACHE_KEY)
 	by_user = frappe.parse_json(captured) if captured else {}
 

--- a/mail/patches/refactor_account_settings.py
+++ b/mail/patches/refactor_account_settings.py
@@ -1,0 +1,65 @@
+import frappe
+
+from mail.patches.capture_user_outgoing_settings import CACHE_KEY
+
+
+def execute() -> None:
+	"""Reshape Account Settings into a per-account-ID, shared document.
+
+	Previously each document was per user, named by a UUID, with `user` and `account`
+	(`user:account_id`) columns. The document is now named by the bare JMAP account ID
+	and shared across every user with access. This runs pre_model_sync (while the old
+	columns still exist) to rename/dedupe documents to their account ID. The first
+	document per account ID wins; the rest are dropped.
+	"""
+
+	if not frappe.db.has_column("Account Settings", "account"):
+		# Fresh install (or already migrated) — nothing to reshape.
+		return
+
+	captured = frappe.cache.get_value(CACHE_KEY)
+	by_user = frappe.parse_json(captured) if captured else {}
+
+	seen: set[str] = set()
+	rows = frappe.db.get_all(
+		"Account Settings",
+		fields=["name", "account", "user"],
+		order_by="creation asc",
+	)
+
+	for row in rows:
+		account = (row.get("account") or "").strip()
+		account_id = account.split(":", 1)[1].strip() if ":" in account else ""
+
+		if not account_id or account_id in seen or frappe.db.exists("Account Settings", account_id):
+			frappe.delete_doc(
+				"Account Settings", row["name"], force=True, ignore_permissions=True, delete_permanently=True
+			)
+			continue
+
+		# Apply any per-user Outgoing settings captured before they were dropped from
+		# User Settings (no-op on sites that already ran migrate_outgoing_settings_to_account).
+		if old := by_user.get(row.get("user")):
+			frappe.db.set_value(
+				"Account Settings",
+				row["name"],
+				{
+					"default_outgoing_email": old.get("default_outgoing_email"),
+					"create_contacts_after_email_submit": old.get("create_contacts_after_email_submit") or 0,
+					"destroy_email_after_submit": old.get("destroy_email_after_submit") or 0,
+					"destroy_newsletter_after_submit": old.get("destroy_newsletter_after_submit") or 0,
+				},
+				update_modified=False,
+			)
+
+		seen.add(account_id)
+		frappe.rename_doc(
+			"Account Settings",
+			row["name"],
+			account_id,
+			force=True,
+			show_alert=False,
+		)
+
+	if captured:
+		frappe.cache.delete_value(CACHE_KEY)

--- a/mail/patches/set_user_account.py
+++ b/mail/patches/set_user_account.py
@@ -1,67 +1,10 @@
-import frappe
-from frappe import _
-from frappe.query_builder import Case
-
-from mail.utils import log_error
-from mail.utils.user import get_user_personal_account
-
-DOCTYPES = [
-	"Mail Exchange",
-	"Mail Queue",
-	"Mail Sync History",
-	"Mailbox Settings",
-	"Blocked Email Address",
-]
-
-
 def execute() -> None:
-	cached_user_accounts = {}
+	"""Obsolete: backfilled the per-user `account` (user:account_id) handle on several client
+	doctypes.
 
-	for doctype in DOCTYPES:
-		try:
-			DOCTYPE = frappe.qb.DocType(doctype)
-			USER_SETTINGS = frappe.qb.DocType("User Settings")
-			users = (
-				frappe.qb.from_(DOCTYPE)
-				.join(USER_SETTINGS)
-				.on(DOCTYPE.user == USER_SETTINGS.user)
-				.select(DOCTYPE.user)
-				.distinct()
-				.where(
-					(DOCTYPE.user.isnotnull())
-					& (DOCTYPE.account.isnull())
-					& (USER_SETTINGS.username.isnotnull())
-				)
-			).run(pluck="user")
+	Every doctype it targeted (Mail Exchange, Mail Queue, Mail Sync History, Mailbox Settings,
+	Blocked Email Address) was later reshaped to key on a bare `account_id`, dropping the `account`
+	column this patch wrote to. It already ran on existing sites; there is nothing left to do.
+	"""
 
-			if not users:
-				continue
-
-			user_to_account = {}
-
-			for user in users:
-				if user not in cached_user_accounts:
-					cached_user_accounts[user] = get_user_personal_account(user, raise_exception=False)
-
-				account = cached_user_accounts[user]
-				if account:
-					user_to_account[user] = account
-
-			if not user_to_account:
-				continue
-
-			case_stmt = Case()
-			for user, account in user_to_account.items():
-				case_stmt = case_stmt.when(DOCTYPE.user == user, account)
-
-			(
-				frappe.qb.update(DOCTYPE)
-				.set(DOCTYPE.account, case_stmt)
-				.where((DOCTYPE.user.isin(list(user_to_account.keys()))) & (DOCTYPE.account.isnull()))
-			).run()
-
-		except Exception as e:
-			log_error(
-				_("Error while setting user account for {0}").format(doctype),
-				str(e),
-			)
+	return

--- a/mail/storage/__init__.py
+++ b/mail/storage/__init__.py
@@ -1,31 +1,72 @@
 import os
+import shutil
 
 import frappe
 from frappe.utils import get_bench_path
 
 from mail.storage.blob_store import BlobStore
 from mail.storage.data_store import DataStore
-from mail.utils import get_mail_config
 
 
-def get_data_store(user: str, account_id: str | None = None) -> DataStore:
-	"""Factory function to create a DataStore instance for the given user and account ID."""
+def _get_data_base_path() -> str:
+	"""Helper function to get the base path for data storage."""
 
-	base_path = os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "data-store")
-	key = f"{user}{DataStore.SEPARATOR}{account_id}" if account_id else user
-
-	return DataStore(base_path=base_path, key=key)
+	return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "data-store")
 
 
-def get_blob_store(user: str, account_id: str | None = None) -> "BlobStore":
-	"""Factory function to create a BlobStore instance for the given user and account ID."""
+def _get_blob_base_path() -> str:
+	"""Helper function to get the base path for blob storage."""
 
-	base_path = os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
-	key = f"{user}{BlobStore.SEPARATOR}{account_id}" if account_id else user
-	shard_count = get_mail_config("storage_shard_count")
+	return os.path.join(get_bench_path(), "sites", frappe.local.site, "private", "files", "blob-store")
 
-	return BlobStore(
-		base_path=base_path,
-		key=key,
-		shard_count=shard_count,
-	)
+
+def get_data_store(account_id: str) -> DataStore:
+	"""Factory function to create a DataStore instance for the given JMAP account ID.
+
+	The store is keyed solely by the account ID, so every user with access to a shared
+	account reads and writes the same cache. LMDB serves concurrent access natively —
+	many lock-free readers via MVCC snapshots and a single serialized writer — so multiple
+	users (and worker processes) can hit the same account's store safely.
+	"""
+
+	base_path = _get_data_base_path()
+
+	return DataStore(base_path=base_path, key=account_id)
+
+
+@frappe.whitelist()
+def destroy_data_store() -> None:
+	"""Utility function to destroy the data store."""
+
+	from mail.utils.user import is_system_manager
+
+	if is_system_manager(frappe.session.user):
+		base_path = _get_data_base_path()
+		if os.path.exists(base_path):
+			shutil.rmtree(base_path)
+
+
+def get_blob_store(account_id: str) -> "BlobStore":
+	"""Factory function to create a BlobStore instance for the given JMAP account ID.
+
+	Each account's blobs live in their own directory named by the account ID, so the blob
+	cache is shared across every user of an account. Writes are atomic (temp file +
+	``os.replace``) and reads open the file independently, so concurrent access from multiple
+	users/processes is safe.
+	"""
+
+	base_path = _get_blob_base_path()
+
+	return BlobStore(base_path=base_path, key=account_id)
+
+
+@frappe.whitelist()
+def destroy_blob_store() -> None:
+	"""Utility function to destroy the blob store."""
+
+	from mail.utils.user import is_system_manager
+
+	if is_system_manager(frappe.session.user):
+		base_path = _get_blob_base_path()
+		if os.path.exists(base_path):
+			shutil.rmtree(base_path)

--- a/mail/storage/base_store.py
+++ b/mail/storage/base_store.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 from threading import RLock
 from typing import ClassVar
@@ -10,7 +9,6 @@ from mail.utils.logger import get_storage_logger
 
 class BaseStore:
 	SEPARATOR: ClassVar[str] = ":"
-	SHARD_DIR_PREFIX: ClassVar[str] = "shard-"
 	_PROCESS_LOCKS: ClassVar[dict[str, RLock]] = {}
 	_PROCESS_LOCKS_GUARD: ClassVar[RLock] = RLock()
 
@@ -18,13 +16,11 @@ class BaseStore:
 		self,
 		base_path: str,
 		key: str,
-		shard_count: int = 1,
 	) -> None:
-		"""Initialize the storage with base path, key, and optional sharding parameters."""
+		"""Initialize the storage with the base path and key."""
 
 		self.base_path = base_path
 		self.key = key
-		self.shard_count = max(1, shard_count)
 
 		self.logger_context = {"req_id": random_string(10), "key": self.key}
 		self.logger = get_storage_logger(self.logger_context)
@@ -35,18 +31,9 @@ class BaseStore:
 		self._prefix = f"{self.key}{self.SEPARATOR}"
 
 	def _get_storage_path(self) -> str:
-		"""Return the shard path for this key, or the base path when sharding is disabled."""
+		"""Return the storage path for this store; subclasses scope it per key."""
 
-		if self.shard_count == 1:
-			return self.base_path
-
-		shard = self._get_shard_index()
-		return os.path.join(self.base_path, f"{self.SHARD_DIR_PREFIX}{shard:02d}")
-
-	def _get_shard_index(self) -> int:
-		"""Calculate the shard index for the current key based on its hash."""
-
-		return int(hashlib.sha256(self.key.encode()).hexdigest(), 16) % self.shard_count
+		return self.base_path
 
 	def _get_process_lock(self, path: str | None = None) -> RLock:
 		"""Return a process-local lock shared by all storage instances for the same path."""

--- a/mail/storage/blob_store.py
+++ b/mail/storage/blob_store.py
@@ -11,23 +11,31 @@ from mail.storage.base_store import BaseStore
 
 
 class BlobStore(BaseStore):
-	"""A simple blob storage backed by the local file system."""
+	"""A blob storage backed by the local file system.
+
+	Each account's blobs live in their own directory named by the account ID
+	(``<base_path>/<account_id>/``); files inside are named by their encoded blob key.
+	"""
 
 	def __init__(
 		self,
 		base_path: str,
 		key: str,
-		shard_count: int = 1,
 	) -> None:
-		"""Initialize the storage with base path, key, and optional sharding parameters."""
+		"""Initialize per-account blob storage rooted at ``<base_path>/<account_id>``."""
 
-		super().__init__(
-			base_path=base_path,
-			key=key,
-			shard_count=shard_count,
-		)
+		super().__init__(base_path=base_path, key=key)
 
 		self.logger_context["store"] = "blob"
+
+		# Blobs are isolated per account by directory, so the on-disk file name is just the
+		# (encoded) blob key — no account prefix is needed.
+		self._prefix = ""
+
+	def _get_storage_path(self) -> str:
+		"""Store an account's blobs in their own directory, named by the account ID."""
+
+		return os.path.join(self.base_path, self._encode_key(self.key))
 
 	def _is_within_storage_path(self, path: str) -> bool:
 		"""Return True when a path resolves within the configured storage directory."""
@@ -93,7 +101,10 @@ class BlobStore(BaseStore):
 		process_lock = self._get_process_lock(blob_path)
 
 		with process_lock:
-			fd, temp_path = tempfile.mkstemp(dir=self.path)
+			# Write the temp file in the base path (not the per-account directory) so it stays
+			# outside what scan/count/delete_all walk, while remaining on the same filesystem
+			# for an atomic os.replace into the account directory.
+			fd, temp_path = tempfile.mkstemp(dir=self.base_path)
 			try:
 				with os.fdopen(fd, "wb") as file:
 					file.write(blob)

--- a/mail/storage/data_store.py
+++ b/mail/storage/data_store.py
@@ -47,10 +47,11 @@ class _EnvEntry:
 
 
 class DataStore(BaseStore):
-	"""A key-value store backed by LMDB, with one environment per ``user:account`` key.
+	"""A key-value store backed by LMDB, with one environment per ``account`` key.
 
-	LMDB natively supports concurrent multi-process access: many readers run lock-free via
-	MVCC snapshots while a single writer briefly serializes on a robust mutex (and waits
+	The store is shared by every user with access to the account. LMDB natively supports
+	concurrent multi-process access: many readers run lock-free via MVCC snapshots while a
+	single writer briefly serializes on a robust mutex (and waits
 	rather than failing). Environments are kept open and shared per process, so there is no
 	per-operation open cost and no external locking layer.
 	"""
@@ -86,14 +87,14 @@ class DataStore(BaseStore):
 		map_size: int | None = None,
 		**_legacy: Any,
 	) -> None:
-		"""Initialize the store for the given base path and ``user:account`` key.
+		"""Initialize the store for the given base path and ``account`` key.
 
 		``**_legacy`` absorbs parameters from the previous RocksDB implementation
 		(acquire_timeout, lock_timeout, max_retries, retry_delay, shard_count) so existing
 		callers keep working; they no longer have any effect.
 		"""
 
-		super().__init__(base_path=base_path, key=key, shard_count=1)
+		super().__init__(base_path=base_path, key=key)
 
 		self.logger_context["store"] = "data"
 		self.map_size = map_size or self.DEFAULT_MAP_SIZE

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -110,7 +110,6 @@ def get_mail_config(key: str | None = None) -> dict[str, Any] | Any:
 		"storage_log_file_count": 10,
 		"storage_log_level": "INFO",
 		"storage_log_max_size": 5_000_000,
-		"storage_shard_count": 8,
 	}
 
 	config = frappe.conf.mail or {}

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -88,13 +88,96 @@ def get_jmap_username(user: str) -> str | None:
 	return frappe.db.get_value("User Settings", {"user": user}, "username")
 
 
+@request_cache
+def get_user_account_ids(user: str) -> list[str]:
+	"""Returns the JMAP account IDs the user has access to.
+
+	The IDs are read from the user's cached JMAP session (populated whenever a JMAP
+	connection is established). This is the source of truth for which Account Settings
+	a user may read/write, since those documents are shared per JMAP account ID.
+	"""
+
+	from mail.jmap import get_jmap_session_manager
+
+	session = get_jmap_session_manager(user).get_session() or {}
+	return list((session.get("accounts") or {}).keys())
+
+
+def get_session_account(account_id: str) -> str:
+	"""Rebuild the full ``user:account_id`` JMAP handle for the current session user.
+
+	The frontend sends only the bare ``account_id``; the user component of the handle is
+	always the logged-in user. Internal code keeps using the full handle as the canonical
+	account identifier, so API endpoints reconstruct it here at the boundary.
+	"""
+
+	if not account_id:
+		frappe.throw(_("Account ID is required."))
+
+	return f"{frappe.session.user}:{account_id}"
+
+
+def resolve_account_handle(account: str) -> str:
+	"""Resolve an account reference to a full ``user:account_id`` handle.
+
+	Accepts either a full ``user:account_id`` handle (passed positionally by internal
+	callers) or a bare ``account_id`` (sent by the frontend), so dual-use whitelisted
+	functions work in both contexts. Account IDs never contain a colon, so its presence
+	reliably distinguishes the two forms.
+	"""
+
+	if not account:
+		frappe.throw(_("Account is required."))
+
+	return account if ":" in account else f"{frappe.session.user}:{account}"
+
+
+def get_account_scoped_permission_query(
+	doctype: str, column: str = "account_id", user: str | None = None
+) -> str:
+	"""Permission query condition for doctypes shared by JMAP account.
+
+	Restricts non-admins to rows whose `column` (the bare JMAP account ID) is one of the
+	accounts the user has access to. `column="name"` is used by doctypes named directly by
+	the account ID (e.g. Account Settings).
+	"""
+
+	user = user or frappe.session.user
+
+	if is_system_manager(user):
+		return ""
+
+	account_ids = get_user_account_ids(user)
+	if not account_ids:
+		return "1=0"
+
+	ids = ", ".join(frappe.db.escape(account_id) for account_id in account_ids)
+	return f"(`tab{doctype}`.`{column}` in ({ids}))"
+
+
+def has_account_scoped_permission(doc, column: str = "account_id", user: str | None = None) -> bool:
+	"""Document-level permission for doctypes shared by JMAP account.
+
+	Grants access when the user is a System Manager or has JMAP access to the account the
+	document is scoped to.
+	"""
+
+	user = user or frappe.session.user
+
+	if is_system_manager(user):
+		return True
+
+	value = doc.name if column == "name" else doc.get(column)
+	return value in get_user_account_ids(user)
+
+
 def get_account_emails(account: str) -> list[str]:
 	"""Returns the list of email addresses associated with the account."""
 
 	from mail.jmap import get_identities
 
 	emails = []
-	for identity in get_identities(account):
+	for identity in get_identities(*parse_account(account)):
 		emails.append(identity["email"])
 
 	return emails
@@ -231,43 +314,37 @@ def generate_user_keys(user: str) -> dict:
 def get_sync_state(account: str, type: Literal["email"]) -> str | None:
 	"""Returns the Sync State for the given account and type."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	from mail.client.doctype.account_settings.account_settings import get_or_create_account_settings
+
+	store = get_data_store(parse_account(account)[1])
 	value = store.get(Entity.STATE, f"{type}_current_state")
 
-	if not value and not frappe.db.exists("Account Settings", {"account": account}):
-		settings = frappe.new_doc("Account Settings")
-		settings.account = account
-		settings.flags.ignore_links = True
-		settings.insert(ignore_permissions=True)
+	if not value:
+		get_or_create_account_settings(account)
 
 	return value
 
 
 def update_sync_state(account: str, type: Literal["email"], state: str) -> None:
-	"""Updates the Sync State for the given account and type."""
+	"""Updates the Sync State for the given account and type.
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	The state (and its last-update timestamp, used to throttle scheduled syncs) lives in
+	the per-account data store, shared across every user of the account.
+	"""
+
+	store = get_data_store(parse_account(account)[1])
 
 	current_state = store.get(Entity.STATE, f"{type}_current_state")
 	store.set(Entity.STATE, f"{type}_previous_state", current_state)
 	store.set(Entity.STATE, f"{type}_current_state", state)
-
-	state_last_update_field = f"{type}_state_last_update"
-	ACCOUNT_SETTINGS = frappe.qb.DocType("Account Settings")
-	(
-		frappe.qb.update(ACCOUNT_SETTINGS)
-		.set(getattr(ACCOUNT_SETTINGS, state_last_update_field), frappe.utils.now())
-		.where(ACCOUNT_SETTINGS.account == account)
-	).run()
+	store.set(Entity.STATE, f"{type}_state_last_update", frappe.utils.now())
 
 
 @reconnect_on_failure()
 def clear_sync_state(account: str, type: Literal["email"]) -> None:
 	"""Clear the Sync State for the given account and type."""
 
-	user, account_id = parse_account(account)
-	store = get_data_store(user, account_id)
+	store = get_data_store(parse_account(account)[1])
 	store.delete(Entity.STATE, f"{type}_current_state")
 	store.delete(Entity.STATE, f"{type}_previous_state")
+	store.delete(Entity.STATE, f"{type}_state_last_update")


### PR DESCRIPTION
Backport of #602 to `v0`.

## What

Shares **Account Settings, Blocked/Junk Email Address, Mailbox Settings, Mail Exchange, Mail Sync History and Mail Queue** across every user with JMAP access to an account by keying them on the bare JMAP account ID instead of the per-user `user:account_id` handle. The data and blob stores are keyed by account ID too, and blob-store sharding is dropped (one directory per account).

## Adapted for v0

- Keep `get_mail_config` (v0) rather than develop's `get_config`.
- `patches.txt` registers only #602's own patches — `refactor_account_settings` plus the `account_id` backfills and the legacy-store cleanups. The unrelated `configure_*_log` patches do not exist on v0 and are intentionally excluded.
- Drop the `storage_shard_count` default from `get_mail_config`.
- User Settings already lacks the Account Settings cascade-delete on v0, so it is left unchanged.

## Migration notes

The six `backfill_*_account_id` patches run post-model-sync and read the legacy `account` column (which Frappe retains as an orphan column after the field is removed from the doctype JSON) to populate `account_id`, dedupe, and drop the stale per-handle unique indexes. `refactor_account_settings` runs pre-model-sync to rename/dedupe Account Settings docs to their account ID. `clear_legacy_user_scoped_stores` / `clear_legacy_blob_store_layout` drop the now-unreachable per-user caches (they rebuild on demand).

## Validation

- Backend: `py_compile` + `ruff` clean on all changed files; new-patch import targets verified.
- Frontend: full production `vite build` succeeds (validates the `account` → `accountId` rename end to end).

⚠️ Not yet verified against a populated v0 site — please run `bench migrate` and the v0 test suite before merging to confirm the backfills populate `account_id` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)