### PR TITLE
feat(mail-exchange): show user-friendly progress in the output field

### DIFF
--- a/mail/client/doctype/mail_exchange/mail_exchange.py
+++ b/mail/client/doctype/mail_exchange/mail_exchange.py
@@ -712,6 +712,7 @@ class MailExchange(Document):
 
 		freeze_jmap_push_notifications(self.user)
 		self._mark_started()
+		self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
 
 		import_file = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
 		base_dir = os.path.join(get_mail_import_directory(), self.name)
@@ -724,6 +725,7 @@ class MailExchange(Document):
 			else:
 				extract_compressed_file(import_file, base_dir)
 			logger.debug("import-source-prepared", base_dir=base_dir)
+			self._log_output(_("Prepared the source files for import."))
 
 			service = get_email_service(*parse_account(self.account))
 
@@ -735,6 +737,7 @@ class MailExchange(Document):
 				self.import_format, base_dir, mailbox_map, self.import_metadata_dict
 			)
 			logger.info("import-metadata-loaded", emails=len(meta), max_import=self.max_import)
+			self._log_output(_("Found {0} email(s) to import.").format(len(meta)))
 
 			if not meta:
 				frappe.throw(_("No emails found for import."))
@@ -745,10 +748,14 @@ class MailExchange(Document):
 			clear_sync_state(self.account, type="email")
 
 			logger.info("import-completed", emails=len(meta))
-			kwargs.update({"status": "Completed", "output": _("Import completed")})
+			self._log_output(_("Import completed successfully. {0} email(s) imported.").format(len(meta)))
+			kwargs.update({"status": "Completed"})
 		except Exception:
 			logger.exception("import-failed")
-			kwargs.update({"status": "Failed", "output": frappe.get_traceback(with_context=False)})
+			self._log_output(_("Import failed. See the error details below."))
+			kwargs.update(
+				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+			)
 		finally:
 			shutil.rmtree(base_dir, ignore_errors=True)
 			unfreeze_jmap_push_notifications(self.user)
@@ -767,6 +774,7 @@ class MailExchange(Document):
 		logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
 
 		self._mark_started()
+		self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
 		out_dir = os.path.join(get_mail_export_directory(), self.name)
 		os.makedirs(out_dir, exist_ok=True)
 
@@ -776,6 +784,9 @@ class MailExchange(Document):
 			total = service.query(self.export_filter_dict, limit=1)["total"]
 			limit = min(total, cint(self.export_limit or total))
 			logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)
+			self._log_output(
+				_("Found {0} email(s) matching the filter; exporting up to {1}.").format(total, limit)
+			)
 
 			if limit > self.max_export:
 				frappe.throw(_("Export limit exceeded."))
@@ -796,6 +807,11 @@ class MailExchange(Document):
 						unique_emails[key] = e
 				emails = list(unique_emails.values())
 				logger.debug("export-deduplicated", fetched=fetched, unique=len(emails))
+				self._log_output(
+					_("Removed {0} duplicate(s); {1} unique email(s) remain.").format(
+						fetched - len(emails), len(emails)
+					)
+				)
 
 			mailbox_map = {}
 			if self.export_format == "mbox":
@@ -804,13 +820,21 @@ class MailExchange(Document):
 				mailbox_map = self._build_mailbox_map(service.mailboxes)
 
 			self._export_batches(service, emails, out_dir, mailbox_map, logger)
+
+			self._log_output(
+				_("Packaging exported emails into a {0} archive.").format(self.export_archive_type)
+			)
 			self._attach_export(out_dir)
 
 			logger.info("export-completed", emails=len(emails))
-			kwargs.update({"status": "Completed", "output": _("Export completed")})
+			self._log_output(_("Export completed successfully. {0} email(s) exported.").format(len(emails)))
+			kwargs.update({"status": "Completed"})
 		except Exception:
 			logger.exception("export-failed")
-			kwargs.update({"status": "Failed", "output": frappe.get_traceback(with_context=False)})
+			self._log_output(_("Export failed. See the error details below."))
+			kwargs.update(
+				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+			)
 		finally:
 			shutil.rmtree(out_dir, ignore_errors=True)
 
@@ -825,6 +849,7 @@ class MailExchange(Document):
 			status="In Progress",
 			started_at=started_at,
 			started_after=time_diff_in_seconds(started_at, self.queued_at),
+			output="",
 		)
 
 	def _mark_completed(self, **kwargs) -> None:
@@ -880,6 +905,7 @@ class MailExchange(Document):
 
 			imported += len(batch)
 			logger.debug("import-batch-processed", batch=len(batch), imported=imported, total=total)
+			self._log_output(_("Imported {0} of {1} email(s).").format(imported, total))
 
 	def _export_batches(
 		self,
@@ -924,6 +950,7 @@ class MailExchange(Document):
 
 			exported += len(export_emails)
 			logger.debug("export-batch-written", batch=len(export_emails), exported=exported, total=total)
+			self._log_output(_("Exported {0} of {1} email(s).").format(exported, total))
 
 	def _build_mailbox_map(self, mailboxes: list[dict]) -> dict[str, str]:
 		"""Builds a mapping of mailbox IDs to their full paths."""
@@ -999,6 +1026,16 @@ class MailExchange(Document):
 			},
 			now=True,
 		)
+
+	def _log_output(self, message: str) -> None:
+		"""Appends a timestamped, user-friendly line to the `output` field and persists it.
+
+		These messages are surfaced in the UI so the user can follow the progress of the
+		background import/export as it happens."""
+
+		line = f"[{now()}] {message}"
+		self.output = f"{self.output}\n{line}" if self.output else line
+		self._db_set(output=self.output)
 
 	def _db_set(self, **kwargs) -> None:
 		"""Updates the document with the given key-value pairs."""


### PR DESCRIPTION
### Summary

Turns the **Mail Exchange `output` field** into a live, timestamped progress log instead of a single end-of-run message, so users can follow what's happening during a background import/export from the UI.

A new `_log_output()` helper appends a translatable, timestamped line and persists it immediately (committed), and it's wired into each milestone:

- **Import** — start → source prepared → "Found N email(s) to import." → "Imported X of N email(s)." (per batch) → completion summary
- **Export** — start → "Found N matching the filter; exporting up to M." → dedupe summary → "Exported X of N email(s)." (per batch) → packaging → completion summary

### Notes

- **Failures** append a friendly "… failed. See the error details below." line and keep the full traceback underneath, preserving debuggability for admins viewing the doc.
- `_mark_started()` now resets `output` so retries start with a clean log rather than stacking onto the previous attempt's traceback.
- All messages go through `_()` for translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)