### PR TITLE
refactor(mail-exchange): drop account handle; pass user and account_id directly

### DIFF
--- a/mail/client/doctype/mail_exchange/mail_exchange.py
+++ b/mail/client/doctype/mail_exchange/mail_exchange.py
@@ -35,7 +35,7 @@ from mail.client.doctype.push_subscription.push_subscription import (
 	freeze_jmap_push_notifications,
 	unfreeze_jmap_push_notifications,
 )
-from mail.jmap import get_email_service, parse_account
+from mail.jmap import get_jmap_connection
 from mail.jmap.services.mail.email import EmailService
 from mail.utils import (
 	compress_directory,
@@ -526,15 +526,6 @@ class MailExchange(Document):
 			"receivedAt": metadata.get("receivedAt"),
 		}
 
-	@property
-	def account(self) -> str:
-		"""The full `user:account_id` JMAP handle.
-
-		`user` provides the credentials used to authenticate with JMAP, while `account_id`
-		is the (shared) account being imported into or exported from."""
-
-		return f"{self.user}:{self.account_id}"
-
 	def autoname(self) -> None:
 		self.name = str(uuid7())
 
@@ -633,7 +624,7 @@ class MailExchange(Document):
 				"exchange": self.name,
 				"operation": self.operation,
 				"user": self.user,
-				"account": self.account,
+				"account_id": self.account_id,
 			}
 		)
 
@@ -725,7 +716,7 @@ class MailExchange(Document):
 				extract_compressed_file(import_file, base_dir)
 			logger.debug("import-source-prepared", base_dir=base_dir)
 
-			service = get_email_service(*parse_account(self.account))
+			service = get_email_service(self.user, self.account_id)
 
 			mailbox_map = {}
 			if self.import_format == "maildir-nested":
@@ -742,7 +733,7 @@ class MailExchange(Document):
 				frappe.throw(_("Import limit exceeded."))
 
 			self._import_batches(service, base_dir, meta, logger)
-			clear_sync_state(self.account, type="email")
+			clear_sync_state(self.account_id, type="email")
 
 			logger.info("import-completed", emails=len(meta))
 			kwargs.update({"status": "Completed", "output": _("Import completed")})
@@ -772,7 +763,7 @@ class MailExchange(Document):
 
 		kwargs = {}
 		try:
-			service = get_email_service(*parse_account(self.account))
+			service = get_email_service(self.user, self.account_id)
 			total = service.query(self.export_filter_dict, limit=1)["total"]
 			limit = min(total, cint(self.export_limit or total))
 			logger.info("export-query-resolved", total=total, limit=limit, max_export=self.max_export)
@@ -1025,6 +1016,17 @@ def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
 		return True
 
 	return doc.user == user
+
+
+def get_email_service(
+	user: str,
+	account_id: str,
+	ignore_permissions: bool = False,
+) -> EmailService:
+	"""Returns an instance of EmailService for handling email-related operations for the specified account."""
+
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
+	return EmailService(account_id, connection)
 
 
 def extract_received_or_sent(msg: Message) -> datetime:

--- a/mail/jmap/__init__.py
+++ b/mail/jmap/__init__.py
@@ -31,8 +31,7 @@ from mail.utils.validation import has_permission_for_user
 
 
 def get_jmap_connection(
-	user: str,
-	ignore_permissions: bool = False,
+	user: str, ignore_permissions: bool = False, timeout: tuple[float, float] = (30.0, 60.0)
 ) -> JMAPConnection:
 	"""Returns a JMAPConnection instance for the specified user, using the user's settings for connection details."""
 
@@ -56,7 +55,10 @@ def get_jmap_connection(
 
 	return JMAPConnection(
 		JMAPConnectionInfo(
-			get_config("server_url"), user_settings.username, user_settings.get_password("app_password")
+			get_config("server_url"),
+			user_settings.username,
+			user_settings.get_password("app_password"),
+			timeout,
 		),
 		session_manager=get_jmap_session_manager(user),
 	)

--- a/mail/utils/user.py
+++ b/mail/utils/user.py
@@ -268,10 +268,10 @@ def update_sync_state(account: str, type: Literal["email"], state: str) -> None:
 
 
 @reconnect_on_failure()
-def clear_sync_state(account: str, type: Literal["email"]) -> None:
-	"""Clear the Sync State for the given account and type."""
+def clear_sync_state(account_id: str, type: Literal["email"]) -> None:
+	"""Clear the Sync State for the given account ID and type."""
 
-	store = get_data_store(parse_account(account)[1])
+	store = get_data_store(account_id)
 	store.delete(Entity.STATE, f"{type}_current_state")
 	store.delete(Entity.STATE, f"{type}_previous_state")
 	store.delete(Entity.STATE, f"{type}_state_last_update")


### PR DESCRIPTION
## Summary

- Remove the `account` property from `MailExchange` that concatenated `user` and `account_id` into a `user:account_id` handle
- Call `get_email_service(user, account_id)` and `clear_sync_state(account_id)` directly instead of routing through the account handle
- Move `get_email_service()` into `mail_exchange.py` (was previously exported from `mail.jmap`) with a longer timeout (60s/180s) appropriate for import/export operations
- Add a `timeout` parameter to `get_jmap_connection()` so callers can override the default (30s/60s)

## Test plan

- [ ] Run a mail import via Mail Exchange and confirm it completes successfully
- [ ] Run a mail export via Mail Exchange and confirm it completes successfully
- [ ] Verify `clear_sync_state` works correctly after an import

🤖 Generated with [Claude Code](https://claude.com/claude-code)