### PR TITLE
fix(jmap): fix pagination in all query services — replace hasMoreItems with reliable termination [v0 backport]

### DIFF
--- a/mail/jmap/services/calendars/calendar_event.py
+++ b/mail/jmap/services/calendars/calendar_event.py
@@ -184,28 +184,33 @@ class CalendarEventService(CalendarsService):
 		sort = sort or [{"property": "start", "isAscending": True}]
 
 		while len(ids) < limit:
+			current_batch_size = min(batch_size, limit - len(ids))
+
 			response = self._query(
 				filter,
 				position,
-				batch_size,
+				current_batch_size,
 				sort,
 				calculate_total=total is None,
 				timeZone=time_zone,
 				expandRecurrences=expand_recurrences,
 			)
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				ids.extend(query_response.get("ids", []))
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if total is None:
-					total = query_response.get("total", 0)
+			if total is None:
+				total = query_response.get("total", 0)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
 
-				position += batch_size
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/calendars/calendar_event.py
+++ b/mail/jmap/services/calendars/calendar_event.py
@@ -205,9 +205,9 @@ class CalendarEventService(CalendarsService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/calendars/calendar_event_notification.py
+++ b/mail/jmap/services/calendars/calendar_event_notification.py
@@ -50,20 +50,25 @@ class CalendarEventNotificationService(CalendarsService):
 		sort = sort or [{"property": "created", "isAscending": True}]
 
 		while len(ids) < limit:
-			response = self._query(filter, position, batch_size, sort, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/calendars/calendar_event_notification.py
+++ b/mail/jmap/services/calendars/calendar_event_notification.py
@@ -63,9 +63,9 @@ class CalendarEventNotificationService(CalendarsService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/contacts/contact_card.py
+++ b/mail/jmap/services/contacts/contact_card.py
@@ -146,20 +146,25 @@ class ContactCardService(ContactsService):
 		batch_size = min(limit, self.max_objects_in_get)
 
 		while len(ids) < limit:
-			response = self._query(filter, position, batch_size, sort, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/contacts/contact_card.py
+++ b/mail/jmap/services/contacts/contact_card.py
@@ -159,9 +159,9 @@ class ContactCardService(ContactsService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/mail/email.py
+++ b/mail/jmap/services/mail/email.py
@@ -158,9 +158,9 @@ class EmailService(MailService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/mail/email.py
+++ b/mail/jmap/services/mail/email.py
@@ -145,20 +145,25 @@ class EmailService(MailService):
 		sort = sort or [{"property": "receivedAt", "isAscending": False}]
 
 		while len(ids) < limit:
-			response = self._query(filter, position, batch_size, sort, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/principals/principal.py
+++ b/mail/jmap/services/principals/principal.py
@@ -72,20 +72,25 @@ class PrincipalService(CalendarsService):
 		batch_size = min(limit, self.max_objects_in_get)
 
 		while len(ids) < limit:
-			response = self._query(filter, position, batch_size, sort, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/principals/principal.py
+++ b/mail/jmap/services/principals/principal.py
@@ -85,9 +85,9 @@ class PrincipalService(CalendarsService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/quota/quota.py
+++ b/mail/jmap/services/quota/quota.py
@@ -63,9 +63,9 @@ class QuotaService(CoreService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)

--- a/mail/jmap/services/quota/quota.py
+++ b/mail/jmap/services/quota/quota.py
@@ -50,20 +50,25 @@ class QuotaService(CoreService):
 		batch_size = min(limit, self.max_objects_in_get)
 
 		while len(ids) < limit:
-			response = self._query(filter, position, batch_size, sort, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(filter, position, current_batch_size, sort, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/sieve/sieve_script.py
+++ b/mail/jmap/services/sieve/sieve_script.py
@@ -129,20 +129,25 @@ class SieveScriptService(CoreService):
 		batch_size = min(limit, self.max_objects_in_get)
 
 		while len(ids) < limit:
-			response = self._query(_filter, position, batch_size, calculate_total=total is None)
+			current_batch_size = min(batch_size, limit - len(ids))
 
-			if method_responses := response.get("methodResponses"):
-				query_response = method_responses[0][1]
+			response = self._query(_filter, position, current_batch_size, calculate_total=total is None)
 
-				ids.extend(query_response.get("ids", []))
+			method_responses = response.get("methodResponses")
+			if not method_responses:
+				break
 
-				if total is None:
-					total = query_response.get("total", 0)
+			query_response = method_responses[0][1]
+			batch_ids = query_response.get("ids", [])
+			ids.extend(batch_ids)
 
-				if not query_response.get("hasMoreItems", False):
-					break
+			if total is None:
+				total = query_response.get("total", 0)
 
-				position += batch_size
+			if len(batch_ids) < current_batch_size or len(ids) >= total:
+				break
+
+			position += len(batch_ids)
 
 		return {"ids": ids[:limit], "total": total}
 

--- a/mail/jmap/services/sieve/sieve_script.py
+++ b/mail/jmap/services/sieve/sieve_script.py
@@ -142,9 +142,9 @@ class SieveScriptService(CoreService):
 			ids.extend(batch_ids)
 
 			if total is None:
-				total = query_response.get("total", 0)
+				total = query_response.get("total")
 
-			if len(batch_ids) < current_batch_size or len(ids) >= total:
+			if len(batch_ids) < current_batch_size or (total is not None and len(ids) >= total):
 				break
 
 			position += len(batch_ids)


### PR DESCRIPTION
Backport of #609 for the `v0` branch.

## Summary

All `query` methods across JMAP services relied on `hasMoreItems` to continue pagination, but Stalwart never includes that field in query responses — causing every loop to exit after the first batch and return at most one server page of IDs (e.g. 500) regardless of the requested `limit`.

**Services fixed:**
- `mail/email.py` (also removes a leftover `breakpoint()` debug call)
- `quota/quota.py`
- `calendars/calendar_event.py`
- `calendars/calendar_event_notification.py`
- `sieve/sieve_script.py`
- `principals/principal.py`
- `contacts/contact_card.py`

**Termination logic replaced with signals Stalwart does return:**
- **Short batch** — fewer IDs returned than requested means end of result set.
- **Reached total** — collected IDs ≥ `total` (only checked when the server actually provides it; defaults to `None` to avoid the `>= 0` always-true trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)