### PR TITLE
fix(frontend): default chunked upload to mail.api.mail.upload_file

### DIFF
--- a/frontend/src/utils/useChunkedUpload.ts
+++ b/frontend/src/utils/useChunkedUpload.ts
@@ -36,7 +36,7 @@ export function useChunkedUpload() {
 	const upload = (file: File, options: ChunkedUploadOptions = {}): Promise<UploadedFile> => {
 		const chunkSize = options.chunk_size || DEFAULT_CHUNK_SIZE
 		const totalChunks = Math.max(1, Math.ceil(file.size / chunkSize))
-		const endpoint = options.upload_endpoint || '/api/method/upload_file'
+		const endpoint = options.upload_endpoint || '/api/method/mail.api.mail.upload_file'
 
 		const buildFormData = (chunk: Blob, chunkIndex: number, chunkByteOffset: number) => {
 			const form = new FormData()


### PR DESCRIPTION
## Description

Point the chunked upload's default endpoint at the app's own whitelisted `mail.api.mail.upload_file` method instead of Frappe's generic `/api/method/upload_file`.

```diff
-const endpoint = options.upload_endpoint || '/api/method/upload_file'
+const endpoint = options.upload_endpoint || '/api/method/mail.api.mail.upload_file'
```

The app-specific endpoint (`mail/api/mail.py:988`) is the intended target for uploads in Frappe Mail; callers that don't pass an explicit `upload_endpoint` now hit it by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)