### PR TITLE
feat(calendar): add Calendar Exchange (ICS/JMAP import & export) (backport #611)

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -36,6 +36,8 @@ declare module 'vue' {
     AutomationSettings: typeof import('./src/components/Settings/AutomationSettings.vue')['default']
     BlockListSettings: typeof import('./src/components/Settings/BlockListSettings.vue')['default']
     BlockSenderModal: typeof import('./src/components/Modals/BlockSenderModal.vue')['default']
+    CalendarExportSettings: typeof import('./src/components/Settings/CalendarExportSettings.vue')['default']
+    CalendarImportSettings: typeof import('./src/components/Settings/CalendarImportSettings.vue')['default']
     ChangePasswordModal: typeof import('./src/components/Modals/ChangePasswordModal.vue')['default']
     ComposeMailEditor: typeof import('./src/components/ComposeMailEditor.vue')['default']
     ComposeMailToolbar: typeof import('./src/components/ComposeMailToolbar.vue')['default']

--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -75,6 +75,8 @@ declare module 'vue' {
     MailDate: typeof import('./src/components/MailDate.vue')['default']
     MailDetails: typeof import('./src/components/MailDetails.vue')['default']
     MailDetailsPopover: typeof import('./src/components/MailDetailsPopover.vue')['default']
+    MailExportSettings: typeof import('./src/components/Settings/MailExportSettings.vue')['default']
+    MailImportSettings: typeof import('./src/components/Settings/MailImportSettings.vue')['default']
     MailListItem: typeof import('./src/components/MailListItem.vue')['default']
     MailListItemActions: typeof import('./src/components/MailListItemActions.vue')['default']
     MailLogo: typeof import('./src/components/Icons/MailLogo.vue')['default']

--- a/frontend/src/components/Modals/SettingsModal.vue
+++ b/frontend/src/components/Modals/SettingsModal.vue
@@ -41,6 +41,8 @@
 import { computed, inject, markRaw, ref, watch } from 'vue'
 import {
 	Ban,
+	CalendarPlus,
+	CalendarRange,
 	Code,
 	Feather,
 	Fingerprint,
@@ -61,6 +63,8 @@ import AdvancedSettings from '@/components/Settings/AdvancedSettings.vue'
 import AppearanceSettings from '@/components/Settings/AppearanceSettings.vue'
 import AutomationSettings from '@/components/Settings/AutomationSettings.vue'
 import BlockListSettings from '@/components/Settings/BlockListSettings.vue'
+import CalendarExportSettings from '@/components/Settings/CalendarExportSettings.vue'
+import CalendarImportSettings from '@/components/Settings/CalendarImportSettings.vue'
 import ExportSettings from '@/components/Settings/ExportSettings.vue'
 import FolderSettings from '@/components/Settings/FolderSettings.vue'
 import IdentitySettings from '@/components/Settings/IdentitySettings.vue'
@@ -138,6 +142,18 @@ const tabs = computed(() => {
 			label: __('Export'),
 			icon: HardDriveUpload,
 			component: markRaw(ExportSettings),
+			condition: user.data.is_jmap_configured,
+		},
+		{
+			label: __('Calendar Import'),
+			icon: CalendarPlus,
+			component: markRaw(CalendarImportSettings),
+			condition: user.data.is_jmap_configured,
+		},
+		{
+			label: __('Calendar Export'),
+			icon: CalendarRange,
+			component: markRaw(CalendarExportSettings),
 			condition: user.data.is_jmap_configured,
 		},
 		{

--- a/frontend/src/components/Modals/SettingsModal.vue
+++ b/frontend/src/components/Modals/SettingsModal.vue
@@ -41,8 +41,6 @@
 import { computed, inject, markRaw, ref, watch } from 'vue'
 import {
 	Ban,
-	CalendarPlus,
-	CalendarRange,
 	Code,
 	Feather,
 	Fingerprint,
@@ -63,8 +61,6 @@ import AdvancedSettings from '@/components/Settings/AdvancedSettings.vue'
 import AppearanceSettings from '@/components/Settings/AppearanceSettings.vue'
 import AutomationSettings from '@/components/Settings/AutomationSettings.vue'
 import BlockListSettings from '@/components/Settings/BlockListSettings.vue'
-import CalendarExportSettings from '@/components/Settings/CalendarExportSettings.vue'
-import CalendarImportSettings from '@/components/Settings/CalendarImportSettings.vue'
 import ExportSettings from '@/components/Settings/ExportSettings.vue'
 import FolderSettings from '@/components/Settings/FolderSettings.vue'
 import IdentitySettings from '@/components/Settings/IdentitySettings.vue'
@@ -142,18 +138,6 @@ const tabs = computed(() => {
 			label: __('Export'),
 			icon: HardDriveUpload,
 			component: markRaw(ExportSettings),
-			condition: user.data.is_jmap_configured,
-		},
-		{
-			label: __('Calendar Import'),
-			icon: CalendarPlus,
-			component: markRaw(CalendarImportSettings),
-			condition: user.data.is_jmap_configured,
-		},
-		{
-			label: __('Calendar Export'),
-			icon: CalendarRange,
-			component: markRaw(CalendarExportSettings),
 			condition: user.data.is_jmap_configured,
 		},
 		{

--- a/frontend/src/components/Settings/CalendarExportSettings.vue
+++ b/frontend/src/components/Settings/CalendarExportSettings.vue
@@ -1,0 +1,178 @@
+<template>
+	<h1>{{ __('Export Calendar') }}</h1>
+	<FormControl
+		v-model="calendarExport.format"
+		:label="__('Format')"
+		type="select"
+		variant="outline"
+		:options="FORMAT_OPTIONS"
+	/>
+	<FormControl
+		v-model="calendarExport.archive_type"
+		:label="__('Archive Type')"
+		type="select"
+		variant="outline"
+		:options="ARCHIVE_TYPE_OPTIONS"
+	/>
+	<Switch
+		v-model="customSelection"
+		:label="__('Custom Selection')"
+		:description="__('Apply filters to select specific events for export.')"
+		class="hover:!bg-surface-white !cursor-default !p-0"
+	/>
+	<template v-if="customSelection">
+		<FormControl
+			v-model="filter.inCalendar"
+			:label="__('Calendar')"
+			type="select"
+			variant="outline"
+			:options="calendarOptions"
+		/>
+		<FormControl v-model="filter.title" type="text" variant="outline" :label="__('Title')" />
+		<FormControl
+			v-model="filter.after"
+			type="date"
+			variant="outline"
+			:label="__('From Date')"
+		/>
+		<FormControl
+			v-model="filter.before"
+			type="date"
+			variant="outline"
+			:label="__('To Date')"
+		/>
+		<FormControl
+			v-model="calendarExport.limit"
+			:label="__('Max Number of Events')"
+			type="number"
+			variant="outline"
+			placeholder="1000"
+		/>
+		<FormControl
+			v-if="calendarExport.limit && calendarExport.limit > 0"
+			v-model="calendarExport.sort"
+			:label="__('Start From')"
+			type="select"
+			variant="outline"
+			:options="sortOptions"
+		/>
+	</template>
+
+	<Button
+		class="min-h-7"
+		:label="__('Create Export')"
+		:loading="ongoingExport.data?.name"
+		:disabled="ongoingExport.loading || ongoingExport.error || createCalendarExport.loading"
+		@click="createCalendarExport.submit()"
+	/>
+	<div class="!mt-3 space-x-1 text-base">
+		<span class="text-ink-gray-5">{{ exportSubtitle }}</span>
+		<a class="hover:underline" :href="exportHref" target="_blank">
+			{{ exportLinkText }}
+		</a>
+	</div>
+	<ErrorMessage
+		v-if="createCalendarExport.error"
+		:message="createCalendarExport.error"
+		class="mb-2.5"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onMounted, reactive, ref } from 'vue'
+import { Button, ErrorMessage, FormControl, Switch, createResource } from 'frappe-ui'
+
+import { userStore } from '@/stores/user'
+
+const { accountId, user: sessionUser } = userStore()
+
+const user = inject('$user')
+const socket = inject('$socket')
+
+const calendarExport = reactive({
+	format: 'jmap',
+	archive_type: '.zip',
+	sort: 'Start (ASC)',
+	limit: undefined,
+})
+
+const customSelection = ref(false)
+
+const filter = reactive({
+	inCalendar: '',
+	title: '',
+	after: '',
+	before: '',
+})
+
+const calendars = createResource({
+	url: 'mail.client.doctype.calendar.calendar.fetch_calendars',
+	auto: true,
+	makeParams: () => ({ account: `${sessionUser}:${accountId}`, limit: 100 }),
+})
+
+const calendarOptions = computed(() =>
+	[{ label: __(''), value: ' ' }].concat(
+		(calendars.data || []).map((c: { id: string; _name: string }) => ({
+			label: c._name,
+			value: c.id,
+		})),
+	),
+)
+
+const sortOptions = computed(() => [
+	{ label: __('Oldest Events'), value: 'Start (ASC)' },
+	{ label: __('Newest Events'), value: 'Start (DESC)' },
+])
+
+const createCalendarExport = createResource({
+	url: 'mail.api.account.create_calendar_export',
+	makeParams: () => {
+		const cleanedFilter = Object.fromEntries(
+			Object.entries(filter)
+				.map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
+				.filter(([, v]) => Boolean(v)),
+		)
+		return { account_id: accountId, ...calendarExport, filter: cleanedFilter }
+	},
+	onSuccess: () => ongoingExport.reload(),
+})
+
+const ongoingExport = createResource({
+	url: 'frappe.client.get_value',
+	auto: true,
+	makeParams: () => ({
+		doctype: 'Calendar Exchange',
+		fieldname: 'name',
+		filters: {
+			user: user.data.name,
+			operation: 'Export',
+			status: ['in', ['Queued', 'In Progress']],
+		},
+	}),
+})
+
+onMounted(() =>
+	socket.on('calendar_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
+		if (payload.action === 'Export') ongoingExport.reload()
+	}),
+)
+
+const exportSubtitle = computed(() => {
+	if (ongoingExport.data?.name) return __("Export in progress. We'll email you when it's ready.")
+	return __('No exports in progress.')
+})
+
+const exportHref = computed(() => {
+	if (ongoingExport.data?.name) return `/mail/calendar-exchanges/${ongoingExport.data.name}`
+	return '/mail/calendar-exchanges?operation=Export'
+})
+
+const exportLinkText = computed(() => {
+	if (ongoingExport.data?.name) return __('Track status')
+	return __('View history')
+})
+
+const FORMAT_OPTIONS = ['jmap', 'ics']
+const ARCHIVE_TYPE_OPTIONS = ['.zip', '.tgz', '.tar.gz']
+</script>

--- a/frontend/src/components/Settings/CalendarImportSettings.vue
+++ b/frontend/src/components/Settings/CalendarImportSettings.vue
@@ -1,0 +1,158 @@
+<template>
+	<h1>{{ __('Import Calendar') }}</h1>
+	<FormControl
+		v-model="calendarImport.format"
+		:label="__('Format')"
+		type="select"
+		variant="outline"
+		:options="FORMAT_OPTIONS"
+		required
+	/>
+	<FormControl
+		v-model="calendarImport.calendar"
+		:label="__('Calendar')"
+		type="select"
+		variant="outline"
+		:options="calendarOptions"
+	/>
+	<input
+		ref="fileInput"
+		type="file"
+		class="hidden"
+		:accept="acceptTypes"
+		@change="onFileSelected"
+	/>
+	<Button
+		class="w-full"
+		:label="uploading ? __('Uploading ({0}%)', [progress]) : __('Upload File')"
+		:loading="uploading"
+		@click="fileInput?.click()"
+	/>
+	<p class="text-ink-gray-5 mt-2 flex text-sm">{{ fileUploadSubtitle }}</p>
+
+	<Button
+		class="min-h-7"
+		:label="__('Create Import')"
+		variant="solid"
+		:loading="ongoingImport.data?.name"
+		:disabled="ongoingImport.loading || ongoingImport.error || !calendarImport.file"
+		@click="createCalendarImport.submit()"
+	/>
+	<div class="!mt-3 space-x-1 text-base">
+		<span class="text-ink-gray-5">{{ importSubtitle }}</span>
+		<a class="hover:underline" :href="importHref" target="_blank">
+			{{ importLinkText }}
+		</a>
+	</div>
+	<ErrorMessage
+		v-if="createCalendarImport.error"
+		:message="createCalendarImport.error"
+		class="mb-2.5"
+	/>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onMounted, reactive, ref } from 'vue'
+import { Button, ErrorMessage, FormControl, createResource } from 'frappe-ui'
+
+import { raiseToast } from '@/utils'
+import { useChunkedUpload } from '@/utils/useChunkedUpload'
+import { userStore } from '@/stores/user'
+
+const { accountId, user: sessionUser } = userStore()
+
+const user = inject('$user')
+const socket = inject('$socket')
+
+const calendarImport = reactive({
+	format: 'ics',
+	file: '',
+	calendar: '',
+})
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const { uploading, progress, upload } = useChunkedUpload()
+
+const acceptTypes = computed(() =>
+	calendarImport.format === 'ics' ? '.ics' : '.zip,.tgz,.tar.gz',
+)
+
+// Upload in chunks so large import archives aren't blocked by the web server's request-size limit.
+const onFileSelected = async (event: Event) => {
+	const input = event.target as HTMLInputElement
+	const file = input.files?.[0]
+	input.value = '' // let the same file be re-selected after an error
+	if (!file) return
+
+	try {
+		const uploaded = await upload(file, { private: true })
+		calendarImport.file = uploaded.file_url
+	} catch (error) {
+		raiseToast((error as Error).message, 'error')
+	}
+}
+
+const calendars = createResource({
+	url: 'mail.client.doctype.calendar.calendar.fetch_calendars',
+	auto: true,
+	makeParams: () => ({ account: `${sessionUser}:${accountId}`, limit: 100 }),
+})
+
+const calendarOptions = computed(() =>
+	[{ label: __('Default'), value: '' }].concat(
+		(calendars.data || []).map((c: { id: string; _name: string }) => ({
+			label: c._name,
+			value: c.id,
+		})),
+	),
+)
+
+const fileUploadSubtitle = computed(() => {
+	if (calendarImport.file) return __('File uploaded: {0}', [calendarImport.file])
+	if (calendarImport.format === 'ics') return __('Supported file format: .ics')
+	return __('Supported file formats: .zip, .tar, .tgz')
+})
+
+const createCalendarImport = createResource({
+	url: 'mail.api.account.create_calendar_import',
+	makeParams: () => ({ account_id: accountId, ...calendarImport }),
+	onSuccess: () => ongoingImport.reload(),
+})
+
+const ongoingImport = createResource({
+	url: 'frappe.client.get_value',
+	auto: true,
+	makeParams: () => ({
+		doctype: 'Calendar Exchange',
+		fieldname: 'name',
+		filters: {
+			user: user.data.name,
+			operation: 'Import',
+			status: ['in', ['Queued', 'In Progress']],
+		},
+	}),
+})
+
+onMounted(() =>
+	socket.on('calendar_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
+		if (payload.action === 'Import') ongoingImport.reload()
+	}),
+)
+
+const importSubtitle = computed(() => {
+	if (ongoingImport.data?.name) return __("Import in progress. We'll email you when it's ready.")
+	return __('No imports in progress.')
+})
+
+const importHref = computed(() => {
+	if (ongoingImport.data?.name) return `/mail/calendar-exchanges/${ongoingImport.data.name}`
+	return '/mail/calendar-exchanges?operation=Import'
+})
+
+const importLinkText = computed(() => {
+	if (ongoingImport.data?.name) return __('Track status')
+	return __('View history')
+})
+
+const FORMAT_OPTIONS = ['ics', 'jmap']
+</script>

--- a/frontend/src/components/Settings/CalendarImportSettings.vue
+++ b/frontend/src/components/Settings/CalendarImportSettings.vue
@@ -95,15 +95,16 @@ const calendars = createResource({
 	url: 'mail.client.doctype.calendar.calendar.fetch_calendars',
 	auto: true,
 	makeParams: () => ({ account: `${sessionUser}:${accountId}`, limit: 100 }),
+	onSuccess: (data: { id: string }[]) => {
+		if (!calendarImport.calendar && data?.length) calendarImport.calendar = data[0].id
+	},
 })
 
 const calendarOptions = computed(() =>
-	[{ label: __('Default'), value: '' }].concat(
-		(calendars.data || []).map((c: { id: string; _name: string }) => ({
-			label: c._name,
-			value: c.id,
-		})),
-	),
+	(calendars.data || []).map((c: { id: string; _name: string }) => ({
+		label: c._name,
+		value: c.id,
+	})),
 )
 
 const fileUploadSubtitle = computed(() => {

--- a/frontend/src/components/Settings/ExportSettings.vue
+++ b/frontend/src/components/Settings/ExportSettings.vue
@@ -1,183 +1,27 @@
 <template>
-	<h1>{{ __('Export Mail') }}</h1>
-	<FormControl
-		v-model="mailExport.format"
-		:label="__('Format')"
-		type="select"
-		variant="outline"
-		:options="FORMAT_OPTIONS"
-	/>
-	<FormControl
-		v-model="mailExport.archive_type"
-		:label="__('Archive Type')"
-		type="select"
-		variant="outline"
-		:options="ARCHIVE_TYPE_OPTIONS"
-	/>
-	<Switch
-		v-model="customSelection"
-		:label="__('Custom Selection')"
-		:description="__('Apply filters to select specific emails for export.')"
-		class="hover:!bg-surface-white !cursor-default !p-0"
-	/>
-	<template v-if="customSelection">
-		<FormControl
-			v-model="filter.inMailbox"
-			:label="__('Folder')"
-			type="select"
-			variant="outline"
-			:options="mailboxOptions"
-		/>
-		<FormControl
-			v-model="filter.after"
-			type="date"
-			variant="outline"
-			:label="__('From Date')"
-		/>
-		<FormControl
-			v-model="filter.before"
-			type="date"
-			variant="outline"
-			:label="__('To Date')"
-		/>
-		<FormControl
-			v-model="filter.hasAttachment"
-			type="select"
-			variant="outline"
-			:label="__('Attachments')"
-			:options="getAttachmentOptions()"
-		/>
-		<FormControl
-			v-model="filter.isRead"
-			type="select"
-			variant="outline"
-			:label="__('Read Status')"
-			:options="getReadStatusOptions()"
-		/>
-		<FormControl
-			v-model="mailExport.limit"
-			:label="__('Max Number of Emails')"
-			type="number"
-			variant="outline"
-			placeholder="1000"
-		/>
-		<FormControl
-			v-if="mailExport.limit && mailExport.limit > 0"
-			v-model="mailExport.sort"
-			:label="__('Start From')"
-			type="select"
-			variant="outline"
-			:options="sortOptions"
-		/>
-	</template>
-
-	<Button
-		class="min-h-7"
-		:label="__('Create Export')"
-		:loading="ongoingExport.data?.name"
-		:disabled="ongoingExport.loading || ongoingExport.error || createMailExport.loading"
-		@click="createMailExport.submit()"
-	/>
-	<div class="!mt-3 space-x-1 text-base">
-		<span class="text-ink-gray-5">{{ exportSubtitle }}</span>
-		<a class="hover:underline" :href="exportHref" target="_blank">
-			{{ exportLinkText }}
-		</a>
-	</div>
-	<ErrorMessage v-if="createMailExport.error" :message="createMailExport.error" class="mb-2.5" />
+	<h1>{{ __('Export') }}</h1>
+	<TabButtons v-model="activeType" :buttons="typeButtons" />
+	<component :is="activeComponent" :key="activeType" />
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, reactive, ref } from 'vue'
-import { Button, ErrorMessage, FormControl, Switch, createResource } from 'frappe-ui'
+import { type Component, computed, markRaw, ref } from 'vue'
+import { TabButtons } from 'frappe-ui'
 
-import { getAttachmentOptions, getReadStatusOptions } from '@/constants'
-import { userStore } from '@/stores/user'
+import CalendarExportSettings from '@/components/Settings/CalendarExportSettings.vue'
+import MailExportSettings from '@/components/Settings/MailExportSettings.vue'
 
-const { accountId, mailboxes } = userStore()
+const activeType = ref('mail')
 
-const user = inject('$user')
-const socket = inject('$socket')
+const typeButtons = [
+	{ label: __('Mail'), value: 'mail' },
+	{ label: __('Calendar'), value: 'calendar' },
+]
 
-const mailExport = reactive({
-	format: 'jmap',
-	archive_type: '.zip',
-	sort: 'Received At (ASC)',
-	limit: undefined,
-})
+const components: Record<string, Component> = {
+	mail: markRaw(MailExportSettings),
+	calendar: markRaw(CalendarExportSettings),
+}
 
-const customSelection = ref(false)
-
-const filter = reactive({
-	inMailbox: '',
-	after: '',
-	before: '',
-	hasAttachment: ' ',
-	isRead: ' ',
-})
-
-const mailboxOptions = computed(() =>
-	[{ label: __(''), value: ' ' }].concat(
-		mailboxes.data.map((m: { id: string; _name: string }) => ({
-			label: m._name,
-			value: m.id,
-		})),
-	),
-)
-
-const sortOptions = computed(() => [
-	{ label: __('Oldest Emails'), value: 'Received At (ASC)' },
-	{ label: __('Newest Emails'), value: 'Received At (DESC)' },
-])
-
-const createMailExport = createResource({
-	url: 'mail.api.account.create_mail_export',
-	makeParams: () => {
-		const cleanedFilter = Object.fromEntries(
-			Object.entries(filter)
-				.map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
-				.filter(([, v]) => Boolean(v)),
-		)
-		return { account_id: accountId, ...mailExport, filter: cleanedFilter }
-	},
-	onSuccess: () => ongoingExport.reload(),
-})
-
-const ongoingExport = createResource({
-	url: 'frappe.client.get_value',
-	auto: true,
-	makeParams: () => ({
-		doctype: 'Mail Exchange',
-		fieldname: 'name',
-		filters: {
-			user: user.data.name,
-			operation: 'Export',
-			status: ['in', ['Queued', 'In Progress']],
-		},
-	}),
-})
-
-onMounted(() =>
-	socket.on('mail_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
-		if (payload.action === 'Export') ongoingExport.reload()
-	}),
-)
-
-const exportSubtitle = computed(() => {
-	if (ongoingExport.data?.name) return __("Export in progress. We'll email you when it's ready.")
-	return __('No exports in progress.')
-})
-
-const exportHref = computed(() => {
-	if (ongoingExport.data?.name) return `/mail/mail-exchanges/${ongoingExport.data.name}`
-	return '/mail/mail-exchanges?operation=Export'
-})
-
-const exportLinkText = computed(() => {
-	if (ongoingExport.data?.name) return __('Track status')
-	return __('View history')
-})
-
-const FORMAT_OPTIONS = ['jmap', 'mbox', 'maildir', 'maildir-nested']
-const ARCHIVE_TYPE_OPTIONS = ['.zip', '.tgz', '.tar.gz']
+const activeComponent = computed(() => components[activeType.value])
 </script>

--- a/frontend/src/components/Settings/ImportSettings.vue
+++ b/frontend/src/components/Settings/ImportSettings.vue
@@ -1,169 +1,27 @@
 <template>
-	<h1>{{ __('Import Mail') }}</h1>
-	<FormControl
-		v-model="mailImport.format"
-		:label="__('Format')"
-		type="select"
-		variant="outline"
-		:options="FORMAT_OPTIONS"
-		required
-	/>
-	<template v-if="['eml', 'mbox', 'maildir'].includes(mailImport.format)">
-		<FormControl
-			v-model="mailImport.mailbox"
-			:label="__('Folder')"
-			type="select"
-			variant="outline"
-			:options="mailboxOptions"
-		/>
-		<FormControl
-			v-model="mailImport.seen"
-			:label="__('Mark as Read')"
-			type="select"
-			variant="outline"
-			:options="markAsReadOptions"
-		/>
-	</template>
-	<input
-		ref="fileInput"
-		type="file"
-		class="hidden"
-		:accept="acceptTypes"
-		@change="onFileSelected"
-	/>
-	<Button
-		class="w-full"
-		:label="uploading ? __('Uploading ({0}%)', [progress]) : __('Upload File')"
-		:loading="uploading"
-		@click="fileInput?.click()"
-	/>
-	<p class="text-ink-gray-5 mt-2 flex text-sm">{{ fileUploadSubtitle }}</p>
-
-	<Button
-		class="min-h-7"
-		:label="__('Create Import')"
-		variant="solid"
-		:loading="ongoingImport.data?.name"
-		:disabled="ongoingImport.loading || ongoingImport.error || !mailImport.file"
-		@click="createMailImport.submit()"
-	/>
-	<div class="!mt-3 space-x-1 text-base">
-		<span class="text-ink-gray-5">{{ importSubtitle }}</span>
-		<a class="hover:underline" :href="importHref" target="_blank">
-			{{ importLinkText }}
-		</a>
-	</div>
-	<ErrorMessage v-if="createMailImport.error" :message="createMailImport.error" class="mb-2.5" />
+	<h1>{{ __('Import') }}</h1>
+	<TabButtons v-model="activeType" :buttons="typeButtons" />
+	<component :is="activeComponent" :key="activeType" />
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, reactive, ref, watch } from 'vue'
-import { Button, ErrorMessage, FormControl, createResource } from 'frappe-ui'
+import { type Component, computed, markRaw, ref } from 'vue'
+import { TabButtons } from 'frappe-ui'
 
-import { raiseToast } from '@/utils'
-import { useChunkedUpload } from '@/utils/useChunkedUpload'
-import { userStore } from '@/stores/user'
+import CalendarImportSettings from '@/components/Settings/CalendarImportSettings.vue'
+import MailImportSettings from '@/components/Settings/MailImportSettings.vue'
 
-const { accountId, mailboxes } = userStore()
+const activeType = ref('mail')
 
-const user = inject('$user')
-const socket = inject('$socket')
+const typeButtons = [
+	{ label: __('Mail'), value: 'mail' },
+	{ label: __('Calendar'), value: 'calendar' },
+]
 
-const mailImport = reactive({
-	format: 'eml',
-	file: '',
-	mailbox: '',
-	seen: true,
-})
-
-const fileInput = ref<HTMLInputElement | null>(null)
-const { uploading, progress, upload } = useChunkedUpload()
-
-const acceptTypes = computed(() => (mailImport.format === 'eml' ? '.eml' : '.zip,.tgz,.tar.gz'))
-
-// Upload in chunks so large import archives aren't blocked by the web server's request-size limit.
-const onFileSelected = async (event: Event) => {
-	const input = event.target as HTMLInputElement
-	const file = input.files?.[0]
-	input.value = '' // let the same file be re-selected after an error
-	if (!file) return
-
-	try {
-		const uploaded = await upload(file, { private: true })
-		mailImport.file = uploaded.file_url
-	} catch (error) {
-		raiseToast((error as Error).message, 'error')
-	}
+const components: Record<string, Component> = {
+	mail: markRaw(MailImportSettings),
+	calendar: markRaw(CalendarImportSettings),
 }
 
-const mailboxOptions = computed(() =>
-	mailboxes.data.map((m: { id: string; _name: string }) => ({
-		label: m._name,
-		value: m.id,
-	})),
-)
-
-const markAsReadOptions = computed(() => [
-	{ label: __('Yes'), value: true },
-	{ label: __('No'), value: false },
-])
-
-const fileUploadSubtitle = computed(() => {
-	if (mailImport.file) return __('File uploaded: {0}', [mailImport.file])
-	if (mailImport.format === 'eml') return __('Supported file format: .eml')
-	return __('Supported file formats: .zip, .tar, .tgz')
-})
-
-watch(
-	mailboxOptions,
-	(options) => {
-		if (options.length > 0 && !mailImport.mailbox) {
-			mailImport.mailbox = options[0].value
-		}
-	},
-	{ immediate: true },
-)
-
-const createMailImport = createResource({
-	url: 'mail.api.account.create_mail_import',
-	makeParams: () => ({ account_id: accountId, ...mailImport }),
-	onSuccess: () => ongoingImport.reload(),
-})
-
-const ongoingImport = createResource({
-	url: 'frappe.client.get_value',
-	auto: true,
-	makeParams: () => ({
-		doctype: 'Mail Exchange',
-		fieldname: 'name',
-		filters: {
-			user: user.data.name,
-			operation: 'Import',
-			status: ['in', ['Queued', 'In Progress']],
-		},
-	}),
-})
-
-onMounted(() =>
-	socket.on('mail_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
-		if (payload.action === 'Import') ongoingImport.reload()
-	}),
-)
-
-const importSubtitle = computed(() => {
-	if (ongoingImport.data?.name) return __("Import in progress. We'll email you when it's ready.")
-	return __('No imports in progress.')
-})
-
-const importHref = computed(() => {
-	if (ongoingImport.data?.name) return `/mail/mail-exchanges/${ongoingImport.data.name}`
-	return '/mail/mail-exchanges?operation=Import'
-})
-
-const importLinkText = computed(() => {
-	if (ongoingImport.data?.name) return __('Track status')
-	return __('View history')
-})
-
-const FORMAT_OPTIONS = ['eml', 'jmap', 'mbox', 'maildir', 'maildir-nested']
+const activeComponent = computed(() => components[activeType.value])
 </script>

--- a/frontend/src/components/Settings/MailExportSettings.vue
+++ b/frontend/src/components/Settings/MailExportSettings.vue
@@ -1,13 +1,13 @@
 <template>
 	<FormControl
-		v-model="calendarExport.format"
+		v-model="mailExport.format"
 		:label="__('Format')"
 		type="select"
 		variant="outline"
 		:options="FORMAT_OPTIONS"
 	/>
 	<FormControl
-		v-model="calendarExport.archive_type"
+		v-model="mailExport.archive_type"
 		:label="__('Archive Type')"
 		type="select"
 		variant="outline"
@@ -16,18 +16,17 @@
 	<Switch
 		v-model="customSelection"
 		:label="__('Custom Selection')"
-		:description="__('Apply filters to select specific events for export.')"
+		:description="__('Apply filters to select specific emails for export.')"
 		class="hover:!bg-surface-white !cursor-default !p-0"
 	/>
 	<template v-if="customSelection">
 		<FormControl
-			v-model="filter.inCalendar"
-			:label="__('Calendar')"
+			v-model="filter.inMailbox"
+			:label="__('Folder')"
 			type="select"
 			variant="outline"
-			:options="calendarOptions"
+			:options="mailboxOptions"
 		/>
-		<FormControl v-model="filter.title" type="text" variant="outline" :label="__('Title')" />
 		<FormControl
 			v-model="filter.after"
 			type="date"
@@ -41,15 +40,29 @@
 			:label="__('To Date')"
 		/>
 		<FormControl
-			v-model="calendarExport.limit"
-			:label="__('Max Number of Events')"
+			v-model="filter.hasAttachment"
+			type="select"
+			variant="outline"
+			:label="__('Attachments')"
+			:options="getAttachmentOptions()"
+		/>
+		<FormControl
+			v-model="filter.isRead"
+			type="select"
+			variant="outline"
+			:label="__('Read Status')"
+			:options="getReadStatusOptions()"
+		/>
+		<FormControl
+			v-model="mailExport.limit"
+			:label="__('Max Number of Emails')"
 			type="number"
 			variant="outline"
 			placeholder="1000"
 		/>
 		<FormControl
-			v-if="calendarExport.limit && calendarExport.limit > 0"
-			v-model="calendarExport.sort"
+			v-if="mailExport.limit && mailExport.limit > 0"
+			v-model="mailExport.sort"
 			:label="__('Start From')"
 			type="select"
 			variant="outline"
@@ -61,8 +74,8 @@
 		class="min-h-7"
 		:label="__('Create Export')"
 		:loading="ongoingExport.data?.name"
-		:disabled="ongoingExport.loading || ongoingExport.error || createCalendarExport.loading"
-		@click="createCalendarExport.submit()"
+		:disabled="ongoingExport.loading || ongoingExport.error || createMailExport.loading"
+		@click="createMailExport.submit()"
 	/>
 	<div class="!mt-3 space-x-1 text-base">
 		<span class="text-ink-gray-5">{{ exportSubtitle }}</span>
@@ -70,69 +83,61 @@
 			{{ exportLinkText }}
 		</a>
 	</div>
-	<ErrorMessage
-		v-if="createCalendarExport.error"
-		:message="createCalendarExport.error"
-		class="mb-2.5"
-	/>
+	<ErrorMessage v-if="createMailExport.error" :message="createMailExport.error" class="mb-2.5" />
 </template>
 
 <script setup lang="ts">
 import { computed, inject, onMounted, reactive, ref } from 'vue'
 import { Button, ErrorMessage, FormControl, Switch, createResource } from 'frappe-ui'
 
+import { getAttachmentOptions, getReadStatusOptions } from '@/constants'
 import { userStore } from '@/stores/user'
 
-const { accountId, user: sessionUser } = userStore()
+const { accountId, mailboxes } = userStore()
 
 const user = inject('$user')
 const socket = inject('$socket')
 
-const calendarExport = reactive({
+const mailExport = reactive({
 	format: 'jmap',
 	archive_type: '.zip',
-	sort: 'Start (ASC)',
+	sort: 'Received At (ASC)',
 	limit: undefined,
 })
 
 const customSelection = ref(false)
 
 const filter = reactive({
-	inCalendar: '',
-	title: '',
+	inMailbox: '',
 	after: '',
 	before: '',
+	hasAttachment: ' ',
+	isRead: ' ',
 })
 
-const calendars = createResource({
-	url: 'mail.client.doctype.calendar.calendar.fetch_calendars',
-	auto: true,
-	makeParams: () => ({ account: `${sessionUser}:${accountId}`, limit: 100 }),
-})
-
-const calendarOptions = computed(() =>
+const mailboxOptions = computed(() =>
 	[{ label: __(''), value: ' ' }].concat(
-		(calendars.data || []).map((c: { id: string; _name: string }) => ({
-			label: c._name,
-			value: c.id,
+		mailboxes.data.map((m: { id: string; _name: string }) => ({
+			label: m._name,
+			value: m.id,
 		})),
 	),
 )
 
 const sortOptions = computed(() => [
-	{ label: __('Oldest Events'), value: 'Start (ASC)' },
-	{ label: __('Newest Events'), value: 'Start (DESC)' },
+	{ label: __('Oldest Emails'), value: 'Received At (ASC)' },
+	{ label: __('Newest Emails'), value: 'Received At (DESC)' },
 ])
 
-const createCalendarExport = createResource({
-	url: 'mail.api.account.create_calendar_export',
+const createMailExport = createResource({
+	url: 'mail.api.account.create_mail_export',
 	makeParams: () => {
 		const cleanedFilter = Object.fromEntries(
 			Object.entries(filter)
 				.map(([k, v]) => [k, typeof v === 'string' ? v.trim() : v])
 				.filter(([, v]) => Boolean(v)),
 		)
-		return { account_id: accountId, ...calendarExport, filter: cleanedFilter }
+		return { account_id: accountId, ...mailExport, filter: cleanedFilter }
 	},
 	onSuccess: () => ongoingExport.reload(),
 })
@@ -141,7 +146,7 @@ const ongoingExport = createResource({
 	url: 'frappe.client.get_value',
 	auto: true,
 	makeParams: () => ({
-		doctype: 'Calendar Exchange',
+		doctype: 'Mail Exchange',
 		fieldname: 'name',
 		filters: {
 			user: user.data.name,
@@ -152,7 +157,7 @@ const ongoingExport = createResource({
 })
 
 onMounted(() =>
-	socket.on('calendar_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
+	socket.on('mail_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
 		if (payload.action === 'Export') ongoingExport.reload()
 	}),
 )
@@ -163,8 +168,8 @@ const exportSubtitle = computed(() => {
 })
 
 const exportHref = computed(() => {
-	if (ongoingExport.data?.name) return `/mail/calendar-exchanges/${ongoingExport.data.name}`
-	return '/mail/calendar-exchanges?operation=Export'
+	if (ongoingExport.data?.name) return `/mail/mail-exchanges/${ongoingExport.data.name}`
+	return '/mail/mail-exchanges?operation=Export'
 })
 
 const exportLinkText = computed(() => {
@@ -172,6 +177,6 @@ const exportLinkText = computed(() => {
 	return __('View history')
 })
 
-const FORMAT_OPTIONS = ['jmap', 'ics']
+const FORMAT_OPTIONS = ['jmap', 'mbox', 'maildir', 'maildir-nested']
 const ARCHIVE_TYPE_OPTIONS = ['.zip', '.tgz', '.tar.gz']
 </script>

--- a/frontend/src/components/Settings/MailImportSettings.vue
+++ b/frontend/src/components/Settings/MailImportSettings.vue
@@ -1,19 +1,28 @@
 <template>
 	<FormControl
-		v-model="calendarImport.format"
+		v-model="mailImport.format"
 		:label="__('Format')"
 		type="select"
 		variant="outline"
 		:options="FORMAT_OPTIONS"
 		required
 	/>
-	<FormControl
-		v-model="calendarImport.calendar"
-		:label="__('Calendar')"
-		type="select"
-		variant="outline"
-		:options="calendarOptions"
-	/>
+	<template v-if="['eml', 'mbox', 'maildir'].includes(mailImport.format)">
+		<FormControl
+			v-model="mailImport.mailbox"
+			:label="__('Folder')"
+			type="select"
+			variant="outline"
+			:options="mailboxOptions"
+		/>
+		<FormControl
+			v-model="mailImport.seen"
+			:label="__('Mark as Read')"
+			type="select"
+			variant="outline"
+			:options="markAsReadOptions"
+		/>
+	</template>
 	<input
 		ref="fileInput"
 		type="file"
@@ -34,8 +43,8 @@
 		:label="__('Create Import')"
 		variant="solid"
 		:loading="ongoingImport.data?.name"
-		:disabled="ongoingImport.loading || ongoingImport.error || !calendarImport.file"
-		@click="createCalendarImport.submit()"
+		:disabled="ongoingImport.loading || ongoingImport.error || !mailImport.file"
+		@click="createMailImport.submit()"
 	/>
 	<div class="!mt-3 space-x-1 text-base">
 		<span class="text-ink-gray-5">{{ importSubtitle }}</span>
@@ -43,38 +52,33 @@
 			{{ importLinkText }}
 		</a>
 	</div>
-	<ErrorMessage
-		v-if="createCalendarImport.error"
-		:message="createCalendarImport.error"
-		class="mb-2.5"
-	/>
+	<ErrorMessage v-if="createMailImport.error" :message="createMailImport.error" class="mb-2.5" />
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onMounted, reactive, ref } from 'vue'
+import { computed, inject, onMounted, reactive, ref, watch } from 'vue'
 import { Button, ErrorMessage, FormControl, createResource } from 'frappe-ui'
 
 import { raiseToast } from '@/utils'
 import { useChunkedUpload } from '@/utils/useChunkedUpload'
 import { userStore } from '@/stores/user'
 
-const { accountId, user: sessionUser } = userStore()
+const { accountId, mailboxes } = userStore()
 
 const user = inject('$user')
 const socket = inject('$socket')
 
-const calendarImport = reactive({
-	format: 'ics',
+const mailImport = reactive({
+	format: 'eml',
 	file: '',
-	calendar: '',
+	mailbox: '',
+	seen: true,
 })
 
 const fileInput = ref<HTMLInputElement | null>(null)
 const { uploading, progress, upload } = useChunkedUpload()
 
-const acceptTypes = computed(() =>
-	calendarImport.format === 'ics' ? '.ics' : '.zip,.tgz,.tar.gz',
-)
+const acceptTypes = computed(() => (mailImport.format === 'eml' ? '.eml' : '.zip,.tgz,.tar.gz'))
 
 // Upload in chunks so large import archives aren't blocked by the web server's request-size limit.
 const onFileSelected = async (event: Event) => {
@@ -85,36 +89,43 @@ const onFileSelected = async (event: Event) => {
 
 	try {
 		const uploaded = await upload(file, { private: true })
-		calendarImport.file = uploaded.file_url
+		mailImport.file = uploaded.file_url
 	} catch (error) {
 		raiseToast((error as Error).message, 'error')
 	}
 }
 
-const calendars = createResource({
-	url: 'mail.client.doctype.calendar.calendar.fetch_calendars',
-	auto: true,
-	makeParams: () => ({ account: `${sessionUser}:${accountId}`, limit: 100 }),
-})
-
-const calendarOptions = computed(() =>
-	[{ label: __('Default'), value: '' }].concat(
-		(calendars.data || []).map((c: { id: string; _name: string }) => ({
-			label: c._name,
-			value: c.id,
-		})),
-	),
+const mailboxOptions = computed(() =>
+	mailboxes.data.map((m: { id: string; _name: string }) => ({
+		label: m._name,
+		value: m.id,
+	})),
 )
 
+const markAsReadOptions = computed(() => [
+	{ label: __('Yes'), value: true },
+	{ label: __('No'), value: false },
+])
+
 const fileUploadSubtitle = computed(() => {
-	if (calendarImport.file) return __('File uploaded: {0}', [calendarImport.file])
-	if (calendarImport.format === 'ics') return __('Supported file format: .ics')
+	if (mailImport.file) return __('File uploaded: {0}', [mailImport.file])
+	if (mailImport.format === 'eml') return __('Supported file format: .eml')
 	return __('Supported file formats: .zip, .tar, .tgz')
 })
 
-const createCalendarImport = createResource({
-	url: 'mail.api.account.create_calendar_import',
-	makeParams: () => ({ account_id: accountId, ...calendarImport }),
+watch(
+	mailboxOptions,
+	(options) => {
+		if (options.length > 0 && !mailImport.mailbox) {
+			mailImport.mailbox = options[0].value
+		}
+	},
+	{ immediate: true },
+)
+
+const createMailImport = createResource({
+	url: 'mail.api.account.create_mail_import',
+	makeParams: () => ({ account_id: accountId, ...mailImport }),
 	onSuccess: () => ongoingImport.reload(),
 })
 
@@ -122,7 +133,7 @@ const ongoingImport = createResource({
 	url: 'frappe.client.get_value',
 	auto: true,
 	makeParams: () => ({
-		doctype: 'Calendar Exchange',
+		doctype: 'Mail Exchange',
 		fieldname: 'name',
 		filters: {
 			user: user.data.name,
@@ -133,7 +144,7 @@ const ongoingImport = createResource({
 })
 
 onMounted(() =>
-	socket.on('calendar_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
+	socket.on('mail_exchange_completed', (payload: { action: 'Import' | 'Export' }) => {
 		if (payload.action === 'Import') ongoingImport.reload()
 	}),
 )
@@ -144,8 +155,8 @@ const importSubtitle = computed(() => {
 })
 
 const importHref = computed(() => {
-	if (ongoingImport.data?.name) return `/mail/calendar-exchanges/${ongoingImport.data.name}`
-	return '/mail/calendar-exchanges?operation=Import'
+	if (ongoingImport.data?.name) return `/mail/mail-exchanges/${ongoingImport.data.name}`
+	return '/mail/mail-exchanges?operation=Import'
 })
 
 const importLinkText = computed(() => {
@@ -153,5 +164,5 @@ const importLinkText = computed(() => {
 	return __('View history')
 })
 
-const FORMAT_OPTIONS = ['ics', 'jmap']
+const FORMAT_OPTIONS = ['eml', 'jmap', 'mbox', 'maildir', 'maildir-nested']
 </script>

--- a/frontend/src/pages/CalendarExchangeView.vue
+++ b/frontend/src/pages/CalendarExchangeView.vue
@@ -1,0 +1,125 @@
+<template>
+	<div v-if="calendarExchange.data" class="flex h-screen flex-col">
+		<header class="flex items-center justify-between border-b px-5 py-2.5">
+			<Breadcrumbs :items="breadcrumbs" />
+			<Dropdown
+				v-if="user.data.is_system_manager"
+				:options="dropdownOptions"
+				:button="{ icon: 'more-horizontal' }"
+			/>
+		</header>
+		<div class="mx-auto my-5 rounded border p-12 sm:w-[60rem]">
+			<div class="flex items-center space-x-2">
+				<h1 class="text-xl !font-semibold">
+					{{ __('Calendar {0}', [__(calendarExchange.data?.operation)]) }}
+				</h1>
+				<Badge
+					:theme="getTheme(calendarExchange.data?.status)"
+					:label="calendarExchange.data?.status"
+				/>
+			</div>
+			<p class="my-4 text-base">{{ operationDetails }}</p>
+			<CopyCode
+				v-if="calendarExchange.data?.output"
+				:code="calendarExchange.data?.output"
+				class="mt-8 max-h-80 overflow-y-auto"
+			/>
+			<template v-if="attachment.data?.file_url">
+				<hr class="my-8" />
+				<a
+					v-if="attachment.data?.file_url"
+					class="flex cursor-pointer items-center space-x-2 text-base hover:underline"
+					:href="attachment.data.file_url"
+					target="_blank"
+				>
+					<Download class="text-ink-gray-4 h-4 w-4 shrink-0" />
+					<span>
+						{{
+							__('{0} ({1})', [
+								attachment.data?.file_name,
+								formatBytes(attachment.data?.file_size),
+							])
+						}}
+					</span>
+				</a>
+			</template>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+import { useRouter } from 'vue-router'
+import { Download } from 'lucide-vue-next'
+import { Badge, Breadcrumbs, Dropdown, createResource } from 'frappe-ui'
+
+import { formatBytes, getTheme } from '@/utils'
+import CopyCode from '@/components/CopyCode.vue'
+
+const { id } = defineProps<{ id: string }>()
+
+const user = inject('$user')
+const dayjs = inject('$dayjs')
+
+const router = useRouter()
+
+const calendarExchange = createResource({
+	url: 'frappe.client.get_value',
+	auto: true,
+	makeParams: () => ({
+		doctype: 'Calendar Exchange',
+		filters: { name: id },
+		fieldname: [
+			'status',
+			'operation',
+			'started_at',
+			'completed_at',
+			'output',
+			'import_format',
+			'export_format',
+		],
+	}),
+	onSuccess: (data) => {
+		if (!data?.operation) router.replace('/calendar-exchanges')
+	},
+	onError: () => router.replace('/calendar-exchanges'),
+})
+
+const operationDetails = computed(() => {
+	const format =
+		calendarExchange.data?.operation === 'Import'
+			? calendarExchange.data?.import_format
+			: calendarExchange.data?.export_format
+	return `${format.toUpperCase()} · ${dayjs(calendarExchange.data?.started_at).format('MMM D, YYYY [at] h:mm A')}`
+})
+
+const attachment = createResource({
+	url: 'frappe.client.get_value',
+	auto: true,
+	makeParams: () => ({
+		doctype: 'File',
+		fieldname: ['file_size', 'file_url', 'file_type', 'file_name'],
+		filters: {
+			attached_to_doctype: 'Calendar Exchange',
+			attached_to_name: id,
+			attached_to_field: 'file',
+		},
+	}),
+})
+
+const dropdownOptions = computed(() => [
+	{
+		label: __('View in Desk'),
+		icon: 'external-link',
+		onClick: () => window.open(`/app/calendar-exchange/${id}`, '_blank')?.focus(),
+	},
+])
+
+const breadcrumbs = computed(() => [
+	{
+		label: __('Calendar Exchanges'),
+		route: `/calendar-exchanges?operation=${calendarExchange.data?.operation}`,
+	},
+	{ label: id },
+])
+</script>

--- a/frontend/src/pages/CalendarExchangesView.vue
+++ b/frontend/src/pages/CalendarExchangesView.vue
@@ -1,0 +1,150 @@
+<template>
+	<div class="flex h-screen flex-col">
+		<header class="flex items-center border-b px-5 py-2.5">
+			<Breadcrumbs :items="[{ label: __('Calendar Exchanges') }]" />
+		</header>
+		<Tabs
+			v-model="tabIndex"
+			:tabs="TABS"
+			@update:model-value="
+				$router.replace({ query: { operation: tabIndex ? 'Export' : 'Import' } })
+			"
+		>
+			<template #tab-panel>
+				<div class="m-5 flex flex-1 flex-col space-y-5 overflow-y-auto">
+					<div class="flex items-center space-x-3">
+						<FormControl
+							v-model="status"
+							:label="__('Status')"
+							type="select"
+							:options="STATUS_OPTIONS"
+							class="w-40"
+						/>
+					</div>
+					<ListView
+						v-if="calendarExchanges.data"
+						:columns="listColumns"
+						:rows="calendarExchanges.data"
+						:options="LIST_OPTIONS"
+						row-key="name"
+						class="flex-1"
+					>
+						<ListHeader />
+						<ListRows>
+							<template v-if="calendarExchanges.data.length">
+								<ListRow
+									v-for="row in calendarExchanges.data"
+									:key="row.name"
+									v-slot="{ item, column }"
+									:row="row"
+								>
+									<ListRowItem :item="item">
+										<Badge
+											v-if="column.key == 'status'"
+											:theme="getTheme(item)"
+											:label="item"
+										/>
+									</ListRowItem>
+								</ListRow>
+							</template>
+							<ListEmptyState v-else />
+						</ListRows>
+					</ListView>
+					<ErrorMessage
+						v-if="calendarExchanges.error"
+						:message="calendarExchanges.error"
+					/>
+				</div>
+			</template>
+		</Tabs>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { CalendarPlus, CalendarRange } from 'lucide-vue-next'
+import {
+	Badge,
+	Breadcrumbs,
+	ErrorMessage,
+	FormControl,
+	ListEmptyState,
+	ListHeader,
+	ListRow,
+	ListRowItem,
+	ListRows,
+	ListView,
+	Tabs,
+	useList,
+} from 'frappe-ui'
+
+import { getTheme } from '@/utils'
+
+const user = inject('$user')
+const dayjs = inject('$dayjs')
+const route = useRoute()
+
+const tabIndex = ref(route.query.operation === 'Export' ? 1 : 0)
+const status = ref(' ')
+
+const STATUS_OPTIONS = [
+	{ label: '', value: ' ' },
+	{ label: __('Draft'), value: 'Draft' },
+	{ label: __('Queued'), value: 'Queued' },
+	{ label: __('In Progress'), value: 'In Progress' },
+	{ label: __('Completed'), value: 'Completed' },
+	{ label: __('Failed'), value: 'Failed' },
+	{ label: __('Cancelled'), value: 'Cancelled' },
+]
+
+const calendarExchanges = useList({
+	doctype: 'Calendar Exchange',
+	fields: [
+		'name',
+		'status',
+		'import_format',
+		'export_format',
+		'export_archive_type',
+		'started_at',
+	],
+	filters: () => {
+		const filters: Record<string, string> = {
+			user: user.data.name,
+			operation: tabIndex.value ? 'Export' : 'Import',
+		}
+		if (status.value !== ' ') filters.status = status.value
+		return filters
+	},
+	orderBy: 'creation desc',
+	transform: (data) =>
+		data.map((row) => ({
+			...row,
+			started_at: row.started_at ? dayjs(row.started_at).format('MMM D, YYYY h:mm A') : '-',
+		})),
+})
+
+const listColumns = computed(() => {
+	const columns = [
+		{ label: __('Started'), key: 'started_at' },
+		{ label: __('Status'), key: 'status' },
+		{
+			label: __('Format'),
+			key: tabIndex.value ? 'export_format' : 'import_format',
+		},
+	]
+	if (tabIndex.value) columns.push({ label: __('Archive Type'), key: 'export_archive_type' })
+	return columns
+})
+
+const LIST_OPTIONS = {
+	selectable: false,
+	getRowRoute: (row) => ({ name: 'CalendarExchange', params: { id: row.name } }),
+	emptyState: { description: __('No calendar exchanges found.') },
+}
+
+const TABS = [
+	{ label: __('Import'), icon: CalendarPlus, index: 0 },
+	{ label: __('Export'), icon: CalendarRange, index: 1 },
+]
+</script>

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -1062,6 +1062,10 @@ onMounted(() => {
 	socket.on('mail_exchange_completed', (payload: { success: boolean; message: string }) =>
 		raiseToast(payload.message, payload.success ? 'success' : 'error'),
 	)
+
+	socket.on('calendar_exchange_completed', (payload: { success: boolean; message: string }) =>
+		raiseToast(payload.message, payload.success ? 'success' : 'error'),
+	)
 })
 
 onUnmounted(() => {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -90,6 +90,19 @@ const routes = [
 		props: true,
 	},
 	{
+		path: '/calendar-exchanges',
+		name: 'CalendarExchanges',
+		component: () => import('@/pages/CalendarExchangesView.vue'),
+		meta: { noLayout: true },
+	},
+	{
+		path: '/calendar-exchanges/:id',
+		name: 'CalendarExchange',
+		component: () => import('@/pages/CalendarExchangeView.vue'),
+		meta: { noLayout: true },
+		props: true,
+	},
+	{
 		path: '/mime-message/:id',
 		name: 'MimeMessage',
 		component: () => import('@/pages/MimeMessageView.vue'),

--- a/mail/api/account.py
+++ b/mail/api/account.py
@@ -299,6 +299,71 @@ def create_mail_export(
 
 
 @frappe.whitelist()
+def create_calendar_import(
+	account_id: str,
+	format: Literal["ics", "jmap"],
+	file: str,
+	calendar: str | None = None,
+) -> None:
+	"""Creates calendar exchange of operation import"""
+
+	doc = frappe.new_doc("Calendar Exchange")
+	doc.user = frappe.session.user
+	doc.account_id = account_id
+	doc.operation = "Import"
+	doc.import_format = format
+	doc.import_file = file
+	if calendar:
+		doc.import_metadata = json.dumps({"calendarIds": {calendar: True}})
+	doc.insert()
+	doc.submit()
+
+
+@frappe.whitelist()
+def create_calendar_export(
+	account_id: str,
+	format: Literal["ics", "jmap"],
+	archive_type: Literal[".zip", ".tgz", ".tar.gz"],
+	sort: Literal["Start (ASC)", "Start (DESC)"],
+	limit: int | None = None,
+	filter: dict | None = None,
+) -> None:
+	"""Creates calendar exchange of operation export"""
+
+	doc = frappe.new_doc("Calendar Exchange")
+	doc.user = frappe.session.user
+	doc.account_id = account_id
+	doc.operation = "Export"
+	doc.export_format = format
+	doc.export_archive_type = archive_type
+	doc.export_sort = sort
+	doc.export_limit = limit
+	if filter:
+		filter = {k: v for k, v in filter.items() if v}
+		if normalized := normalize_calendar_filter(filter):
+			doc.export_filter = json.dumps(normalized)
+	doc.insert()
+	doc.submit()
+
+
+def normalize_calendar_filter(filter: dict) -> dict:
+	"""Normalize a calendar export filter into a JMAP CalendarEvent/query FilterCondition."""
+
+	from mail.utils.dt import convert_to_utc
+
+	normalized = {}
+	if title := filter.get("title"):
+		normalized["title"] = title
+	if in_calendar := filter.get("inCalendar"):
+		normalized["inCalendar"] = in_calendar
+	for key in ("after", "before"):
+		if value := filter.get(key):
+			normalized[key] = convert_to_utc(value, naive=True).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+	return normalized
+
+
+@frappe.whitelist()
 def is_push_notification_relay_enabled() -> bool:
 	return frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay")
 

--- a/mail/client/doctype/calendar_exchange/calendar_exchange.js
+++ b/mail/client/doctype/calendar_exchange/calendar_exchange.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Calendar Exchange', {
+	refresh(frm) {
+		frm.trigger('set_account_options')
+		if (!frm.doc.__islocal) {
+			frm.trigger('add_actions')
+		}
+	},
+
+	user(frm) {
+		frm.set_value('account_id', null)
+		frm.trigger('set_account_options')
+	},
+
+	add_actions(frm) {
+		if (frm.doc.docstatus != 1) return
+		if (!frappe.user_roles.includes('System Manager')) return
+
+		if (['Failed'].includes(frm.doc.status)) {
+			frm.add_custom_button(__('Retry'), () => frm.trigger('retry'), __('Actions'))
+		}
+	},
+
+	set_account_options(frm) {
+		if (frm.doc.user) {
+			frappe.call({
+				method: 'mail.jmap.get_user_account_ids',
+				args: {
+					user: frm.doc.user,
+				},
+				callback: (r) => {
+					frm.set_df_property('account_id', 'options', r.message || [])
+					frm.refresh_field('account_id')
+				},
+			})
+		} else {
+			frm.set_df_property('account_id', 'options', [])
+			frm.refresh_field('account_id')
+		}
+	},
+
+	retry(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: 'retry',
+			freeze: true,
+			freeze_message: __('Retrying...'),
+			callback: (r) => {
+				if (!r.exc) {
+					frm.refresh()
+				}
+			},
+		})
+	},
+})

--- a/mail/client/doctype/calendar_exchange/calendar_exchange.json
+++ b/mail/client/doctype/calendar_exchange/calendar_exchange.json
@@ -1,0 +1,318 @@
+{
+ "actions": [],
+ "creation": "2026-06-24 09:29:39.200543",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_r2c6",
+  "amended_from",
+  "section_break_vxtc",
+  "column_break_frsy",
+  "user",
+  "account_id",
+  "operation",
+  "import_format",
+  "import_metadata",
+  "import_file",
+  "export_format",
+  "export_archive_type",
+  "column_break_julx",
+  "status",
+  "retries",
+  "section_break_wrha",
+  "queued_at",
+  "started_at",
+  "completed_at",
+  "column_break_bnqr",
+  "started_after",
+  "duration",
+  "section_break_ovtu",
+  "column_break_emiw",
+  "export_filter",
+  "column_break_xxyr",
+  "export_sort",
+  "export_limit",
+  "deduplicate_export",
+  "section_break_flrw",
+  "output"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_r2c6",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Calendar Exchange",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_vxtc",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "Draft",
+   "depends_on": "eval: !doc.__islocal",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Draft\nQueued\nIn Progress\nCompleted\nFailed\nCancelled",
+   "read_only": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.retries",
+   "fieldname": "retries",
+   "fieldtype": "Int",
+   "label": "Retries",
+   "no_copy": 1,
+   "non_negative": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_frsy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "operation",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Operation",
+   "options": "\nImport\nExport",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "default": "jmap",
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "export_format",
+   "fieldtype": "Select",
+   "label": "Format",
+   "mandatory_depends_on": "eval: doc.operation == \"Export\"",
+   "options": "jmap\nics"
+  },
+  {
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "export_archive_type",
+   "fieldtype": "Select",
+   "label": "Archive Type",
+   "mandatory_depends_on": "eval: doc.operation == \"Export\"",
+   "options": ".zip\n.tgz\n.tar.gz"
+  },
+  {
+   "fieldname": "section_break_wrha",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "queued_at",
+   "fieldtype": "Datetime",
+   "label": "Queued At",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "started_at",
+   "fieldtype": "Datetime",
+   "label": "Started At",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "completed_at",
+   "fieldtype": "Datetime",
+   "label": "Completed At",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_bnqr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.docstatus != 0",
+   "description": "Started At - Queued At",
+   "fieldname": "started_after",
+   "fieldtype": "Float",
+   "label": "Started After (Seconds)",
+   "no_copy": 1,
+   "non_negative": 1,
+   "precision": "3",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.docstatus != 0",
+   "fieldname": "duration",
+   "fieldtype": "Float",
+   "label": "Duration (Seconds)",
+   "no_copy": 1,
+   "non_negative": 1,
+   "precision": "3",
+   "read_only": 1
+  },
+  {
+   "default": "ics",
+   "depends_on": "eval: doc.operation == \"Import\"",
+   "fieldname": "import_format",
+   "fieldtype": "Select",
+   "label": "Format",
+   "mandatory_depends_on": "eval: doc.operation == \"Import\"",
+   "options": "ics\njmap"
+  },
+  {
+   "depends_on": "eval: doc.operation == \"Import\"",
+   "description": "Supported: <code>.ics</code>, <code>.zip</code>, <code>.tgz</code>, <code>.tar.gz</code>",
+   "fieldname": "import_file",
+   "fieldtype": "Attach",
+   "label": "File",
+   "mandatory_depends_on": "eval: doc.operation == \"Import\"",
+   "no_copy": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.docstatus == 0",
+   "fieldname": "section_break_ovtu",
+   "fieldtype": "Section Break",
+   "label": "Filters"
+  },
+  {
+   "default": "{}",
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "export_filter",
+   "fieldtype": "JSON",
+   "label": "Filter"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "export_limit",
+   "fieldtype": "Int",
+   "label": "Limit",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_xxyr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "export_sort",
+   "fieldtype": "Select",
+   "label": "Sort",
+   "options": "\nStart (ASC)\nStart (DESC)"
+  },
+  {
+   "fieldname": "column_break_emiw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_flrw",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "output",
+   "fieldtype": "Code",
+   "label": "Output",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "default": "1",
+   "depends_on": "eval: doc.operation == \"Export\"",
+   "fieldname": "deduplicate_export",
+   "fieldtype": "Check",
+   "label": "Deduplicate by UID"
+  },
+  {
+   "depends_on": "eval: doc.operation == \"Import\"",
+   "description": "Optional. Target calendar to import events into. Example: <code>{\"calendarIds\": {\"a\": True}}</code>",
+   "fieldname": "import_metadata",
+   "fieldtype": "JSON",
+   "label": "Metadata"
+  },
+  {
+   "fieldname": "column_break_julx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "The JMAP account ID to import into or export from. Populated from the accounts the selected user can access.",
+   "fieldname": "account_id",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Account ID",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "description": "The user whose JMAP credentials are used to authenticate the import/export.",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "User",
+   "no_copy": 1,
+   "options": "User",
+   "reqd": 1,
+   "search_index": 1,
+   "set_only_once": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "max_attachments": 1,
+ "modified": "2026-06-24 12:18:05.735864",
+ "modified_by": "Administrator",
+ "module": "Client",
+ "name": "Calendar Exchange",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Mail Admin",
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "All",
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/mail/client/doctype/calendar_exchange/calendar_exchange.py
+++ b/mail/client/doctype/calendar_exchange/calendar_exchange.py
@@ -1,0 +1,1085 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import json
+import os
+import shutil
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from uuid import uuid7
+from zoneinfo import ZoneInfo
+
+import frappe
+import isodate
+from frappe import _
+from frappe.model.document import Document
+from frappe.query_builder import Order
+from frappe.utils import (
+	add_to_date,
+	cint,
+	create_batch,
+	get_bench_path,
+	get_datetime,
+	get_url,
+	now,
+	random_string,
+	time_diff_in_seconds,
+)
+
+from mail.client.doctype.push_subscription.push_subscription import (
+	freeze_jmap_push_notifications,
+	unfreeze_jmap_push_notifications,
+)
+from mail.jmap import get_jmap_connection
+from mail.jmap.services.calendars.calendar import CalendarService
+from mail.jmap.services.calendars.calendar_event import CalendarEventService
+from mail.utils import (
+	compress_directory,
+	extract_compressed_file,
+	get_calendar_export_directory,
+	get_calendar_import_directory,
+	get_config,
+	reconnect_on_failure,
+)
+from mail.utils.logger import ExchangeLogger, get_exchange_logger
+from mail.utils.user import (
+	get_user_email_address,
+	is_administrator,
+	is_jmap_configured,
+	is_mail_admin,
+	is_system_manager,
+)
+
+# JSCalendar (RFC 8984) -> iCalendar (RFC 5545) value maps.
+STATUS_MAP: dict[str, str] = {
+	"confirmed": "CONFIRMED",
+	"tentative": "TENTATIVE",
+	"cancelled": "CANCELLED",
+}
+PRIVACY_MAP: dict[str, str] = {
+	"public": "PUBLIC",
+	"private": "PRIVATE",
+	"secret": "CONFIDENTIAL",
+}
+FREE_BUSY_MAP: dict[str, str] = {
+	"free": "TRANSPARENT",
+	"busy": "OPAQUE",
+}
+PARTICIPANT_ROLE_MAP: dict[str, str] = {
+	"chair": "CHAIR",
+	"required": "REQ-PARTICIPANT",
+	"attendee": "REQ-PARTICIPANT",
+	"optional": "OPT-PARTICIPANT",
+	"informational": "NON-PARTICIPANT",
+}
+PARTSTAT_MAP: dict[str, str] = {
+	"needs-action": "NEEDS-ACTION",
+	"accepted": "ACCEPTED",
+	"declined": "DECLINED",
+	"tentative": "TENTATIVE",
+	"delegated": "DELEGATED",
+}
+CUTYPE_MAP: dict[str, str] = {
+	"individual": "INDIVIDUAL",
+	"group": "GROUP",
+	"resource": "RESOURCE",
+	"location": "ROOM",
+}
+WEEKDAY_MAP: dict[str, str] = {
+	"mo": "MO",
+	"tu": "TU",
+	"we": "WE",
+	"th": "TH",
+	"fr": "FR",
+	"sa": "SA",
+	"su": "SU",
+}
+
+# Server-managed / computed properties that must be dropped before re-creating an event,
+# otherwise the JMAP server rejects the "set" call with invalidProperties.
+SERVER_MANAGED_KEYS = (
+	"id",
+	"blobId",
+	"method",
+	"x-href",
+	"created",
+	"updated",
+	"isOrigin",
+	"mayInviteSelf",
+	"mayInviteOthers",
+	"hideAttendees",
+)
+
+
+class CalendarExchange(Document):
+	@property
+	def max_import(self) -> int:
+		"""Returns the maximum number of events allowed for import."""
+
+		return cint(get_config("exchange_max_import"))
+
+	@property
+	def max_export(self) -> int:
+		"""Returns the maximum number of events allowed for export."""
+
+		return cint(get_config("exchange_max_export"))
+
+	@property
+	def export_filter_dict(self) -> dict:
+		"""Returns the export filter as a dictionary."""
+
+		if self.operation == "Export" and self.export_filter:
+			return json.loads(self.export_filter)
+		return {}
+
+	@property
+	def export_sort_clause(self) -> list[dict]:
+		"""Returns the export sort as a list of dictionaries."""
+
+		if self.operation != "Export":
+			return []
+		if self.export_sort == "Start (DESC)":
+			return [{"property": "start", "isAscending": False}]
+		return [{"property": "start", "isAscending": True}]
+
+	@property
+	def import_metadata_dict(self) -> dict:
+		"""Return the import metadata as a dictionary."""
+
+		if self.operation != "Import" or not self.import_metadata:
+			return {}
+
+		return json.loads(self.import_metadata)
+
+	@property
+	def target_calendar_ids(self) -> dict[str, bool] | None:
+		"""Returns the target calendar IDs for import, if specified."""
+
+		return self.import_metadata_dict.get("calendarIds")
+
+	def autoname(self) -> None:
+		self.name = str(uuid7())
+
+	def validate(self) -> None:
+		if self.is_new():
+			self.validate_account()
+
+		if self.operation == "Import":
+			self.validate_import()
+		elif self.operation == "Export":
+			self.validate_export()
+
+	def before_submit(self) -> None:
+		self.status = "Queued"
+		self.queued_at = now()
+
+	def on_submit(self) -> None:
+		self.process()
+
+	def before_cancel(self) -> None:
+		self.status = "Cancelled"
+
+	def validate_account(self) -> None:
+		"""Validate that the selected user can authenticate and has access to the account."""
+
+		if not is_jmap_configured(self.user):
+			frappe.throw(
+				_("User {0} does not have JMAP settings configured.").format(frappe.bold(self.user)),
+				frappe.PermissionError,
+			)
+
+		from mail.jmap import get_user_account_ids
+
+		if self.account_id not in get_user_account_ids(self.user):
+			frappe.throw(
+				_("Account ID {0} is not accessible to user {1}.").format(
+					frappe.bold(self.account_id), frappe.bold(self.user)
+				),
+				frappe.PermissionError,
+			)
+
+	def validate_import(self) -> None:
+		"""Validate the import parameters."""
+
+		if not self.import_format:
+			frappe.throw(_("Import Format is required."))
+		if not self.import_file:
+			frappe.throw(_("Import File is required."))
+
+		allowed_extensions = (".ics", ".zip", ".tgz", ".tar.gz")
+		if not self.import_file.endswith(allowed_extensions):
+			frappe.throw(
+				_("Only {0} files are supported for import.").format(
+					", ".join(f"<code>{ext}</code>" for ext in allowed_extensions)
+				)
+			)
+
+		if self.import_metadata:
+			try:
+				self.import_metadata = json.dumps(json.loads(self.import_metadata), indent=4)
+			except json.JSONDecodeError:
+				frappe.throw(_("Metadata must be valid JSON."))
+
+	def validate_export(self) -> None:
+		"""Validate the export parameters."""
+
+		if self.export_filter:
+			try:
+				self.export_filter = json.dumps(json.loads(self.export_filter), indent=4)
+			except json.JSONDecodeError:
+				frappe.throw(_("Export filter must be valid JSON."))
+
+		if not self.export_archive_type:
+			frappe.throw(_("Archive Type is required."))
+
+		if not self.export_sort:
+			self.export_sort = "Start (ASC)"
+
+		if self.export_limit:
+			export_limit = cint(self.export_limit)
+			if export_limit <= 0:
+				frappe.throw(_("Export Limit must be greater than zero."))
+			if export_limit > self.max_export:
+				frappe.throw(_("Export Limit cannot exceed {0}.").format(self.max_export))
+			self.export_limit = export_limit
+		else:
+			self.export_limit = self.max_export
+
+	def _get_logger(self) -> ExchangeLogger:
+		"""Returns a structured event logger bound to this exchange's context."""
+
+		return get_exchange_logger(
+			{
+				"req_id": random_string(10),
+				"exchange": self.name,
+				"kind": "calendar",
+				"operation": self.operation,
+				"user": self.user,
+				"account_id": self.account_id,
+			}
+		)
+
+	def process(self) -> None:
+		"""Enqueue the import or export based on the operation type."""
+
+		logger = self._get_logger()
+
+		if self.operation == "Import":
+			job_id = f"{self.name}:calendar:import"
+			frappe.enqueue_doc(
+				self.doctype,
+				self.name,
+				"_import",
+				queue="long",
+				timeout=cint(get_config("exchange_import_timeout")),
+				job_id=job_id,
+				deduplicate=True,
+				enqueue_after_commit=True,
+			)
+			logger.debug("import-enqueued", job_id=job_id, format=self.import_format)
+		elif self.operation == "Export":
+			job_id = f"{self.name}:calendar:export"
+			frappe.enqueue_doc(
+				self.doctype,
+				self.name,
+				"_export",
+				queue="long",
+				timeout=cint(get_config("exchange_export_timeout")),
+				job_id=job_id,
+				deduplicate=True,
+				enqueue_after_commit=True,
+			)
+			logger.debug("export-enqueued", job_id=job_id, format=self.export_format)
+
+	@frappe.whitelist()
+	def retry(self) -> None:
+		"""Retry the import or export."""
+
+		frappe.only_for("System Manager")
+
+		self._get_logger().info("retry-requested", status=self.status, retries=cint(self.retries))
+
+		if self.docstatus != 1:
+			frappe.throw(_("Only submitted calendar exchange can be retried."))
+		elif self.status not in ["Queued", "In Progress", "Failed"]:
+			frappe.throw(
+				_("Only calendar exchange with status 'Queued', 'In Progress', or 'Failed' can be retried.")
+			)
+
+		if self.operation == "Export":
+			if files := frappe.db.get_all(
+				"File",
+				{
+					"attached_to_doctype": self.doctype,
+					"attached_to_name": self.name,
+					"attached_to_field": "file",
+				},
+				pluck="name",
+			):
+				for file in files:
+					frappe.delete_doc("File", file)
+
+		self._db_set(status="Queued", queued_at=now())
+		self.process()
+
+	@reconnect_on_failure()
+	def _import(self) -> None:
+		"""Imports the calendar events."""
+
+		if self.operation != "Import":
+			return
+
+		logger = self._get_logger()
+		logger.info("import-started", format=self.import_format, import_file=self.import_file)
+
+		freeze_jmap_push_notifications(self.user)
+		self._mark_started()
+		self._log_output(_("Starting import from the uploaded {0} file.").format(self.import_format.upper()))
+
+		import_file = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{self.import_file}")
+		base_dir = os.path.join(get_calendar_import_directory(), self.name)
+		os.makedirs(base_dir, exist_ok=True)
+
+		kwargs = {}
+		try:
+			if self.import_format == "ics" and self.import_file.endswith(".ics"):
+				shutil.copy(import_file, os.path.join(base_dir, os.path.basename(import_file)))
+			else:
+				extract_compressed_file(import_file, base_dir)
+			logger.debug("import-source-prepared", base_dir=base_dir)
+			self._log_output(_("Prepared the source files for import."))
+
+			service = get_calendar_event_service(self.user, self.account_id)
+
+			if self.import_format == "ics":
+				events = self._load_ics_events(service, base_dir, logger)
+			else:
+				events = self._load_jmap_events(base_dir)
+
+			logger.info("import-events-loaded", events=len(events), max_import=self.max_import)
+			self._log_output(_("Found {0} event(s) to import.").format(len(events)))
+
+			if not events:
+				frappe.throw(_("No calendar events found for import."))
+			if len(events) > self.max_import:
+				frappe.throw(_("Import limit exceeded."))
+
+			created, skipped, failed = self._create_events(service, events, logger)
+
+			logger.info("import-completed", created=created, skipped=skipped, failed=failed)
+			self._log_output(
+				_("Import completed. {0} created, {1} skipped (already present), {2} failed.").format(
+					created, skipped, failed
+				)
+			)
+			kwargs.update({"status": "Completed"})
+		except Exception:
+			logger.exception("import-failed")
+			self._log_output(_("Import failed. See the error details below."))
+			kwargs.update(
+				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+			)
+		finally:
+			shutil.rmtree(base_dir, ignore_errors=True)
+			unfreeze_jmap_push_notifications(self.user)
+
+		self._mark_completed(**kwargs)
+		self._notify_user(success=kwargs.get("status") == "Completed", action="Import")
+
+	@reconnect_on_failure()
+	def _export(self) -> None:
+		"""Exports the calendar events."""
+
+		if self.operation != "Export":
+			return
+
+		logger = self._get_logger()
+		logger.info("export-started", format=self.export_format, archive_type=self.export_archive_type)
+
+		self._mark_started()
+		self._log_output(_("Starting export to {0} format.").format(self.export_format.upper()))
+		out_dir = os.path.join(get_calendar_export_directory(), self.name)
+		os.makedirs(out_dir, exist_ok=True)
+
+		kwargs = {}
+		try:
+			service = get_calendar_event_service(self.user, self.account_id)
+
+			limit = min(self.max_export, cint(self.export_limit or self.max_export))
+			data = service.query(self.export_filter_dict, limit=limit, sort=self.export_sort_clause)
+			ids = data.get("ids", [])
+			total = data.get("total")
+			logger.info("export-query-resolved", total=total, fetched=len(ids), max_export=self.max_export)
+			self._log_output(
+				_("Found {0} event(s) matching the filter; exporting up to {1}.").format(
+					total if total is not None else len(ids), len(ids)
+				)
+			)
+
+			if not ids:
+				frappe.throw(_("No calendar events found for export."))
+
+			events = service.get(ids)
+
+			if self.deduplicate_export:
+				fetched = len(events)
+				unique: dict[str, dict] = {}
+				for e in events:
+					key = e.get("uid") or e.get("id")
+					if key not in unique:
+						unique[key] = e
+				events = list(unique.values())
+				logger.debug("export-deduplicated", fetched=fetched, unique=len(events))
+				self._log_output(
+					_("Removed {0} duplicate(s); {1} unique event(s) remain.").format(
+						fetched - len(events), len(events)
+					)
+				)
+
+			calendar_map = {c["id"]: c["name"] for c in service.calendars}
+			CalendarExportWriter.write(self.export_format, events, out_dir, calendar_map)
+			self._log_output(_("Wrote {0} event(s) to the export directory.").format(len(events)))
+
+			self._log_output(
+				_("Packaging exported events into a {0} archive.").format(self.export_archive_type)
+			)
+			self._attach_export(out_dir)
+
+			logger.info("export-completed", events=len(events))
+			self._log_output(_("Export completed successfully. {0} event(s) exported.").format(len(events)))
+			kwargs.update({"status": "Completed"})
+		except Exception:
+			logger.exception("export-failed")
+			self._log_output(_("Export failed. See the error details below."))
+			kwargs.update(
+				{"status": "Failed", "output": f"{self.output}\n\n{frappe.get_traceback(with_context=False)}"}
+			)
+		finally:
+			shutil.rmtree(out_dir, ignore_errors=True)
+
+		self._mark_completed(**kwargs)
+		self._notify_user(success=kwargs.get("status") == "Completed", action="Export")
+
+	def _load_ics_events(
+		self, service: CalendarEventService, base_dir: str, logger: ExchangeLogger
+	) -> list[dict]:
+		"""Uploads every .ics file and parses it into JSCalendar events via the JMAP server."""
+
+		ics_files = [
+			os.path.join(root, f)
+			for root, _dirs, files in os.walk(base_dir)
+			for f in files
+			if f.lower().endswith(".ics")
+		]
+		if not ics_files:
+			frappe.throw(_("No .ics files found."))
+
+		blob_to_file: dict[str, str] = {}
+		for path in ics_files:
+			with open(path, "rb") as f:
+				data = f.read()
+			blob_id = service.upload_blob(data, content_type="text/calendar; charset=utf-8").get("blobId")
+			if blob_id:
+				blob_to_file[blob_id] = path
+
+		response = service.parse(list(blob_to_file.keys()))
+
+		events: list[dict] = []
+		for parsed in (response.get("parsed") or {}).values():
+			for event in parsed or []:
+				events.append(event)
+
+		if not_parsable := response.get("notParsable"):
+			logger.warning("import-ics-not-parsable", count=len(not_parsable))
+			self._log_output(_("{0} file(s) could not be parsed and were skipped.").format(len(not_parsable)))
+
+		return events
+
+	def _load_jmap_events(self, base_dir: str) -> list[dict]:
+		"""Loads JSCalendar events from the events.json file in the import directory."""
+
+		path = os.path.join(base_dir, "events.json")
+		if not os.path.exists(path):
+			frappe.throw(_("events.json not found in the import directory."))
+
+		with open(path) as f:
+			events = json.load(f)
+
+		if not isinstance(events, list):
+			frappe.throw(_("events.json must contain a list of calendar events."))
+
+		return events
+
+	def _create_events(
+		self, service: CalendarEventService, events: list[dict], logger: ExchangeLogger
+	) -> tuple[int, int, int]:
+		"""Creates the given JSCalendar events, skipping any whose UID already exists (idempotency).
+
+		Returns a ``(created, skipped, failed)`` tuple. Failures within a batch are recorded and the
+		remaining batches continue, so a few malformed events do not abort the whole import."""
+
+		# Idempotency: skip events whose UID is already present in the account.
+		uids = [e["uid"] for e in events if e.get("uid")]
+		existing_uids: set[str] = set()
+		if uids:
+			if existing_ids := service.get_master_ids(uids):
+				existing_uids = {e["uid"] for e in service.get(existing_ids) if e.get("uid")}
+
+		default_calendar_id: str | None = None
+
+		def resolve_calendar_ids(event: dict) -> dict:
+			nonlocal default_calendar_id
+
+			if self.target_calendar_ids:
+				return self.target_calendar_ids
+			if event.get("calendarIds"):
+				return event["calendarIds"]
+			if default_calendar_id is None:
+				default_calendar_id = CalendarService(service.account_id, service.connection).get_default(
+					raise_exception=True
+				)
+			return {default_calendar_id: True}
+
+		pending: list[dict] = []
+		skipped = 0
+		for event in events:
+			if event.get("uid") and event["uid"] in existing_uids:
+				skipped += 1
+				continue
+			pending.append(event)
+
+		created = 0
+		failed = 0
+		total = len(pending)
+		for batch in create_batch(pending, service.max_objects_in_set):
+			payload: dict[str, dict] = {}
+			creation_to_uid: dict[str, str] = {}
+			for event in batch:
+				event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
+				event["@type"] = "Event"
+				event["calendarIds"] = resolve_calendar_ids(event)
+
+				creation_id = str(uuid7())
+				payload[creation_id] = event
+				creation_to_uid[creation_id] = event.get("uid", creation_id)
+
+			response = service._create(payload, sendSchedulingMessages=False)
+			method_responses = response.get("methodResponses") or []
+			result = method_responses[0][1] if method_responses else {}
+
+			batch_created = result.get("created") or {}
+			batch_failed = result.get("notCreated") or {}
+			created += len(batch_created)
+			failed += len(batch_failed)
+
+			for creation_id, error in batch_failed.items():
+				logger.warning(
+					"import-event-not-created",
+					uid=creation_to_uid.get(creation_id),
+					reason=str(error),
+				)
+
+			self._log_output(_("Imported {0} of {1} event(s).").format(created, total))
+
+		return created, skipped, failed
+
+	def _mark_started(self) -> None:
+		"""Marks the calendar exchange as started and updates the started_at and started_after fields."""
+
+		started_at = now()
+		self._db_set(
+			status="In Progress",
+			started_at=started_at,
+			started_after=time_diff_in_seconds(started_at, self.queued_at),
+			output="",
+		)
+
+	def _mark_completed(self, **kwargs) -> None:
+		"""Marks the calendar exchange as completed and updates the completed_at and duration fields."""
+
+		kwargs["completed_at"] = now()
+		kwargs["duration"] = time_diff_in_seconds(kwargs["completed_at"], self.started_at)
+
+		if kwargs["status"] == "Failed":
+			kwargs["retries"] = cint(self.retries) + 1
+
+		self._db_set(**kwargs)
+
+	def _attach_export(self, out_dir: str) -> None:
+		"""Attaches the exported file to the calendar exchange."""
+
+		archive = f"{self.name}{self.export_archive_type}"
+		url = f"/private/files/{archive}"
+		path = os.path.join(get_bench_path(), f"sites/{frappe.local.site}{url}")
+		compress_directory(out_dir, path)
+
+		file = frappe.new_doc("File")
+		file.is_private = 1
+		file.file_url = url
+		file.file_name = archive
+		file.attached_to_doctype = self.doctype
+		file.attached_to_name = self.name
+		file.attached_to_field = "file"
+		file.insert()
+
+		# https://github.com/frappe/frappe/issues/26615
+		frappe.db.set_value("File", file.name, {"file_url": url, "file_name": archive})
+
+	def _notify_user(self, success: bool, action: Literal["Import", "Export"]) -> None:
+		"""Sends notification email to the owner of the calendar exchange."""
+
+		if is_administrator(self.owner):
+			return
+		if not (email := get_user_email_address(self.owner)):
+			return
+
+		subject = _("Calendar Data {0} {1}").format(action, "Completed" if success else "Failed")
+		frappe.publish_realtime(
+			"calendar_exchange_completed",
+			{"action": action, "success": success, "message": subject},
+			user=self.user,
+		)
+		frappe.sendmail(
+			recipients=email,
+			subject=subject,
+			template="generic",
+			args={
+				"title": subject,
+				"description": _("View details for this exchange."),
+				"button": _("View {0}").format(action),
+				"link": get_url(f"/mail/calendar-exchanges/{self.name}"),
+			},
+			now=True,
+		)
+
+	def _log_output(self, message: str) -> None:
+		"""Appends a timestamped, user-friendly line to the `output` field and persists it.
+
+		These messages are surfaced in the UI so the user can follow the progress of the
+		background import/export as it happens."""
+
+		line = f"[{now()}] {message}"
+		self.output = f"{self.output}\n{line}" if self.output else line
+		self._db_set(output=self.output)
+
+	def _db_set(self, **kwargs) -> None:
+		"""Updates the document with the given key-value pairs."""
+
+		self.db_set(kwargs, notify=True, commit=True)
+
+
+class CalendarExportWriter:
+	@classmethod
+	def write(
+		cls,
+		format: Literal["jmap", "ics"],
+		events: list[dict],
+		out_dir: str,
+		calendar_map: dict[str, str],
+	) -> None:
+		"""Writes the exported events in the specified format."""
+
+		writers = {
+			"jmap": cls._jmap,
+			"ics": cls._ics,
+		}
+
+		if format not in writers:
+			frappe.throw(_("Unsupported export format: {0}").format(format))
+
+		writers[format](events, out_dir, calendar_map)
+
+	@staticmethod
+	def _jmap(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
+		"""Writes the raw JSCalendar events and the calendar map (fully round-trippable)."""
+
+		with open(os.path.join(out_dir, "events.json"), "w") as f:
+			json.dump(events, f, indent=4)
+
+		with open(os.path.join(out_dir, "calendars.json"), "w") as f:
+			json.dump(calendar_map, f, indent=4)
+
+	@staticmethod
+	def _ics(events: list[dict], out_dir: str, calendar_map: dict[str, str]) -> None:
+		"""Writes one VCALENDAR file per calendar, mirroring mbox's one-file-per-mailbox layout."""
+
+		from icalendar import Calendar
+
+		def safe_name(name: str) -> str:
+			return (
+				"".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in name).strip() or "calendar"
+			)
+
+		# Group events by the calendars they belong to (an event can live in several).
+		by_calendar: dict[str, list[dict]] = {}
+		for event in events:
+			calendar_ids = list((event.get("calendarIds") or {}).keys()) or ["__default__"]
+			for calendar_id in calendar_ids:
+				by_calendar.setdefault(calendar_id, []).append(event)
+
+		used_names: set[str] = set()
+		for calendar_id, calendar_events in by_calendar.items():
+			calendar_name = calendar_map.get(calendar_id, "Calendar")
+			cal = Calendar()
+			cal.add("prodid", "-//Frappe Mail//Calendar Exchange//EN")
+			cal.add("version", "2.0")
+			cal.add("method", "PUBLISH")
+
+			for event in calendar_events:
+				categories = [
+					calendar_map[cid] for cid in (event.get("calendarIds") or {}) if cid in calendar_map
+				]
+				for component in _build_components(event, categories):
+					cal.add_component(component)
+
+			file_name = safe_name(calendar_name)
+			candidate = file_name
+			suffix = 1
+			while candidate in used_names:
+				suffix += 1
+				candidate = f"{file_name}_{suffix}"
+			used_names.add(candidate)
+
+			with open(os.path.join(out_dir, f"{candidate}.ics"), "wb") as f:
+				f.write(cal.to_ical())
+
+
+def get_calendar_event_service(
+	user: str,
+	account_id: str,
+	ignore_permissions: bool = False,
+) -> CalendarEventService:
+	"""Returns a CalendarEventService configured with the longer exchange timeouts."""
+
+	connection = get_jmap_connection(user, ignore_permissions=ignore_permissions, timeout=(60.0, 180.0))
+	return CalendarEventService(account_id, connection)
+
+
+def _parse_local_datetime(value: str | None, time_zone: str | None) -> datetime | None:
+	"""Parses a JSCalendar LocalDateTime string into a (possibly timezone-aware) datetime."""
+
+	if not value:
+		return None
+
+	dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+	if dt.tzinfo is None and time_zone:
+		try:
+			dt = dt.replace(tzinfo=ZoneInfo(time_zone))
+		except Exception:
+			pass
+
+	return dt
+
+
+def _parse_duration(value: str | None, start: datetime | None) -> timedelta | None:
+	"""Parses an ISO 8601 duration string into a timedelta."""
+
+	if not value:
+		return None
+
+	try:
+		duration = isodate.parse_duration(value)
+	except Exception:
+		return None
+
+	if isinstance(duration, timedelta):
+		return duration
+
+	# isodate.Duration (carries months/years): resolve against the start when available.
+	try:
+		return duration.totimedelta(start=start or datetime(2000, 1, 1))
+	except Exception:
+		return None
+
+
+def _build_recurrence_rule(rule: dict) -> dict | None:
+	"""Converts a JSCalendar RecurrenceRule object into an iCalendar RRULE value dict."""
+
+	if not rule:
+		return None
+
+	recur: dict[str, list] = {}
+
+	if frequency := rule.get("frequency"):
+		recur["FREQ"] = [frequency.upper()]
+	if (interval := rule.get("interval")) and cint(interval) > 1:
+		recur["INTERVAL"] = [cint(interval)]
+	if count := rule.get("count"):
+		recur["COUNT"] = [cint(count)]
+	if until := rule.get("until"):
+		parsed = _parse_local_datetime(until, None)
+		if parsed:
+			recur["UNTIL"] = [parsed]
+	if first_day := rule.get("firstDayOfWeek"):
+		if mapped := WEEKDAY_MAP.get(first_day.lower()):
+			recur["WKST"] = [mapped]
+
+	if by_day := rule.get("byDay"):
+		days = []
+		for nday in by_day:
+			day = WEEKDAY_MAP.get((nday.get("day") or "").lower())
+			if not day:
+				continue
+			nth = nday.get("nthOfPeriod")
+			days.append(f"{nth}{day}" if nth else day)
+		if days:
+			recur["BYDAY"] = days
+
+	scalar_map = {
+		"byMonthDay": "BYMONTHDAY",
+		"byMonth": "BYMONTH",
+		"byYearDay": "BYYEARDAY",
+		"byWeekNo": "BYWEEKNO",
+		"byHour": "BYHOUR",
+		"byMinute": "BYMINUTE",
+		"bySecond": "BYSECOND",
+		"bySetPosition": "BYSETPOS",
+	}
+	for js_key, ical_key in scalar_map.items():
+		if values := rule.get(js_key):
+			recur[ical_key] = list(values)
+
+	return recur or None
+
+
+def _add_participants(component, participants: dict) -> None:
+	"""Adds ATTENDEE properties to a VEVENT from a JSCalendar participants map."""
+
+	from icalendar import vCalAddress
+
+	for participant in (participants or {}).values():
+		address = participant.get("calendarAddress") or (
+			f"mailto:{participant['email']}" if participant.get("email") else None
+		)
+		if not address:
+			continue
+
+		attendee = vCalAddress(address)
+		if name := participant.get("name"):
+			attendee.params["CN"] = name
+
+		roles = participant.get("roles") or {}
+		role = next((PARTICIPANT_ROLE_MAP[r] for r in roles if r in PARTICIPANT_ROLE_MAP), None)
+		if role:
+			attendee.params["ROLE"] = role
+
+		if kind := participant.get("kind"):
+			if cutype := CUTYPE_MAP.get(kind.lower()):
+				attendee.params["CUTYPE"] = cutype
+
+		if partstat := participant.get("participationStatus"):
+			if mapped := PARTSTAT_MAP.get(partstat.lower()):
+				attendee.params["PARTSTAT"] = mapped
+
+		attendee.params["RSVP"] = "TRUE" if participant.get("expectReply") else "FALSE"
+
+		component.add("attendee", attendee, encode=0)
+
+
+def _add_alarms(component, alerts: dict) -> None:
+	"""Adds VALARM sub-components to a VEVENT from a JSCalendar alerts map."""
+
+	from icalendar import Alarm
+
+	for alert in (alerts or {}).values():
+		action = (alert.get("action") or "display").upper()
+		if action not in ("DISPLAY", "EMAIL", "AUDIO"):
+			action = "DISPLAY"
+
+		trigger = alert.get("trigger") or {}
+		alarm = Alarm()
+		alarm.add("action", action)
+
+		trigger_type = trigger.get("@type")
+		if trigger_type == "AbsoluteTrigger" and trigger.get("when"):
+			when = _parse_local_datetime(trigger["when"], None)
+			if when:
+				alarm.add("trigger", when)
+		else:
+			offset = _parse_duration(trigger.get("offset", "-PT10M"), None)
+			if offset is None:
+				offset = timedelta(minutes=-10)
+			related = (trigger.get("relativeTo") or "start").upper()
+			alarm.add("trigger", offset, parameters={"RELATED": related})
+
+		# DISPLAY/EMAIL alarms require a description per RFC 5545.
+		alarm.add("description", component.get("summary") or "Reminder")
+		if action == "EMAIL":
+			alarm.add("summary", component.get("summary") or "Reminder")
+
+		component.add_component(alarm)
+
+
+def jscalendar_to_vevent(event: dict, categories: list[str] | None = None):
+	"""Converts a single JSCalendar Event object into an iCalendar VEVENT component.
+
+	Recurrence overrides are NOT applied here; :func:`_build_components` handles those by
+	emitting the master event plus per-instance override components."""
+
+	from icalendar import Event, vText
+
+	component = Event()
+
+	if uid := event.get("uid"):
+		component.add("uid", uid)
+
+	if title := event.get("title"):
+		component.add("summary", title)
+	if description := event.get("description"):
+		component.add("description", description)
+
+	time_zone = event.get("timeZone")
+	start = _parse_local_datetime(event.get("start"), time_zone)
+	if start:
+		if event.get("showWithoutTime"):
+			component.add("dtstart", start.date())
+		else:
+			component.add("dtstart", start)
+
+	duration = _parse_duration(event.get("duration"), start)
+	if duration is not None:
+		if event.get("showWithoutTime"):
+			# All-day events use a DATE-valued DTEND (exclusive) for broad client compatibility.
+			if start:
+				component.add("dtend", (start + (duration or timedelta(days=1))).date())
+		else:
+			component.add("duration", duration)
+
+	if (status := event.get("status")) and status.lower() in STATUS_MAP:
+		component.add("status", STATUS_MAP[status.lower()])
+	if (privacy := event.get("privacy")) and privacy.lower() in PRIVACY_MAP:
+		component.add("class", PRIVACY_MAP[privacy.lower()])
+	if (free_busy := event.get("freeBusyStatus")) and free_busy.lower() in FREE_BUSY_MAP:
+		component.add("transp", FREE_BUSY_MAP[free_busy.lower()])
+
+	if organizer := event.get("organizerCalendarAddress"):
+		component.add("organizer", vText(organizer))
+
+	locations = [l.get("name") for l in (event.get("locations") or {}).values() if l.get("name")]
+	if locations:
+		component.add("location", "; ".join(locations))
+
+	for link in (event.get("links") or {}).values():
+		if href := link.get("href"):
+			component.add("url", href)
+			break
+
+	if categories:
+		component.add("categories", categories)
+
+	recurrence_rule = event.get("recurrenceRule")
+	if isinstance(recurrence_rule, list):
+		recurrence_rule = recurrence_rule[0] if recurrence_rule else None
+	if recur := _build_recurrence_rule(recurrence_rule):
+		component.add("rrule", recur)
+
+	created = _parse_local_datetime(event.get("created"), None)
+	updated = _parse_local_datetime(event.get("updated"), None)
+	if created:
+		component.add("created", created)
+	if updated:
+		component.add("last-modified", updated)
+	component.add("dtstamp", updated or created or datetime.now(UTC))
+
+	if (sequence := event.get("sequence")) is not None:
+		component.add("sequence", cint(sequence))
+
+	_add_participants(component, event.get("participants"))
+	_add_alarms(component, event.get("alerts"))
+
+	return component
+
+
+def _build_components(event: dict, categories: list[str] | None = None) -> list:
+	"""Builds the VEVENT component(s) for an event: the master plus any recurrence overrides.
+
+	Excluded instances become EXDATE entries on the master; modified instances become separate
+	VEVENT components sharing the UID and carrying RECURRENCE-ID."""
+
+	master = jscalendar_to_vevent(event, categories)
+	components = [master]
+
+	overrides = event.get("recurrenceOverrides") or {}
+	time_zone = event.get("timeZone")
+	excluded: list = []
+
+	for recurrence_id, patch in overrides.items():
+		instance_dt = _parse_local_datetime(recurrence_id, time_zone)
+		if instance_dt is None:
+			continue
+
+		if patch.get("excluded"):
+			excluded.append(instance_dt.date() if event.get("showWithoutTime") else instance_dt)
+			continue
+
+		# A modified instance: merge the master with the patch, drop the recurrence machinery,
+		# and tag it with RECURRENCE-ID so clients reconcile it against the series.
+		merged = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
+		merged.update(patch)
+		override = jscalendar_to_vevent(merged, categories)
+		if event.get("showWithoutTime"):
+			override.add("recurrence-id", instance_dt.date())
+		else:
+			override.add("recurrence-id", instance_dt)
+		components.append(override)
+
+	if excluded:
+		master.add("exdate", excluded)
+
+	return components
+
+
+def get_permission_query_condition(user: str | None = None) -> str:
+	user = user or frappe.session.user
+
+	if is_system_manager(user) or is_mail_admin(user):
+		return ""
+
+	return f"(`tabCalendar Exchange`.user = '{user}')"
+
+
+def has_permission(doc: Document, ptype: str, user: str | None = None) -> bool:
+	if doc.doctype != "Calendar Exchange":
+		return False
+
+	user = user or frappe.session.user
+
+	if is_system_manager(user) or is_mail_admin(user):
+		return True
+
+	return doc.user == user
+
+
+def retry_stuck_calendar_exchanges() -> None:
+	"""Called by the scheduler to retry stuck calendar exchanges."""
+
+	CE = frappe.qb.DocType("Calendar Exchange")
+	exchanges = (
+		frappe.qb.from_(CE)
+		.select(CE.name)
+		.where(
+			(CE.status.isin(["Queued", "In Progress"]))
+			& (CE.queued_at <= get_datetime(add_to_date(now(), days=-1)))
+		)
+		.orderby(CE.queued_at, order=Order.asc)
+	).run(pluck="name")
+
+	for exchange in exchanges:
+		frappe.get_doc("Calendar Exchange", exchange).retry()
+
+
+def clean_calendar_import_export_directories() -> None:
+	"""Called by the scheduler to clean up calendar import and export directories."""
+
+	for base in (get_calendar_import_directory(), get_calendar_export_directory()):
+		if not os.path.exists(base):
+			continue
+
+		for item in os.listdir(base):
+			path = os.path.join(base, item)
+			if os.path.isdir(path):
+				if frappe.db.exists("Calendar Exchange", {"name": item, "status": "In Progress"}):
+					continue
+				shutil.rmtree(path, ignore_errors=True)
+			else:
+				os.remove(path)

--- a/mail/client/doctype/calendar_exchange/calendar_exchange.py
+++ b/mail/client/doctype/calendar_exchange/calendar_exchange.py
@@ -38,7 +38,7 @@ from mail.utils import (
 	extract_compressed_file,
 	get_calendar_export_directory,
 	get_calendar_import_directory,
-	get_config,
+	get_mail_config,
 	reconnect_on_failure,
 )
 from mail.utils.logger import ExchangeLogger, get_exchange_logger
@@ -116,13 +116,13 @@ class CalendarExchange(Document):
 	def max_import(self) -> int:
 		"""Returns the maximum number of events allowed for import."""
 
-		return cint(get_config("exchange_max_import"))
+		return cint(get_mail_config("exchange_max_import"))
 
 	@property
 	def max_export(self) -> int:
 		"""Returns the maximum number of events allowed for export."""
 
-		return cint(get_config("exchange_max_export"))
+		return cint(get_mail_config("exchange_max_export"))
 
 	@property
 	def export_filter_dict(self) -> dict:
@@ -271,7 +271,7 @@ class CalendarExchange(Document):
 				self.name,
 				"_import",
 				queue="long",
-				timeout=cint(get_config("exchange_import_timeout")),
+				timeout=cint(get_mail_config("exchange_import_timeout")),
 				job_id=job_id,
 				deduplicate=True,
 				enqueue_after_commit=True,
@@ -284,7 +284,7 @@ class CalendarExchange(Document):
 				self.name,
 				"_export",
 				queue="long",
-				timeout=cint(get_config("exchange_export_timeout")),
+				timeout=cint(get_mail_config("exchange_export_timeout")),
 				job_id=job_id,
 				deduplicate=True,
 				enqueue_after_commit=True,

--- a/mail/client/doctype/calendar_exchange/calendar_exchange_list.js
+++ b/mail/client/doctype/calendar_exchange/calendar_exchange_list.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.listview_settings['Calendar Exchange'] = {
+	get_indicator: (doc) => {
+		const status_colors = {
+			Draft: 'grey',
+			Queued: 'blue',
+			'In Progress': 'orange',
+			Completed: 'green',
+			Failed: 'red',
+			Cancelled: 'red',
+		}
+		return [__(doc.status), status_colors[doc.status] || 'darkgrey', 'status,=,' + doc.status]
+	},
+
+	refresh: (listview) => {
+		set_account_options(listview)
+	},
+}
+
+function set_account_options(listview) {
+	const user_field = listview.page.fields_dict.user
+	if (!user_field) return
+
+	const user = user_field ? user_field.get_value() : null
+	if (!user) return
+
+	frappe.call({
+		method: 'mail.jmap.get_user_account_ids',
+		args: {
+			user: user,
+		},
+		callback: (r) => {
+			const account_field = listview.page.fields_dict.account_id
+			if (!account_field) return
+
+			const options = r.message || []
+			options.unshift('')
+			account_field.df.options = options
+			account_field.set_options()
+		},
+	})
+}

--- a/mail/client/doctype/calendar_exchange/test_calendar_exchange.py
+++ b/mail/client/doctype/calendar_exchange/test_calendar_exchange.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestCalendarExchange(IntegrationTestCase):
+	"""
+	Integration tests for CalendarExchange.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/mail/client/doctype/mail_exchange/mail_exchange.py
+++ b/mail/client/doctype/mail_exchange/mail_exchange.py
@@ -631,6 +631,7 @@ class MailExchange(Document):
 			{
 				"req_id": random_string(10),
 				"exchange": self.name,
+				"key": "mail",
 				"operation": self.operation,
 				"user": self.user,
 				"account": self.account,
@@ -1112,7 +1113,7 @@ def retry_stuck_mail_exchanges() -> None:
 		.select(ME.name)
 		.where(
 			(ME.status.isin(["Queued", "In Progress"]))
-			& (ME.queued_at <= get_datetime(add_to_date(now(), hours=-1)))
+			& (ME.queued_at <= get_datetime(add_to_date(now(), days=-1)))
 		)
 		.orderby(ME.queued_at, order=Order.asc)
 	).run(pluck="name")

--- a/mail/hooks.py
+++ b/mail/hooks.py
@@ -164,6 +164,7 @@ permission_query_conditions = {
 	# Client
 	"Account Settings": "mail.client.doctype.account_settings.account_settings.get_permission_query_condition",
 	"Blocked Email Address": "mail.client.doctype.blocked_email_address.blocked_email_address.get_permission_query_condition",
+	"Calendar Exchange": "mail.client.doctype.calendar_exchange.calendar_exchange.get_permission_query_condition",
 	"Junk Email Address": "mail.client.doctype.junk_email_address.junk_email_address.get_permission_query_condition",
 	"Mail Exchange": "mail.client.doctype.mail_exchange.mail_exchange.get_permission_query_condition",
 	"Mail Queue": "mail.client.doctype.mail_queue.mail_queue.get_permission_query_condition",
@@ -185,6 +186,7 @@ has_permission = {
 	"Blocked Email Address": "mail.client.doctype.blocked_email_address.blocked_email_address.has_permission",
 	"Calendar": "mail.client.doctype.calendar.calendar.has_permission",
 	"Calendar Event": "mail.client.doctype.calendar_event.calendar_event.has_permission",
+	"Calendar Exchange": "mail.client.doctype.calendar_exchange.calendar_exchange.has_permission",
 	"Contact Card": "mail.client.doctype.contact_card.contact_card.has_permission",
 	"Event Notification": "mail.client.doctype.event_notification.event_notification.has_permission",
 	"Identity": "mail.client.doctype.identity.identity.has_permission",
@@ -237,6 +239,7 @@ scheduler_events = {
 	"daily": [
 		"mail.client.doctype.mail_exchange.mail_exchange.clean_import_export_directories",
 		"mail.server.doctype.mail_data_exchange.mail_data_exchange.clean_import_export_directories",
+		"mail.client.doctype.calendar_exchange.calendar_exchange.clean_calendar_import_export_directories",
 	],
 	# "daily_long": [
 	#     "mail.tasks.daily_long"
@@ -244,6 +247,7 @@ scheduler_events = {
 	"hourly": [
 		"mail.client.doctype.mail_exchange.mail_exchange.retry_stuck_mail_exchanges",
 		"mail.server.doctype.mail_data_exchange.mail_data_exchange.retry_stuck_data_exchanges",
+		"mail.client.doctype.calendar_exchange.calendar_exchange.retry_stuck_calendar_exchanges",
 	],
 	"hourly_long": [
 		"mail.client.doctype.mail_message.mail_message.schedule_fetch_changes",
@@ -299,6 +303,7 @@ ignore_links_on_delete = [
 	"Mail Domain Request",
 	# Client
 	"Account Settings",
+	"Calendar Exchange",
 	"Junk Email Address",
 	"Mail Exchange",
 	"Mail Queue",

--- a/mail/utils/__init__.py
+++ b/mail/utils/__init__.py
@@ -814,6 +814,22 @@ def get_mail_export_directory() -> str:
 	return directory
 
 
+def get_calendar_import_directory() -> str:
+	"""Returns the path to the calendar import directory for the current site."""
+
+	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "import")
+	os.makedirs(directory, exist_ok=True)
+	return directory
+
+
+def get_calendar_export_directory() -> str:
+	"""Returns the path to the calendar export directory for the current site."""
+
+	directory = os.path.join(get_bench_path(), "sites", frappe.local.site, "calendar-exchange", "export")
+	os.makedirs(directory, exist_ok=True)
+	return directory
+
+
 def get_stalwart_cli_path() -> str:
 	"""Returns the path to the Stalwart CLI tool, raising an error if not found."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pexpect~=4.9.0",
     "msgpack~=1.1.2",
     "isodate~=0.7.2",
+    "icalendar~=6.1.0",
     "paramiko~=5.0.0",
     "dnspython~=2.4.2",
     "lmdb~=1.5.1",


### PR DESCRIPTION
Backports #611 to `v0`.

Adds the Calendar Exchange feature (ICS/JMAP import & export for Calendar Events), mirroring Mail Exchange's architecture, plus the consolidated Import/Export settings UI.

### Commits
- `feat(calendar): add Calendar Exchange (ICS/JMAP import & export)`
- `refactor(frontend): consolidate import/export into two settings tabs`
- `fix(frontend): default calendar import to the first calendar`

### Backport notes (v0 divergence resolved during cherry-pick)
- **`mail/hooks.py`** — kept v0's existing `mail_data_exchange` scheduler entries (daily cleanup + hourly retry) and added the calendar ones alongside. Added `Calendar Exchange` to `ignore_links_on_delete` (v0 does not list `Blocked Email Address` there, so that line was not introduced).
- **`mail/utils/__init__.py`** — added `get_calendar_import_directory` / `get_calendar_export_directory`; preserved v0's `get_stalwart_cli_path()` signature (the `raise_exception` param is a develop-only change, out of scope).
- **`mail/client/doctype/mail_exchange/mail_exchange.py`** — did **not** introduce the develop-only local `get_email_service` (longer-timeout refactor); v0 continues to import it from `mail.jmap`. Kept the in-scope `"key": "mail"` log-context field. The new `calendar_exchange.py` does not depend on that function.

### Verification
- All backend files compile (`py_compile`).
- Frontend changes lint clean (eslint).
- `icalendar~=6.1.0` dependency added to `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)