### PR TITLE
fix(screener): correct icon, restrict move/add, batch triage requests

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -275,7 +275,7 @@ const mailboxItems = computed(
 			?.filter((mailbox: MailboxData) => mailbox.subscribed)
 			?.map((mailbox: MailboxData) => {
 				// The Screening folder opens the dedicated Screener page, not the thread list.
-				const isScreener = mailbox.id === store.mailboxIds.screening
+				const isScreener = mailbox.id === store.mailboxIds.screener
 				return {
 					mailboxId: mailbox.id,
 					label: getMailboxName(mailbox),
@@ -328,7 +328,7 @@ const sidebarItems = computed(() => {
 	// Screening is a roleless folder; it gets its own nameless group pinned to the top of the
 	// sidebar, separate from the default and custom mailboxes.
 	const isScreening = (item: { mailboxId?: string }) =>
-		!!store.mailboxIds.screening && item.mailboxId === store.mailboxIds.screening
+		!!store.mailboxIds.screener && item.mailboxId === store.mailboxIds.screener
 
 	const screenerItem = mailboxItems.value.find((item) => isScreening(item))
 

--- a/frontend/src/components/MailActions.vue
+++ b/frontend/src/components/MailActions.vue
@@ -203,20 +203,20 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				label: __('Accept Sender'),
 				onClick: () => handleScreenSender('Accepted'),
 				icon: CircleCheck,
-				condition: () => mailbox === mailboxIds.screening,
+				condition: () => mailbox === mailboxIds.screener,
 			},
 			{
 				label: __('Reject Sender'),
 				onClick: () => handleScreenSender('Reject'),
 				icon: Ban,
-				condition: () => mailbox === mailboxIds.screening,
+				condition: () => mailbox === mailboxIds.screener,
 			},
 			{
 				label: __('Block Sender'),
 				onClick: () => handleBlockAddress(true),
 				icon: Ban,
 				condition: () =>
-					mailbox !== mailboxIds.screening &&
+					mailbox !== mailboxIds.screener &&
 					!identities.data.some((i: Identity) => i.email === mail.from_email) &&
 					!isSenderBlocked(mail.from_email),
 			},
@@ -225,7 +225,7 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 				onClick: () => handleBlockAddress(false),
 				icon: LockOpen,
 				condition: () =>
-					mailbox !== mailboxIds.screening && isSenderBlocked(mail.from_email),
+					mailbox !== mailboxIds.screener && isSenderBlocked(mail.from_email),
 			},
 		],
 	},

--- a/frontend/src/components/Settings/AccountSettings.vue
+++ b/frontend/src/components/Settings/AccountSettings.vue
@@ -196,7 +196,7 @@ const save = async () => {
 		askMoveToInbox =
 			screeningChanged &&
 			!accountSettings.doc.enable_screening &&
-			(mailboxes.data?.find((m: MailboxData) => m.id === mailboxIds.screening)
+			(mailboxes.data?.find((m: MailboxData) => m.id === mailboxIds.screener)
 				?.total_threads ?? 0) > 0
 		await accountSettings.save.submit()
 		// Sync the shared user data so compose picks up the new default and the junk flow picks up

--- a/frontend/src/components/Settings/FolderSettings.vue
+++ b/frontend/src/components/Settings/FolderSettings.vue
@@ -3,9 +3,9 @@
 		<h1>{{ __('Folders') }}</h1>
 		<Button icon-left="plus" :label="__('New')" @click="editMailbox()" />
 	</div>
-	<div v-if="mailboxes?.data?.length">
+	<div v-if="managedMailboxes.length">
 		<div
-			v-for="mailbox in mailboxes?.data"
+			v-for="mailbox in managedMailboxes"
 			:key="mailbox.name"
 			class="hover:bg-surface-gray-1 -mx-2 flex cursor-pointer items-center justify-between rounded px-3 py-1"
 			@click="editMailbox(mailbox)"
@@ -44,12 +44,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Icon } from 'frappe-ui/icons'
 import { Ellipsis, Eye, EyeOff, Settings, Trash2 } from 'lucide-vue-next'
 import { Button, Dropdown, createResource } from 'frappe-ui'
 
-import { FOLDER_ICON_COLOR_MAP } from '@/constants'
+import { FOLDER_ICON_COLOR_MAP, SCREENER_MAILBOX_NAME } from '@/constants'
 import { getIcon, raiseToast } from '@/utils'
 import { userStore } from '@/stores/user'
 import DeleteFolderModal from '@/components/Modals/DeleteFolderModal.vue'
@@ -58,6 +58,12 @@ import FolderModal from '@/components/Modals/FolderModal.vue'
 import type { MailboxData } from '@/types'
 
 const { mailboxes } = userStore()
+
+// The Screener is a system folder driven by the screening flow, not a user-configurable folder — keep
+// it out of the management list so it can't be renamed, deleted, or given a folder icon/color here.
+const managedMailboxes = computed(
+	() => mailboxes?.data?.filter((m: MailboxData) => m._name !== SCREENER_MAILBOX_NAME) ?? [],
+)
 
 const showFolderModal = ref(false)
 const selectedMailbox = ref<MailboxData>()

--- a/frontend/src/components/ThreadHeader.vue
+++ b/frontend/src/components/ThreadHeader.vue
@@ -240,6 +240,7 @@ const addToOptions = computed(() =>
 		?.filter(
 			(m) =>
 				(!m.role || ['inbox', 'archive'].includes(m.role)) &&
+				m.id !== mailboxIds.screener &&
 				!threadMailboxes.value.includes(m.id),
 		)
 		.map((m) => getMailboxOption(m, 'addThreadToMailbox')),
@@ -259,6 +260,7 @@ const moveToOptions = computed(() => {
 	const excludedMailboxes = new Set([
 		mailboxIds.sent,
 		mailboxIds.drafts,
+		mailboxIds.screener,
 		...threadMailboxes.value,
 	])
 	return mailboxes.data

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,6 +1,6 @@
-// The Screening mailbox is a plain named folder (no JMAP role), created server-side as "Screening";
+// The Screening mailbox is a plain named folder (no JMAP role), created server-side as "Screener";
 // it's surfaced to users as the "Screener".
-export const SCREENING_MAILBOX_NAME = 'Screener'
+export const SCREENER_MAILBOX_NAME = 'Screener'
 
 export const getAttachmentOptions = () => [
 	{ label: __('All'), value: ' ' },

--- a/frontend/src/pages/MailboxView.vue
+++ b/frontend/src/pages/MailboxView.vue
@@ -829,7 +829,7 @@ const activeAccount = computed(() => user.data?.accounts?.find((a) => a.id === a
 const screeningEnabled = computed(() => !!activeAccount.value?.enable_screening)
 const screenerCount = computed(
 	() =>
-		mailboxes.data?.find((m: MailboxData) => m.id === mailboxIds.screening)?.unread_threads ??
+		mailboxes.data?.find((m: MailboxData) => m.id === mailboxIds.screener)?.unread_threads ??
 		0,
 )
 const showScreenerBanner = computed(

--- a/frontend/src/pages/ScreenerView.vue
+++ b/frontend/src/pages/ScreenerView.vue
@@ -305,7 +305,7 @@ const handleKeydown = (e: KeyboardEvent) => {
 // Poll the Screening folder's count and only refetch the (heavier) sender list when it changes — the
 // same cheap-count-then-reload approach the mailbox uses, so a quiet screener isn't reloaded every tick.
 const screeningCount = () =>
-	store.mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screening)
+	store.mailboxes.data?.find((m: MailboxData) => m.id === store.mailboxIds.screener)
 		?.total_threads
 
 const pollForChanges = async () => {
@@ -324,6 +324,11 @@ onMounted(() => {
 onUnmounted(() => {
 	window.removeEventListener('keydown', handleKeydown)
 	clearInterval(pollInterval)
+	// Don't strand a queued batch on navigation — the acted rows were already removed optimistically.
+	if (flushTimer) {
+		clearTimeout(flushTimer)
+		flushScreening()
+	}
 })
 
 usePageMeta(() => {
@@ -352,7 +357,49 @@ const screenOutResource = createResource({
 	}),
 })
 
-const runAction = async (resource: typeof allowResource, fromEmails: string[]) => {
+// Block/Allow clicks are coalesced and flushed as one batched request per action. Triaging senders in
+// quick succession otherwise fires a request per click, and each rebuilds the shared automation sieve —
+// the concurrent rebuilds race on that single script and throw CannotChangeConstantError. The backend
+// already accepts a list, so we just accumulate the burst and submit it once. A sender's latest action
+// wins if both buttons are hit before the flush.
+const SCREEN_FLUSH_DELAY = 500
+const pending = { allow: new Set<string>(), screenOut: new Set<string>() }
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+let flushChain: Promise<void> = Promise.resolve()
+
+const flushScreening = () => {
+	flushTimer = null
+	const allowEmails = [...pending.allow]
+	const screenOutEmails = [...pending.screenOut]
+	pending.allow.clear()
+	pending.screenOut.clear()
+	if (!allowEmails.length && !screenOutEmails.length) return
+
+	// Chain onto the previous flush so requests never overlap (overlapping rebuilds are the bug).
+	flushChain = flushChain.then(async () => {
+		try {
+			if (allowEmails.length) await allowResource.submit({ from_emails: allowEmails })
+			if (screenOutEmails.length)
+				await screenOutResource.submit({ from_emails: screenOutEmails })
+			// Allowing/screening senders changes inbox/junk counts too.
+			store.mailboxes.reload()
+		} catch (error) {
+			senders.reload()
+			raiseToast((error as Error).message || __('Action failed.'), 'error')
+		}
+	})
+}
+
+const queueScreening = (action: 'allow' | 'screenOut', fromEmails: string[]) => {
+	const other = action === 'allow' ? pending.screenOut : pending.allow
+	for (const email of fromEmails) {
+		other.delete(email)
+		pending[action].add(email)
+	}
+	if (!flushTimer) flushTimer = setTimeout(flushScreening, SCREEN_FLUSH_DELAY)
+}
+
+const runAction = (action: 'allow' | 'screenOut', fromEmails: string[]) => {
 	if (!fromEmails.length) return
 
 	// When acting on the sender open in the detail view, line up the next one down so you can triage
@@ -380,18 +427,11 @@ const runAction = async (resource: typeof allowResource, fromEmails: string[]) =
 		else closeSender()
 	}
 
-	try {
-		await resource.submit({ from_emails: fromEmails })
-		// Allowing/screening senders changes inbox/junk counts too.
-		store.mailboxes.reload()
-	} catch (error) {
-		senders.reload()
-		raiseToast((error as Error).message || __('Action failed.'), 'error')
-	}
+	queueScreening(action, fromEmails)
 }
 
-const allow = (fromEmails: string[]) => runAction(allowResource, fromEmails)
-const screenOut = (fromEmails: string[]) => runAction(screenOutResource, fromEmails)
+const allow = (fromEmails: string[]) => runAction('allow', fromEmails)
+const screenOut = (fromEmails: string[]) => runAction('screenOut', fromEmails)
 
 // Clear All empties the queue without judging anyone: it moves all screened mail to the inbox but
 // creates no Block/Allow rule, so a mixed queue can't accidentally whitelist spam or block a real sender.

--- a/frontend/src/pages/ScreenerView.vue
+++ b/frontend/src/pages/ScreenerView.vue
@@ -377,15 +377,31 @@ const flushScreening = () => {
 
 	// Chain onto the previous flush so requests never overlap (overlapping rebuilds are the bug).
 	flushChain = flushChain.then(async () => {
-		try {
-			if (allowEmails.length) await allowResource.submit({ from_emails: allowEmails })
-			if (screenOutEmails.length)
+		// Submit each action independently so one failing doesn't skip the other — a burst can mix
+		// allow and screen-out across different senders, and all were already optimistically removed.
+		let submitted = false
+		let firstError: unknown
+		if (allowEmails.length) {
+			try {
+				await allowResource.submit({ from_emails: allowEmails })
+				submitted = true
+			} catch (error) {
+				firstError ??= error
+			}
+		}
+		if (screenOutEmails.length) {
+			try {
 				await screenOutResource.submit({ from_emails: screenOutEmails })
-			// Allowing/screening senders changes inbox/junk counts too.
-			store.mailboxes.reload()
-		} catch (error) {
+				submitted = true
+			} catch (error) {
+				firstError ??= error
+			}
+		}
+		// Allowing/screening senders changes inbox/junk counts too.
+		if (submitted) store.mailboxes.reload()
+		if (firstError) {
 			senders.reload()
-			raiseToast((error as Error).message || __('Action failed.'), 'error')
+			raiseToast((firstError as Error).message || __('Action failed.'), 'error')
 		}
 	})
 }

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -2,7 +2,7 @@ import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { createResource } from 'frappe-ui'
 
-import { SCREENING_MAILBOX_NAME } from '@/constants'
+import { SCREENER_MAILBOX_NAME } from '@/constants'
 
 import type { UserAccount, UserResource } from '@/types'
 
@@ -66,7 +66,7 @@ export const userStore = defineStore('mail-user', () => {
 	})
 
 	const mailboxIds = computed(() => {
-		const ids: Record<MailboxRole | 'screening', string> = {
+		const ids: Record<MailboxRole | 'screener', string> = {
 			inbox: '',
 			sent: '',
 			drafts: '',
@@ -74,11 +74,11 @@ export const userStore = defineStore('mail-user', () => {
 			junk: '',
 			archive: '',
 			important: '',
-			screening: '',
+			screener: '',
 		}
 		mailboxes.data?.forEach((m: { role?: MailboxRole; _name?: string; id: string }) => {
 			if (m.role) ids[m.role] = m.id
-			else if (m._name === SCREENING_MAILBOX_NAME) ids.screening = m.id
+			else if (m._name === SCREENER_MAILBOX_NAME) ids.screener = m.id
 		})
 		return ids
 	})

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -2,7 +2,7 @@ import * as cheerio from 'cheerio'
 import { File, Paperclip } from 'lucide-vue-next'
 import { toast } from 'frappe-ui'
 
-import { FOLDER_ICON_MAP, SCREENING_MAILBOX_NAME } from '@/constants'
+import { FOLDER_ICON_MAP, SCREENER_MAILBOX_NAME } from '@/constants'
 import dayjs from '@/utils/dayjs'
 import AudioIcon from '@/components/Icons/AudioIcon.vue'
 import ImageIcon from '@/components/Icons/ImageIcon.vue'
@@ -382,15 +382,17 @@ export const hasHtmlContent = (content: string | null | undefined): boolean => {
 }
 
 export const getIcon = (mailbox: MailboxData) => {
+	// The Screener is a system folder: its 'eye' icon is authoritative and can't be overridden by a
+	// stray Mailbox Settings icon (it must never render as a generic folder).
+	if (mailbox._name === SCREENER_MAILBOX_NAME) return 'eye'
 	if (mailbox.icon) return mailbox.icon
 	if (mailbox.role && mailbox.role in FOLDER_ICON_MAP) return FOLDER_ICON_MAP[mailbox.role]
-	if (mailbox._name === SCREENING_MAILBOX_NAME) return 'eye'
 	return 'folder'
 }
 
 // The Screening folder is surfaced to users as the "Screener".
 export const getMailboxName = (mailbox: MailboxData) =>
-	mailbox._name === SCREENING_MAILBOX_NAME ? __('Screener') : mailbox._name
+	mailbox._name === SCREENER_MAILBOX_NAME ? __('Screener') : mailbox._name
 
 export const downloadUrlAsFile = (url: string, filename: string) => {
 	const link = document.createElement('a')

--- a/frontend/src/utils/useThreadActions.ts
+++ b/frontend/src/utils/useThreadActions.ts
@@ -121,7 +121,15 @@ export function useThreadActions(deps: {
 
 	const moveToOptions = computed(() =>
 		mailboxes.data
-			?.filter((m) => ![mailbox.value, mailboxIds.sent, mailboxIds.drafts].includes(m.id))
+			?.filter(
+				(m) =>
+					![
+						mailbox.value,
+						mailboxIds.sent,
+						mailboxIds.drafts,
+						mailboxIds.screener,
+					].includes(m.id),
+			)
 			.map((m) => ({
 				label: getMailboxName(m),
 				icon: h(Icon, { name: getIcon(m), class: FOLDER_ICON_COLOR_MAP[m.color] }),
@@ -176,7 +184,11 @@ export function useThreadActions(deps: {
 
 	const addToOptions = computed(() =>
 		mailboxes.data
-			?.filter((m) => !m.role || ['inbox', 'archive'].includes(m.role))
+			?.filter(
+				(m) =>
+					(!m.role || ['inbox', 'archive'].includes(m.role)) &&
+					m.id !== mailboxIds.screener,
+			)
 			.filter((m) => {
 				const selected = threadsResource.value.data?.filter((t: Thread) =>
 					selections.value.includes(t.thread_id),

--- a/mail/api/mail.py
+++ b/mail/api/mail.py
@@ -13,7 +13,7 @@ from frappe.utils import format_datetime, random_string
 
 from mail.api.contacts import create_contacts_if_not_exists
 from mail.api.sieve import (
-	SCREENING_MAILBOX_NAME,
+	SCREENER_MAILBOX_NAME,
 	build_automation_sieve,
 	pause_automation_sieve_build,
 )
@@ -1054,9 +1054,9 @@ def unscreen_email_addresses(account_id: str, emails: list[str]) -> None:
 def _screening_message_ids(account: str, from_email: str | None = None) -> list[str]:
 	"""Return ids of Screening-folder messages, optionally only those from a given sender."""
 
-	screening_id = get_mailbox_id_by_name(*parse_account(account), SCREENING_MAILBOX_NAME)
+	screening_id = get_mailbox_id_by_name(*parse_account(account), SCREENER_MAILBOX_NAME)
 	if not screening_id:
-		add_mailbox(account, SCREENING_MAILBOX_NAME)
+		add_mailbox(account, SCREENER_MAILBOX_NAME)
 		return []
 
 	conditions = [{"inMailbox": screening_id}]
@@ -1081,9 +1081,9 @@ def get_screening_senders(account_id: str) -> list[dict]:
 
 	has_permission_for_user(parse_account(account)[0])
 
-	screening_id = get_mailbox_id_by_name(*parse_account(account), SCREENING_MAILBOX_NAME)
+	screening_id = get_mailbox_id_by_name(*parse_account(account), SCREENER_MAILBOX_NAME)
 	if not screening_id:
-		add_mailbox(account, SCREENING_MAILBOX_NAME)
+		add_mailbox(account, SCREENER_MAILBOX_NAME)
 		return []
 
 	messages, _total = search_messages(

--- a/mail/api/sieve.py
+++ b/mail/api/sieve.py
@@ -18,7 +18,7 @@ from mail.jmap import (
 )
 from mail.utils.user import get_account_emails, get_session_account
 
-SCREENING_MAILBOX_NAME = "Screener"
+SCREENER_MAILBOX_NAME = "Screener"
 AUTOMATION_SCRIPT_NAME = "frappe_mail_automation"
 AUTOMATION_SCRIPT_REQUIRE = 'require ["fileinto", "imap4flags"];'
 
@@ -409,11 +409,11 @@ def get_screening_folder_path(account: str) -> str:
 	# worker may already have created the Screener. Refresh from the server before deciding to create,
 	# so we never try to recreate an existing mailbox (which JMAP rejects with "already exists").
 	CoreService.invalidate_cache(account_id, key="mailboxes")
-	if not get_mailbox_id_by_name(user, account_id, SCREENING_MAILBOX_NAME):
-		add_mailbox(account, SCREENING_MAILBOX_NAME)
+	if not get_mailbox_id_by_name(user, account_id, SCREENER_MAILBOX_NAME):
+		add_mailbox(account, SCREENER_MAILBOX_NAME)
 		CoreService.invalidate_cache(account_id, key="mailboxes")
 
-	return get_mailbox_folder_path(account, SCREENING_MAILBOX_NAME, raise_exception=True)
+	return get_mailbox_folder_path(account, SCREENER_MAILBOX_NAME, raise_exception=True)
 
 
 def is_screening_enabled(account: str) -> bool:

--- a/mail/api/sieve.py
+++ b/mail/api/sieve.py
@@ -197,9 +197,7 @@ def backfill_mailbox_automation_rules() -> None:
 		for account_id in account_ids:
 			account = f"{user}:{account_id}"
 			try:
-				scripts = SieveScript._fetch_sieve_scripts(
-					account, filter={"name": AUTOMATION_SCRIPT_NAME}
-				)
+				scripts = SieveScript._fetch_sieve_scripts(account, filter={"name": AUTOMATION_SCRIPT_NAME})
 				if not (scripts and scripts[0]):
 					continue
 
@@ -214,9 +212,7 @@ def backfill_mailbox_automation_rules() -> None:
 					continue
 
 				try:
-					set_mailbox_settings(
-						account, mailbox["id"], **automation_rules_to_settings(rules)
-					)
+					set_mailbox_settings(account, mailbox["id"], **automation_rules_to_settings(rules))
 				except Exception:
 					continue
 


### PR DESCRIPTION
Fixes a few Screener bugs:

- **Icon:** the Screener's `eye` icon is now authoritative in `getIcon`, so a stray Mailbox Settings icon can't make it render as a generic folder.
- **Move/Add:** the Screener (a system folder) is excluded from the move-to / add-to target lists and from the Folders management list.
- **Batching:** Block/Allow now batch into one request per burst, so screening senders in quick succession no longer fires concurrent automation-sieve rebuilds that race on the shared script (`CannotChangeConstantError`).

Also renames `SCREENING_MAILBOX_NAME` → `SCREENER_MAILBOX_NAME` and `mailboxIds.screening` → `.screener` for naming consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
